### PR TITLE
Disable Howler autoSuspend to fix iOS audio

### DIFF
--- a/liwords-ui/src/sound/boop.ts
+++ b/liwords-ui/src/sound/boop.ts
@@ -14,6 +14,11 @@ import newpuzzleSound from "../assets/newpuzzle.mp3";
 import puzzlecorrectSound from "../assets/puzzlecorrect-acoustic-fast.mp3";
 import puzzlewrongSound from "../assets/puzzlewrong.mp3";
 
+// Howler auto-suspends the AudioContext after 30s of silence. On iOS Safari,
+// a suspended context can only be resumed from a user gesture, so sounds
+// triggered by WebSocket events (opponent moves, etc.) would fail silently.
+Howler.autoSuspend = false;
+
 const soundToggleCache: { all: boolean | undefined } = { all: undefined };
 
 const soundIsEnabled = (soundName: string) => {
@@ -46,18 +51,7 @@ class Booper {
 
   play() {
     if (soundIsEnabled(this.soundName)) {
-      const ctx = Howler.ctx;
-      if (
-        ctx &&
-        (ctx.state === "suspended" ||
-          ctx.state === ("interrupted" as AudioContextState))
-      ) {
-        ctx.resume().then(() => {
-          this.howl.play();
-        });
-      } else {
-        this.howl.play();
-      }
+      this.howl.play();
     }
   }
 }
@@ -88,30 +82,6 @@ if (!window.location.pathname.startsWith("/embed/")) {
     playableSounds[booper.soundName] = booper;
   }
 }
-
-// iOS Safari requires a user gesture to unlock the AudioContext.
-// Proactively resume it on first interaction so that sounds triggered
-// by non-gesture events (e.g. WebSocket messages) will work.
-const unlockAudioContext = () => {
-  const ctx = Howler.ctx;
-  if (ctx && ctx.state !== "running") {
-    ctx.resume().then(() => {
-      if (ctx.state === "running") {
-        window.removeEventListener("click", unlockAudioContext, true);
-        window.removeEventListener("touchend", unlockAudioContext, true);
-        window.removeEventListener("keydown", unlockAudioContext, true);
-      }
-    });
-  } else if (ctx && ctx.state === "running") {
-    window.removeEventListener("click", unlockAudioContext, true);
-    window.removeEventListener("touchend", unlockAudioContext, true);
-    window.removeEventListener("keydown", unlockAudioContext, true);
-  }
-};
-
-window.addEventListener("click", unlockAudioContext, true);
-window.addEventListener("touchend", unlockAudioContext, true);
-window.addEventListener("keydown", unlockAudioContext, true);
 
 const playSound = (soundName: string) => {
   const booper = playableSounds[soundName];


### PR DESCRIPTION
The root cause: Howler.js auto-suspends the AudioContext after 30s of silence. On iOS Safari, a suspended AudioContext can only be resumed from a user gesture — so when a WebSocket event (opponent move, match request, etc.) tries to play a sound, ctx.resume() fails silently and the sound never plays.

Fix: set Howler.autoSuspend = false so the context stays running after the initial user-gesture unlock (which Howler handles natively).

Also removes the redundant manual unlock listeners and the per-play resume logic (which was actually harmful — if ctx.resume() failed on iOS, the .then() never fired and the sound was swallowed entirely).

https://claude.ai/code/session_018Xnds2nFkfiD6pUuizwa6Y