### PR TITLE
auto-enable analyzer and jump to first turn on finished games

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -386,6 +386,12 @@ export const AnalyzerContextProvider = (
   );
   const [showMovesForTurn, setShowMovesForTurn] = useState(-1);
   const [autoMode, setAutoMode] = useState(false);
+  const { freshExamineSignal } = useExamineStoreContext();
+  useEffect(() => {
+    if (freshExamineSignal > 0) {
+      setAutoMode(true);
+    }
+  }, [freshExamineSignal]);
   const [unrace, setUnrace] = useState(new Unrace());
 
   const { gameContext: examinableGameContext } =

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -1263,7 +1263,7 @@ export const BoardPanel = React.memo((props: Props) => {
         onChallenge={handleChallenge}
         onCommit={handleCommit}
         onRematch={props.handleAcceptRematch ?? rematch}
-        onExamine={handleExamineStart}
+        onExamine={() => handleExamineStart(props.gameDone)}
         onExportGCG={handleExportGCG}
         showNudge={authedSolvingPuzzle ? false : showNudge}
         showAbort={authedSolvingPuzzle ? false : showAbort}

--- a/liwords-ui/src/store/store.tsx
+++ b/liwords-ui/src/store/store.tsx
@@ -196,7 +196,8 @@ type PoolFormatStoreData = {
 type ExamineStoreData = {
   isExamining: boolean;
   examinedTurn: number;
-  handleExamineStart: () => void;
+  freshExamineSignal: number; // increments on first-ever Analyze click on a finished game
+  handleExamineStart: (gameDone?: boolean) => void;
   handleExamineEnd: () => void;
   handleExamineFirst: () => void;
   handleExaminePrev: () => void;
@@ -371,6 +372,7 @@ const PoolFormatContext = createContext<PoolFormatStoreData>({
 const ExamineContext = createContext<ExamineStoreData>({
   isExamining: false,
   examinedTurn: Infinity,
+  freshExamineSignal: 0,
   handleExamineStart: defaultFunction,
   handleExamineEnd: defaultFunction,
   handleExamineFirst: defaultFunction,
@@ -438,6 +440,8 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
   const { gameContext } = gameContextStore;
   const numberOfTurns = gameContext.turns.length;
   const [isExamining, setIsExamining] = useState(false);
+  const hasEverExaminedRef = useRef(false);
+  const [freshExamineSignal, setFreshExamineSignal] = useState(0);
   const doneButtonRef = useRef<HTMLButtonElement | null>(null);
   const [examinedTurn, setExaminedTurnRaw] = useState(Infinity);
   const setExaminedTurn = useCallback(
@@ -464,9 +468,17 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
     },
     [shouldTrigger],
   );
-  const handleExamineStartUnconditionally = useCallback(() => {
-    setIsExamining(true);
-  }, []);
+  const handleExamineStartUnconditionally = useCallback(
+    (gameDone?: boolean) => {
+      if (gameDone && !hasEverExaminedRef.current) {
+        setExaminedTurn(0);
+        setFreshExamineSignal((n) => n + 1);
+      }
+      hasEverExaminedRef.current = true;
+      setIsExamining(true);
+    },
+    [setExaminedTurn],
+  );
   const handleExamineEnd = useCallback(() => {
     setIsExamining(false);
   }, []);
@@ -774,6 +786,7 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
     () => ({
       isExamining,
       examinedTurn,
+      freshExamineSignal,
       handleExamineStart,
       handleExamineEnd,
       handleExamineFirst,
@@ -789,6 +802,7 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
     [
       isExamining,
       examinedTurn,
+      freshExamineSignal,
       handleExamineStart,
       handleExamineEnd,
       handleExamineFirst,


### PR DESCRIPTION
## Summary
- When clicking Analyze for the first time on a finished game, automatically jump to turn 0 and enable auto-analyze mode
- Does not trigger for live games, URL-based examination (?turn=), or re-entering analyzer after exiting
- Uses a signal counter in the examine store to notify the analyzer context

## Test plan
- [ ] Finish a game, click Analyze — jumps to turn 1 with auto-analyze on
- [ ] As observer of live game, click Analyze — stays at current turn, no auto-analyze
- [ ] Open /game/xxx?turn=5 — stays at turn 5, no auto-analyze
- [ ] Exit analyzer, re-enter — stays at current turn, no auto-analyze
- [ ] Navigate turns while auto-analyzing — works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>