### PR TITLE
fix concurrent map iteration/write

### DIFF
--- a/pkg/tournament/tournament.go
+++ b/pkg/tournament/tournament.go
@@ -1302,6 +1302,8 @@ func GetXHRResponse(ctx context.Context, ts TournamentStore, id string) (*ipc.Fu
 	if err != nil {
 		return nil, err
 	}
+	t.RLock()
+	defer t.RUnlock()
 
 	response := &ipc.FullTournamentDivisions{Divisions: make(map[string]*ipc.TournamentDivisionDataResponse),
 		Started: t.IsStarted}
@@ -1376,7 +1378,7 @@ func TournamentDataResponse(ctx context.Context, ts TournamentStore, id string) 
 	if err != nil {
 		return nil, err
 	}
-
+	// no lock needed; only gets called while already locked.
 	return &ipc.TournamentDataResponse{Id: t.UUID,
 		Name:              t.Name,
 		Description:       t.Description,


### PR DESCRIPTION
GetTournament was calling GetXHRResponse for the different divisions. Each division deals with a lot of protobuf data directly. Some of this data could change while it was being serialized, for example, by new results coming in or by players being removed from the tournament. If someone is getting data at the same time it can result in this race condition and crash the program. With this PR we protect GetTournament behind the RWMutex.