### PR TITLE
restyle tie

### DIFF
--- a/liwords-ui/src/App.scss
+++ b/liwords-ui/src/App.scss
@@ -270,13 +270,13 @@ ul {
   }
 
   .ant-tag-orange,
-  .ant-tag-bye {
+  .ant-tag-tie {
     background: #fcac69;
     color: #414141;
     border-color: #fcac69;
   }
   .ant-tag-gray,
-  .ant-tag-tie {
+  .ant-tag-bye {
     background: #aaaaaa;
     color: #414141;
   }


### PR DESCRIPTION
this PR adjusts the color of Tie in the profile page game cards because it was inconsistent.

![8adj7i](https://github.com/user-attachments/assets/dc0d5613-38df-4344-8b79-124b58e0fa5e)

<img width="783" alt="tie-color" src="https://github.com/user-attachments/assets/37db1832-00b6-48c7-ade7-180d410fbaaa">
