### PR TITLE
use numeric keyboard

### DIFF
--- a/liwords-ui/src/admin/puzzle_generator.tsx
+++ b/liwords-ui/src/admin/puzzle_generator.tsx
@@ -190,13 +190,13 @@ export const PuzzleGenerator = () => {
           label="Game Consideration Limit (total for bots, per chunk for real games)"
           initialValue={6000}
         >
-          <InputNumber />
+          <InputNumber inputMode="numeric" />
         </Form.Item>
         <Form.Item
           name="gameCreationLimit"
           label="Game Creation Limit (only for bot v bot games)"
         >
-          <InputNumber />
+          <InputNumber inputMode="numeric" />
         </Form.Item>
 
         <Form.Item
@@ -211,7 +211,7 @@ export const PuzzleGenerator = () => {
           label="Total equity loss limit"
           initialValue={150}
         >
-          <InputNumber />
+          <InputNumber inputMode="numeric" />
         </Form.Item>
 
         <Form.Item
@@ -227,7 +227,7 @@ export const PuzzleGenerator = () => {
           label="How many days to search at a time"
           initialValue={1}
         >
-          <InputNumber />
+          <InputNumber inputMode="numeric" />
         </Form.Item>
 
         <Form.List name="buckets">
@@ -241,7 +241,7 @@ export const PuzzleGenerator = () => {
                     label="Size"
                     rules={[{ required: true, message: 'Missing bucket size' }]}
                   >
-                    <InputNumber />
+                    <InputNumber inputMode="numeric" />
                   </Form.Item>
                   <Form.Item
                     {...field}

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -591,6 +591,7 @@ export const SeekForm = (props: Props) => {
         extra={extraTimeLabel}
       >
         <InputNumber
+          inputMode="numeric"
           min={0}
           max={maxTimeSetting}
           disabled={disableTimeControls}

--- a/liwords-ui/src/mod/moderate.tsx
+++ b/liwords-ui/src/mod/moderate.tsx
@@ -111,7 +111,7 @@ const Moderation = (props: ModProps) => {
           name="duration"
           label="Duration, in hours. Use 0 for indefinite"
         >
-          <InputNumber min={0} max={720 * 6} />
+          <InputNumber inputMode="numeric" min={0} max={720 * 6} />
         </Form.Item>
 
         <Form.Item name="note" label="Optional note">

--- a/liwords-ui/src/profile/games_history.tsx
+++ b/liwords-ui/src/profile/games_history.tsx
@@ -232,6 +232,7 @@ export const GamesHistoryCard = React.memo((props: Props) => {
       />
       <div className="game-history-controls">
         <InputNumber
+          inputMode="numeric"
           min={1}
           value={desiredPageNumber}
           onChange={props.onChangePageNumber}

--- a/liwords-ui/src/tournament/director_tools/add_player_form.tsx
+++ b/liwords-ui/src/tournament/director_tools/add_player_form.tsx
@@ -99,7 +99,7 @@ export const AddPlayerForm = (props: Props) => {
         </Form.Item>
 
         <Form.Item label="Rating" name="rating">
-          <InputNumber min={0} max={10000} />
+          <InputNumber inputMode="numeric" min={0} max={10000} />
         </Form.Item>
 
         <Form.Item

--- a/liwords-ui/src/tournament/director_tools/game_settings_form.tsx
+++ b/liwords-ui/src/tournament/director_tools/game_settings_form.tsx
@@ -186,7 +186,7 @@ export const SettingsForm = (props: Props) => {
         name="extratime"
         extra={extraTimeLabel}
       >
-        <InputNumber min={0} max={maxTimeSetting} />
+        <InputNumber inputMode="numeric" min={0} max={maxTimeSetting} />
       </Form.Item>
 
       <Form.Item label="Rated" name="rated" valuePropName="checked">

--- a/liwords-ui/src/tournament/director_tools/ghetto_tools.tsx
+++ b/liwords-ui/src/tournament/director_tools/ghetto_tools.tsx
@@ -721,7 +721,7 @@ const SetPairing = (props: { tournamentID: string }) => {
       )}
 
       <Form.Item name="round" label="Round (1-indexed)">
-        <InputNumber min={1} required />
+        <InputNumber inputMode="numeric" min={1} required />
       </Form.Item>
 
       <Form.Item>
@@ -825,15 +825,23 @@ const SetResult = (props: { tournamentID: string }) => {
       />
 
       <Form.Item name="round" label="Round (1-indexed)">
-        <InputNumber min={1} required />
+        <InputNumber inputMode="numeric" min={1} required />
       </Form.Item>
 
       <Form.Item name="p1score" label="Player 1 score">
-        <InputNumber onChange={score1Change} value={score1} />
+        <InputNumber
+          inputMode="numeric"
+          onChange={score1Change}
+          value={score1}
+        />
       </Form.Item>
 
       <Form.Item name="p2score" label="Player 2 score">
-        <InputNumber onChange={score2Change} value={score2} />
+        <InputNumber
+          inputMode="numeric"
+          onChange={score2Change}
+          value={score2}
+        />
       </Form.Item>
 
       <Form.Item name="p1result" label="Player 1 result">
@@ -917,7 +925,7 @@ const PairRound = (props: { tournamentID: string }) => {
       <DivisionFormItem />
 
       <Form.Item name="round" label="Round (1-indexed)">
-        <InputNumber min={1} required />
+        <InputNumber inputMode="numeric" min={1} required />
       </Form.Item>
 
       <Form.Item name="preserveByes" label="Preserve byes">
@@ -956,7 +964,7 @@ const UnpairRound = (props: { tournamentID: string }) => {
     <Form onFinish={onFinish}>
       <DivisionFormItem />
       <Form.Item name="round" label="Round (1-indexed)">
-        <InputNumber min={1} required />
+        <InputNumber inputMode="numeric" min={1} required />
       </Form.Item>
       <Form.Item>
         <Button type="primary" htmlType="submit">
@@ -1174,6 +1182,7 @@ const SetTournamentControls = (props: { tournamentID: string }) => {
           }
         >
           <InputNumber
+            inputMode="numeric"
             min={0}
             value={gibsonSpread}
             onChange={(v: number | string | undefined | null) =>
@@ -1192,6 +1201,7 @@ const SetTournamentControls = (props: { tournamentID: string }) => {
           }
         >
           <InputNumber
+            inputMode="numeric"
             min={1}
             value={gibsonMinPlacement}
             onChange={(p: number | string | undefined | null) =>
@@ -1211,6 +1221,7 @@ const SetTournamentControls = (props: { tournamentID: string }) => {
           }
         >
           <InputNumber
+            inputMode="numeric"
             min={1}
             value={byeMaxPlacement}
             onChange={(p: number | string | undefined | null) =>
@@ -1229,6 +1240,7 @@ const SetTournamentControls = (props: { tournamentID: string }) => {
           }
         >
           <InputNumber
+            inputMode="numeric"
             min={0}
             value={spreadCap}
             onChange={(p: number | string | undefined | null) =>
@@ -1413,6 +1425,7 @@ const SingleRoundControlFields = (props: SingleRdCtrlFieldsProps) => {
                 key={`${idx}-${fieldName}`}
               >
                 <InputNumber
+                  inputMode="numeric"
                   key={key}
                   min={0}
                   value={setting[fieldName] as number}
@@ -1452,6 +1465,7 @@ const RoundControlFields = (props: RdCtrlFieldsProps) => {
       <Form size="small">
         <Form.Item label="First round">
           <InputNumber
+            inputMode="numeric"
             min={1}
             value={setting.beginRound}
             onChange={(e) => props.onChange('beginRound', e as number)}
@@ -1459,6 +1473,7 @@ const RoundControlFields = (props: RdCtrlFieldsProps) => {
         </Form.Item>
         <Form.Item label="Last round">
           <InputNumber
+            inputMode="numeric"
             min={1}
             value={setting.endRound}
             onChange={(e) => props.onChange('endRound', e as number)}
@@ -1602,6 +1617,7 @@ const SetSingleRoundControls = (props: { tournamentID: string }) => {
         </Form.Item>
         <Form.Item {...formItemLayout} label="Round">
           <InputNumber
+            inputMode="numeric"
             value={userVisibleRound}
             onChange={(e) => e && setUserVisibleRound(e as number)}
           />

--- a/liwords-ui/src/tournament/enter_own_scores.tsx
+++ b/liwords-ui/src/tournament/enter_own_scores.tsx
@@ -176,14 +176,14 @@ const ScoreForm = (props: ScoreFormProps) => {
           name="ourscore"
           required
         >
-          <InputNumber />
+          <InputNumber inputMode="numeric" />
         </Form.Item>
         <Form.Item
           label={`Score for ${props.opponentName}`}
           name="theirscore"
           required
         >
-          <InputNumber />
+          <InputNumber inputMode="numeric" />
         </Form.Item>
 
         <Form.Item label="Please have opponent verify scores.">


### PR DESCRIPTION
this PR adds inputMode="numeric" to all antd InputNumber to help with #1365.

see https://inputmodes.com/ for demo.

the following were observed:
- inputMode="decimal":
  - ios: 0-9 and either `.` or `,` depending on region setting
  - android: 0-9 and both `.` and `,`
- inputMode="numeric":
  - ios: 0-9 only
  - android: 0-9, both `.` and `,`, and `-`