### PR TITLE
Format time bank as hours/game in league page

### DIFF
--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -795,7 +795,7 @@ export const LeaguePage = (props: Props) => {
                       <span className="settings-label">Time Bank:</span>
                       <span className="settings-value">
                         {league.settings.timeControl?.timeBankMinutes
-                          ? `${league.settings.timeControl.timeBankMinutes / 60}h`
+                          ? `${league.settings.timeControl.timeBankMinutes / 60}h/game`
                           : "None"}
                       </span>
                     </div>


### PR DESCRIPTION
Random wording suggestion, no strong opinion but may clarify to ppl unfamiliar with the time bank

<img width="345" height="311" alt="Screenshot 2025-11-30 at 11 26 33 AM" src="https://github.com/user-attachments/assets/7c3d3643-ab36-4a1e-b955-488410121676" />
