### PR TITLE
Filter My Correspondence Games section by user ID on front-end

### DIFF
--- a/liwords-ui/src/lobby/correspondence_games.tsx
+++ b/liwords-ui/src/lobby/correspondence_games.tsx
@@ -96,7 +96,6 @@ export const CorrespondenceGames = (props: Props) => {
 
   const formatGameData = useCallback(
     (games: ActiveGame[]): CorrespondenceGameTableData[] => {
-      // Filter to only show games where the current user is a participant
       const userGames = games.filter((ag: ActiveGame) =>
         ag.players.some((player) => player.uuid === userID),
       );


### PR DESCRIPTION
Fixes https://github.com/woogles-io/liwords/issues/1570

Filtered on the front-end since I believe we still want the game data broadcast to the general lobby of games, but happy to implement differently