### PR TITLE
name 3d board exports with game id and turn number

### DIFF
--- a/liwords-ui/src/gameroom/board3d/Board3DModal.tsx
+++ b/liwords-ui/src/gameroom/board3d/Board3DModal.tsx
@@ -31,6 +31,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   data: Board3DData | null;
+  filename?: string;
 };
 
 export const Board3DModal = React.memo((props: Props) => {
@@ -84,8 +85,8 @@ export const Board3DModal = React.memo((props: Props) => {
   }, [tileColor, boardColor]);
 
   const handleSavePNG = useCallback(() => {
-    sceneRef.current?.saveAsPNG();
-  }, []);
+    sceneRef.current?.saveAsPNG(props.filename);
+  }, [props.filename]);
 
   const handleToggleSpin = useCallback(() => {
     const next = sceneRef.current?.toggleSpin();

--- a/liwords-ui/src/gameroom/board3d/scene.ts
+++ b/liwords-ui/src/gameroom/board3d/scene.ts
@@ -1169,11 +1169,11 @@ export class Board3DScene {
     return this.spinEnabled;
   }
 
-  saveAsPNG() {
+  saveAsPNG(filename = "woogles-board.png") {
     this.renderer.render(this.scene, this.camera);
     const link = document.createElement("a");
     link.href = this.renderer.domElement.toDataURL("image/png");
-    link.download = "woogles-board.png";
+    link.download = filename;
     link.click();
   }
 

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -224,6 +224,7 @@ const ExamineGameControls = React.memo(
               open={board3DOpen}
               onClose={() => setBoard3DOpen(false)}
               data={board3DData}
+              filename={`${gameContext.gameID}-3d${isAtLastTurn ? "" : `-${examinableGameContext.turns.length + 1}`}.png`}
             />
           </React.Suspense>
         )}
@@ -673,6 +674,7 @@ const GameControls = React.memo((props: Props) => {
             open={board3DOpen}
             onClose={() => setBoard3DOpen(false)}
             data={board3DData}
+            filename={`${gameContext.gameID}-3d-${gameContext.turns.length + 1}.png`}
           />
         </React.Suspense>
       )}
@@ -797,6 +799,7 @@ const EndGameControls = (props: EGCProps) => {
             open={board3DOpen}
             onClose={() => setBoard3DOpen(false)}
             data={board3DData}
+            filename={`${gameContext.gameID}-3d.png`}
           />
         </React.Suspense>
       )}


### PR DESCRIPTION
## Summary
- 3D board PNG exports now include game ID and turn number in filename, matching 2D export naming
- ExamineGameControls: `{gameID}-3d-{turn}.png` or `{gameID}-3d.png` at last turn
- GameControls (live): `{gameID}-3d-{turn}.png`
- EndGameControls: `{gameID}-3d.png`

## Test plan
- [ ] Open 3D board while examining a mid-game turn, save PNG — filename includes game ID and turn
- [ ] Open 3D board at last turn of finished game, save PNG — filename has game ID, no turn
- [ ] Open 3D board from end game controls, save PNG — filename has game ID, no turn
- [ ] Open 3D board during live game, save PNG — filename has game ID and turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>