### PR TITLE
add show bonus labels style

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -520,7 +520,9 @@ p.streak-loss {
     position: absolute;
     line-height: 1em;
     padding: 0 0 1px;
-    opacity: 0;
+    body:not(.show-bonus-labels) & {
+      opacity: 0;
+    }
 
     @include colorModed() {
       color: m($background);
@@ -533,7 +535,9 @@ p.streak-loss {
 
   &:hover {
     .bonus-label {
-      animation: fadeIn 700ms cubic-bezier(0.17, 0.67, 0.29, 1) 400ms forwards;
+      body:not(.show-bonus-labels) & {
+        animation: fadeIn 700ms cubic-bezier(0.17, 0.67, 0.29, 1) 400ms forwards;
+      }
     }
   }
 


### PR DESCRIPTION
this PR adds a style that would always show the bonus labels, to help with eventual implementation of #1366.

use devtools to explore it:

```js
document.body.classList.add("show-bonus-labels");
```