### PR TITLE
convert user uuids (first step)

### DIFF
--- a/db/migrations/202502220408_proper-user-uuids-part1.down.sql
+++ b/db/migrations/202502220408_proper-user-uuids-part1.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE users DROP COLUMN entity_uuid;
+
+COMMIT;

--- a/db/migrations/202502220408_proper-user-uuids-part1.up.sql
+++ b/db/migrations/202502220408_proper-user-uuids-part1.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-ALTER TABLE users ADD COLUMN entity_uuid uuid DEFAULT public.uuid_generate_v4() NOT NULL UNIQUE;
+ALTER TABLE users ADD COLUMN entity_uuid uuid DEFAULT gen_random_uuid() NOT NULL UNIQUE;
 
 COMMIT;

--- a/db/migrations/202502220408_proper-user-uuids-part1.up.sql
+++ b/db/migrations/202502220408_proper-user-uuids-part1.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE users ADD COLUMN entity_uuid uuid DEFAULT public.uuid_generate_v4() NOT NULL UNIQUE;
+
+COMMIT;

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -7,7 +7,7 @@ The version numbers are UTC timestamps in YYYYMMDDHHmm format.
 To create a set of migrations use the following command:
 
 ```
-./gen-migration.sh {name-of-migration}
+./gen_migration.sh {name-of-migration}
 ```
 
 Replacing `{name-of-migration}` with your chosen name.
@@ -18,7 +18,7 @@ Replacing `{name-of-migration}` with your chosen name.
 If you wish to run a down migration locally (for example, your migration file was missing some stuff and you want to migrate down before migrating back up after adding what you were missing):
 
 ```
-./migrate-down.sh {number-of-migrations}
+./migrate_down.sh {number-of-migrations}
 ```
 
 Replacing `{number_of_migrations}` with how many migrations you want to undo.

--- a/pkg/entity/user.go
+++ b/pkg/entity/user.go
@@ -2,11 +2,13 @@ package entity
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/woogles-io/liwords/pkg/glicko"
 	pb "github.com/woogles-io/liwords/rpc/api/proto/ipc"
 	ms "github.com/woogles-io/liwords/rpc/api/proto/mod_service"
@@ -37,9 +39,10 @@ type User struct {
 	Anonymous bool
 	// ID is the database ID. Since this increases monotonically, we should
 	// not expose it to the user
-	ID uint
+	ID         uint
+	EntityUUID uuid.UUID
 	// UUID is the "user-exposed" ID, in any APIs.
-	UUID     string
+	UUID     string // DEPRECATED: use EntityUUID in next release
 	Username string
 	Password string
 	Email    string
@@ -192,7 +195,8 @@ func (u *User) AvatarUrl() string {
 // TournamentID returns the "player ID" of a user. UUID:username is probably not
 // a good design, but let's at least narrow it down to this function.
 func (u *User) TournamentID() string {
-	return u.UUID + ":" + u.Username
+	return fmt.Sprintf("%s:%s", u.UUID, u.Username)
+	// return fmt.Sprintf("%s:%s", shortuuid.DefaultEncoder.Encode(u.UUID), u.Username)
 }
 
 func InferChildStatus(dob string, now time.Time) pb.ChildStatus {

--- a/pkg/stores/user/db.go
+++ b/pkg/stores/user/db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -183,7 +184,8 @@ func (s *DBStore) New(ctx context.Context, u *entity.User) error {
 	defer tx.Rollback(ctx)
 
 	if u.UUID == "" {
-		u.UUID = shortuuid.New()
+		u.EntityUUID = uuid.New()
+		u.UUID = shortuuid.DefaultEncoder.Encode(u.EntityUUID)
 	}
 
 	var userId uint

--- a/scripts/migrations/user_uuids/main.go
+++ b/scripts/migrations/user_uuids/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/lithammer/shortuuid/v4"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/woogles-io/liwords/pkg/config"
+	"github.com/woogles-io/liwords/pkg/stores/common"
+	"github.com/woogles-io/liwords/pkg/stores/user"
+)
+
+func main() {
+	cfg := &config.Config{}
+	cfg.Load(os.Args[1:])
+	log.Info().Msgf("Loaded config: %v", cfg)
+
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	pool, err := common.OpenDB(cfg.DBHost, cfg.DBPort, cfg.DBName, cfg.DBUser, cfg.DBPassword, cfg.DBSSLMode)
+	if err != nil {
+		panic(err)
+	}
+
+	userStore, err := user.NewDBStore(pool)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	ids, err := userStore.ListAllIDs(ctx)
+	if err != nil {
+		panic(err)
+	}
+	log.Info().Int("ids", len(ids)).Msg("count-user-ids")
+
+	tx, err := pool.BeginTx(ctx, common.DefaultTxOptions)
+	if err != nil {
+		panic(err)
+	}
+	defer tx.Rollback(ctx)
+
+	for _, id := range ids {
+		uuid, err := shortuuid.DefaultEncoder.Decode(id)
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = tx.Exec(ctx, "UPDATE users SET entity_uuid = $1 WHERE id = $2", uuid, id)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
We should start using proper UUID fields instead of fields calling themselves UUIDs but that are actually the shortuuid TEXT encoding of a UUID. The latter ends up being bigger per column (22 vs 16 bytes) and indexing on it for queries like GetBriefProfiles (which happens very frequently) should be faster.