### PR TITLE
fix puzzle keep trying crash

### DIFF
--- a/liwords-ui/src/puzzles/puzzle.tsx
+++ b/liwords-ui/src/puzzles/puzzle.tsx
@@ -725,8 +725,8 @@ export const SinglePuzzle = (props: Props) => {
         </div>
         <div className="play-area puzzle-area">
           {lexiconModal}
-          {responseModalWrong}
-          {responseModalCorrect}
+          {showResponseModalWrong && responseModalWrong}
+          {showResponseModalCorrect && responseModalCorrect}
           {gameHistory?.lexicon && alphabet && (
             <BoardPanel
               anonymousViewer={!loggedIn}


### PR DESCRIPTION
the "keep trying" functionality randomly crashes browsers.
not relying on antd's `open=` seems to fix it.

https://discord.com/channels/741321677828522035/778469677588283403/1309600748606197790