### PR TITLE
Add BCC to conduct@woogles.io for cheating notification emails

### DIFF
--- a/pkg/emailer/ses.go
+++ b/pkg/emailer/ses.go
@@ -20,9 +20,14 @@ const (
 
 // SendSimpleMessage sends an email via Amazon SES.
 // The debugMode parameter controls whether to actually send or just log.
-func SendSimpleMessage(debugMode bool, recipient, subject, body string) (string, error) {
+// The bccAddress parameter optionally adds a BCC recipient.
+func SendSimpleMessage(debugMode bool, recipient, subject, body string, bccAddress ...string) (string, error) {
 	if debugMode {
-		fmt.Printf("=== EMAIL DEBUG ===\nTo: %s\nSubject: %s\nBody:\n%s\n=== END EMAIL ===\n", recipient, subject, body)
+		bccInfo := ""
+		if len(bccAddress) > 0 {
+			bccInfo = fmt.Sprintf("\nBCC: %s", bccAddress[0])
+		}
+		fmt.Printf("=== EMAIL DEBUG ===\nTo: %s%s\nSubject: %s\nBody:\n%s\n=== END EMAIL ===\n", recipient, bccInfo, subject, body)
 		return "debug-mode", nil
 	}
 
@@ -36,11 +41,16 @@ func SendSimpleMessage(debugMode bool, recipient, subject, body string) (string,
 
 	client := sesv2.NewFromConfig(cfg)
 
+	destination := &types.Destination{
+		ToAddresses: []string{recipient},
+	}
+	if len(bccAddress) > 0 && bccAddress[0] != "" {
+		destination.BccAddresses = []string{bccAddress[0]}
+	}
+
 	input := &sesv2.SendEmailInput{
 		FromEmailAddress: aws.String(senderAddress),
-		Destination: &types.Destination{
-			ToAddresses: []string{recipient},
-		},
+		Destination:      destination,
 		Content: &types.EmailContent{
 			Simple: &types.Message{
 				Subject: &types.Content{

--- a/pkg/mod/notify.go
+++ b/pkg/mod/notify.go
@@ -37,10 +37,16 @@ func sendNotification(ctx context.Context, us user.Store, user *entity.User, act
 			log.Debug().Str("email", user.Email).Msg("generated mod action email content")
 			go func() {
 				log.Debug().Str("email", user.Email).Msg("going to send mod action email")
+				// BCC conduct@woogles.io for cheating emails
+				var bccAddress string
+				if action.EmailType == ms.EmailType_CHEATING {
+					bccAddress = AddressToContact
+				}
 				_, err := emailer.SendSimpleMessage(config.EmailDebugMode,
 					user.Email,
 					emailSubject,
-					emailContent)
+					emailContent,
+					bccAddress)
 				if err != nil {
 					// Errors should not be fatal, just log them
 					log.Err(err).Str("userID", user.UUID).Msg("mod-action-send-user-email")


### PR DESCRIPTION
- Modified SendSimpleMessage to accept optional bccAddress parameter
- Updated mod action notifications to BCC conduct@woogles.io when sending cheating-related emails
- Maintains backward compatibility with existing SendSimpleMessage calls