### PR TITLE
fix local puzzle teaser error

### DIFF
--- a/liwords-ui/src/puzzles/puzzle_preview.tsx
+++ b/liwords-ui/src/puzzles/puzzle_preview.tsx
@@ -75,7 +75,17 @@ export const PuzzlePreview = React.memo(() => {
           payload: gh,
         });
       } catch (err) {
-        flashError(err);
+        const typescriptErr = err as Error;
+        if (
+          typescriptErr.name === 'ConnectError' &&
+          typescriptErr.message ===
+            '[invalid_argument] cannot get id from uuid E3kGXKyzhYirNzsMfCW3QV: no rows for table puzzles'
+        ) {
+          // The hard coded puzzle only exists in production.
+          setPuzzleID(null);
+        } else {
+          flashError(err);
+        }
       }
     }
     if (puzzleID) {


### PR DESCRIPTION
when developing locally, the hard coded puzzle id does not exist. this always causes an error message that blocks the top nav for a long time.

this PR avoids showing that particular error so that it is slightly less irritating to develop locally.

when there is no puzzle, the text "We have thousands of puzzles created from real games to help you practice play finding. Ready to try one?" used to be center aligned.

this PR brings back that old style, although it can only be observed locally.