### PR TITLE
Remember last lobby tab in localStorage

### DIFF
--- a/liwords-ui/src/lobby/lobby.tsx
+++ b/liwords-ui/src/lobby/lobby.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { TopBar } from "../navigation/topbar";
 
@@ -38,20 +38,29 @@ export const Lobby = (props: Props) => {
 
   const { loggedIn, username, userID } = loginState;
 
-  const [selectedGameTab, setSelectedGameTab] = useState(
+  const [selectedGameTab, setSelectedGameTabState] = useState(
     getInitialTab(loggedIn),
   );
+  const prevLoggedIn = useRef(loggedIn);
 
-  // Save tab selection to localStorage
+  // Wrapper that saves to localStorage when tab changes
+  const setSelectedGameTab = useCallback((tab: string) => {
+    setSelectedGameTabState(tab);
+    localStorage.setItem(LOBBY_TAB_STORAGE_KEY, tab);
+  }, []);
+
+  // Update tab when login state changes
   useEffect(() => {
-    if (selectedGameTab) {
-      localStorage.setItem(LOBBY_TAB_STORAGE_KEY, selectedGameTab);
+    const wasLoggedIn = prevLoggedIn.current;
+    prevLoggedIn.current = loggedIn;
+
+    if (!wasLoggedIn && loggedIn) {
+      // Login state just loaded - restore from localStorage
+      setSelectedGameTabState(getInitialTab(true));
+    } else if (wasLoggedIn && !loggedIn) {
+      // User logged out - switch to WATCH
+      setSelectedGameTabState("WATCH");
     }
-  }, [selectedGameTab]);
-
-  // Update tab when login status changes
-  useEffect(() => {
-    setSelectedGameTab(getInitialTab(loggedIn));
   }, [loggedIn]);
 
   const handleNewGame = useCallback(


### PR DESCRIPTION
- Add localStorage persistence for lobby tab selection
- If last tab was CORRESPONDENCE, restore it on load
- Otherwise default to PLAY tab (or WATCH if not logged in)
- Save tab selection whenever user switches tabs

Implements automatic restoration of CORRESPONDENCE tab preference, improving UX for users who primarily play correspondence games.