### PR TITLE
fix white text notification on light mode

### DIFF
--- a/liwords-ui/src/themes.tsx
+++ b/liwords-ui/src/themes.tsx
@@ -34,6 +34,12 @@ const lightComponentOverrides = {
     colorTextHeading: "#ffffff",
     colorInfo: "#e2f8ff",
     colorIcon: "#ffffff",
+    // Correct token names for antd 5.x
+    notificationBg: undefined,
+    colorInfoBg: undefined,
+    colorSuccessBg: undefined,
+    colorWarningBg: undefined,
+    colorErrorBg: undefined,
   },
   Message: {
     colorText: "#ffffff",


### PR DESCRIPTION
it was not readable

<img width="828" height="266" alt="image" src="https://github.com/user-attachments/assets/eb271e18-fd9a-42af-a6bc-9653d41753e5" />
