### PR TITLE
Make nudge-restrictions aware of overtime

### DIFF
--- a/pkg/gameplay/common_test.go
+++ b/pkg/gameplay/common_test.go
@@ -16,10 +16,10 @@ type gamesetup struct {
 	stores   *stores.Stores
 }
 
-func setupNewGame() *gamesetup {
+func setupNewGame(opts ...TestGameOption) *gamesetup {
 	_, stores, cfg := recreateDB()
 
-	g, nower, cancel, donechan, consumer := makeGame(cfg, stores)
+	g, nower, cancel, donechan, consumer := makeGame(cfg, stores, opts...)
 
 	return &gamesetup{
 		g, nower, cancel, donechan, consumer, stores,

--- a/pkg/gameplay/meta_events.go
+++ b/pkg/gameplay/meta_events.go
@@ -42,7 +42,7 @@ const (
 
 	// If receiver has this many milliseconds on their clock or fewer, we don't allow
 	// sending them requests.
-	DisallowMsecsRemaining = 30 * 1000
+	DisallowMsecsRemaining = 2 * 60 * 1000
 
 	AbortTimeout = time.Second * 60
 	NudgeTimeout = time.Second * 120
@@ -193,9 +193,12 @@ func HandleMetaEvent(ctx context.Context, evt *pb.GameMetaEvent, eventChan chan<
 		// Receiver may not be the one on turn, since either player may request abort.
 		onTurn := g.Game.PlayerOnTurn()
 		timeRemaining := g.TimeRemaining(onTurn)
-		log.Debug().Int("timeRemaining", timeRemaining).Int("onturn", onTurn).Msg("timeremaining")
-		// XXX: Should time remaining include overtime?
-		if timeRemaining < DisallowMsecsRemaining {
+		overtimeMsecs := int(g.GameReq.MaxOvertimeMinutes * 60 * 1000)
+		totalTimeRemaining := timeRemaining + overtimeMsecs
+
+		log.Debug().Int("timeRemaining", timeRemaining).Int("overtimeMsecs", overtimeMsecs).Int("totalTimeRemaining", totalTimeRemaining).Int("onturn", onTurn).Msg("timeremaining")
+
+		if totalTimeRemaining < DisallowMsecsRemaining {
 			return ErrPleaseWaitToEnd
 		}
 


### PR DESCRIPTION
Closes https://github.com/woogles-io/liwords/issues/1394

Allows nudges if (and only if) the total time remaining for the nudged player is > 2 minutes, including overtime. This aligns with the amount of time a user has to dismiss the nudge

Note that this does not account for increment, we can maybe introduce a heuristic for that based on increment size and tiles remaining if desirable.