### PR TITLE
restyle toggles

### DIFF
--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -296,14 +296,20 @@ export const Preferences = React.memo(() => {
     <div className="preferences">
       <h3>Preferences</h3>
       <div className="section-header">Display</div>
-      <div className="toggle-section">
-        <div className="title">Dark mode</div>
-        <p>Use the dark version of the Woogles UI on Woogles.io</p>
-        <Switch
-          defaultChecked={darkMode}
-          onChange={(checked: boolean) => dispatch(setDarkMode(checked))}
-          className="dark-toggle"
-        />
+      <div className="toggles-section">
+        <div>
+          <div className="toggle-section">
+            <div className="title">Dark mode</div>
+            <div>
+              <div>Use the dark version of the Woogles UI on Woogles.io</div>
+              <Switch
+                defaultChecked={darkMode}
+                onChange={(checked: boolean) => dispatch(setDarkMode(checked))}
+                className="dark-toggle"
+              />
+            </div>
+          </div>
+        </div>
       </div>
       <div className="section-header">OMGWords settings</div>
       <Row>

--- a/liwords-ui/src/settings/secret.tsx
+++ b/liwords-ui/src/settings/secret.tsx
@@ -112,84 +112,102 @@ export const Secret = React.memo(() => {
           Learn more.
         </a>
       </div>
-      <div>
-        <div className="toggle-section">
-          <div className="title">Telestrator</div>
-          <div>Draw on the board while you’re playing</div>
-          <Switch
-            defaultChecked={telestrator}
-            onChange={toggleTelestrator}
-            className="telestrator-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Blindfold</div>
-          <div>Enable text-to-speech keyboard commands</div>
-          <Switch
-            defaultChecked={blindfold}
-            onChange={toggleBlindfold}
-            className="blindfold-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Lexicons</div>
-          <div>Enable all lexicons</div>
-          <Switch
-            defaultChecked={enableAllLexicons}
-            onChange={toggleEnableAllLexicons}
-            className="dark-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Variants</div>
-          <div>Enable Variants, such as WordSmog and ZOMGWords</div>
-          <Switch
-            defaultChecked={variantsEnabled}
-            onChange={toggleVariants}
-            className="variants-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Show equity loss</div>
-          <div>Show equity loss in analyzer</div>
-          <Switch
-            defaultChecked={showEquityLoss}
-            onChange={toggleShowEquityLoss}
-            className="show-equity-loss-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Enable silent site</div>
-          <div>Mute all sounds</div>
-          <Switch
-            defaultChecked={enableSilentSite}
-            onChange={toggleEnableSilentSite}
-            className="sounds-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Practice manual tracking and scoring</div>
-          <div>
-            Disable automatic tracking of tiles and scoring of tentative moves
-            for you only
+      <div className="toggles-section">
+        <div>
+          <div className="toggle-section">
+            <div className="title">Telestrator</div>
+            <div>
+              <div>Draw on the board while you’re playing</div>
+              <Switch
+                defaultChecked={telestrator}
+                onChange={toggleTelestrator}
+                className="telestrator-toggle"
+              />
+            </div>
           </div>
-          <Switch
-            defaultChecked={hidePool}
-            onChange={toggleHidePool}
-            className="pool-toggle"
-          />
-        </div>
-        <div className="toggle-section">
-          <div className="title">Infuse Second Color</div>
-          <div>
-            Highlight one player's tiles instead of the last move. Requires
-            Refresher Orb.
+          <div className="toggle-section">
+            <div className="title">Blindfold</div>
+            <div>
+              <div>Enable text-to-speech keyboard commands</div>
+              <Switch
+                defaultChecked={blindfold}
+                onChange={toggleBlindfold}
+                className="blindfold-toggle"
+              />
+            </div>
           </div>
-          <Switch
-            defaultChecked={enableBicolorMode}
-            onChange={toggleEnableBicolorMode}
-            className="bicolor-toggle"
-          />
+          <div className="toggle-section">
+            <div className="title">Lexicons</div>
+            <div>
+              <div>Enable all lexicons</div>
+              <Switch
+                defaultChecked={enableAllLexicons}
+                onChange={toggleEnableAllLexicons}
+                className="dark-toggle"
+              />
+            </div>
+          </div>
+          <div className="toggle-section">
+            <div className="title">Variants</div>
+            <div>
+              <div>Enable Variants, such as WordSmog and ZOMGWords</div>
+              <Switch
+                defaultChecked={variantsEnabled}
+                onChange={toggleVariants}
+                className="variants-toggle"
+              />
+            </div>
+          </div>
+          <div className="toggle-section">
+            <div className="title">Show equity loss</div>
+            <div>
+              <div>Show equity loss in analyzer</div>
+              <Switch
+                defaultChecked={showEquityLoss}
+                onChange={toggleShowEquityLoss}
+                className="show-equity-loss-toggle"
+              />
+            </div>
+          </div>
+          <div className="toggle-section">
+            <div className="title">Enable silent site</div>
+            <div>
+              <div>Mute all sounds</div>
+              <Switch
+                defaultChecked={enableSilentSite}
+                onChange={toggleEnableSilentSite}
+                className="sounds-toggle"
+              />
+            </div>
+          </div>
+          <div className="toggle-section">
+            <div className="title">Practice manual tracking and scoring</div>
+            <div>
+              <div>
+                Disable automatic tracking of tiles and scoring of tentative
+                moves for you only
+              </div>
+              <Switch
+                defaultChecked={hidePool}
+                onChange={toggleHidePool}
+                className="pool-toggle"
+              />
+            </div>
+          </div>
+          <div className="toggle-section">
+            <div className="title">Infuse Second Color</div>
+            <div>
+              <div>
+                Highlight one player's tiles instead of the last move. Requires
+                Refresher Orb.
+              </div>
+              <Switch
+                defaultChecked={enableBicolorMode}
+                onChange={toggleEnableBicolorMode}
+                className="bicolor-toggle"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/liwords-ui/src/settings/settings.scss
+++ b/liwords-ui/src/settings/settings.scss
@@ -197,21 +197,18 @@
       margin-bottom: 18px;
       width: 100%;
     }
+    .toggles-section {
+      display: flex;
+    }
     .toggle-section {
-      position: relative;
       margin-bottom: 24px;
-      .ant-switch {
-        margin: 12px 0 0 0;
-        @media (min-width: $screen-tablet-min) {
-          margin: 0 0 0 12px;
+      & > div:last-child {
+        display: flex;
+        gap: 12px;
+        & > div:first-child {
+          flex: 1;
         }
       }
-      p {
-        display: inline-block;
-      }
-    }
-    .toggle-section > div {
-      padding-right: 60px;
     }
   }
 }


### PR DESCRIPTION
since one of the antd upgrades, the toggles in the secret features page (in settings) have been wrapped to the next line.

the toggle in the preferences page was using a different approach, which only works when there is only one toggle.

this PR aligns code in both pages to use the same approach, and fixes the styling so that the toggles no longer wrap.