### PR TITLE
refine division stats tooltips and standings display

### DIFF
--- a/liwords-ui/src/leagues/standings.tsx
+++ b/liwords-ui/src/leagues/standings.tsx
@@ -423,6 +423,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
       sorter: (a: StandingRecord, b: StandingRecord) => a.draws - b.draws,
       sortDirections: ["descend", "ascend"] as SortOrder[],
       sortIcon: noSortIcon,
+      render: (draws: number) => (draws > 0 ? draws : "-"),
     },
     {
       title: <ColHeader title="CUM" tooltip="Cumulative spread" />,
@@ -735,6 +736,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
       sorter: (a: StandingRecord, b: StandingRecord) => a.timeouts - b.timeouts,
       sortDirections: ["descend", "ascend"] as SortOrder[],
       sortIcon: noSortIcon,
+      render: (timeouts: number) => (timeouts > 0 ? timeouts : "-"),
     },
     {
       title: <ColHeader title="Result" tooltip="Season result" />,


### PR DESCRIPTION
## Summary
- Remove div avg from PPG tooltip (always 1.00) (follow-up to #1737)
- Remove redundant opponent div avgs (always equal to non-opponent)
- Add div total draws to T column tooltip
- Hide div totals for T and #TO columns when zero
- Show "-" for zero draws and timeouts in standings

## Test plan
- [ ] Hover over PPG column header — no div avg shown
- [ ] Hover over T column header — shows total draws when non-zero
- [ ] Division with no draws/timeouts — T and #TO totals hidden from tooltips
- [ ] Standings rows with zero draws/timeouts show "-" instead of "0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>