### PR TITLE
fix: show user's rack in 3D board during active play (#1717)

### DIFF
--- a/liwords-ui/src/gameroom/board3d/convert.ts
+++ b/liwords-ui/src/gameroom/board3d/convert.ts
@@ -22,6 +22,7 @@ export function convertGameStateTo3DData(
   gameContext: GameState,
   alphabet: Alphabet,
   gameDocument?: GameDocument,
+  userID?: string,
   tileColor = "orange",
   boardColor = "jade",
 ): Board3DData {
@@ -43,9 +44,16 @@ export function convertGameStateTo3DData(
     boardArray.push(rowArr);
   }
 
-  // Rack
-  const onturn = gameContext.onturn;
-  const currentRack = gameContext.players[onturn]?.currentRack ?? [];
+  // Rack: if userID is provided, show that user's rack (for active play).
+  // Otherwise, show the on-turn player's rack (for examining/analyzing).
+  let currentRack: number[];
+  if (userID) {
+    const userPlayer = gameContext.players.find((p) => p.userID === userID);
+    currentRack = userPlayer?.currentRack ?? [];
+  } else {
+    const onturn = gameContext.onturn;
+    currentRack = gameContext.players[onturn]?.currentRack ?? [];
+  }
   const rack: string[] = currentRack
     .filter((ml) => ml !== 0x80)
     .map((ml) => mlToDisplay(ml, alphabet));

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -19,6 +19,7 @@ import {
   useExaminableGameContextStoreContext,
   useExamineStoreContext,
   useGameContextStoreContext,
+  useLoginStateStoreContext,
   useTentativeTileContext,
 } from "../store/store";
 import { EphemeralTile } from "../utils/cwgame/common";
@@ -286,6 +287,8 @@ export type Props = {
 
 const GameControls = React.memo((props: Props) => {
   const { gameContext } = useGameContextStoreContext();
+  const { loginState } = useLoginStateStoreContext();
+  const { userID } = loginState;
   const gameHasNotStarted = gameContext.players.length === 0; // :shrug:
   const [board3DOpen, setBoard3DOpen] = useState(false);
   const [board3DData, setBoard3DData] = useState<Board3DData | null>(null);
@@ -523,6 +526,7 @@ const GameControls = React.memo((props: Props) => {
             gameContext,
             gameContext.alphabet,
             gameContext.gameDocument,
+            userID,
           ),
         );
         setBoard3DOpen(true);
@@ -693,6 +697,8 @@ const EndGameControls = (props: EGCProps) => {
   const [board3DOpen, setBoard3DOpen] = useState(false);
   const [board3DData, setBoard3DData] = useState<Board3DData | null>(null);
   const { gameContext } = useGameContextStoreContext();
+  const { loginState } = useLoginStateStoreContext();
+  const { userID } = loginState;
   const gameHasNotStarted = gameContext.players.length === 0; // :shrug:
   const gameDone = true; // it is endgame controls after all
 
@@ -746,6 +752,7 @@ const EndGameControls = (props: EGCProps) => {
                           gameContext,
                           gameContext.alphabet,
                           gameContext.gameDocument,
+                          userID,
                         ),
                       );
                       setBoard3DOpen(true);


### PR DESCRIPTION
The 3D board now correctly displays:
- Your own rack when viewing during active gameplay
- The on-turn player's rack when examining/analyzing game history

This fixes the issue where the 3D board would only show the rack of the player whose turn it was, making it invisible when it wasn't your turn during live games.

Changes:
- Modified convertGameStateTo3DData to accept optional userID parameter
- When userID provided, shows that user's rack (for active play)
- When userID not provided, shows on-turn player's rack (for examining)
- Updated GameControls and EndGameControls to pass current userID
- ExamineGameControls continues to not pass userID (correct behavior)