### PR TITLE
wire up division jump from chat info text

### DIFF
--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -46,6 +46,7 @@ export type Props = {
   leagueID?: string;
   suppressDefault?: boolean;
   playerInfoMap?: Map<string, string>;
+  onInfoTextClick?: (userId: string) => void;
 };
 
 // userid -> channel -> string
@@ -645,6 +646,7 @@ export const Chat = React.memo((props: Props) => {
                   ? props.playerInfoMap?.get(ent.senderId)
                   : undefined
               }
+              onInfoTextClick={props.onInfoTextClick}
             />
           );
         }),
@@ -653,6 +655,7 @@ export const Chat = React.memo((props: Props) => {
       props.highlight,
       props.highlightText,
       props.playerInfoMap,
+      props.onInfoTextClick,
       channel,
       sendNewMessage,
     ],

--- a/liwords-ui/src/chat/chat_entity.tsx
+++ b/liwords-ui/src/chat/chat_entity.tsx
@@ -35,6 +35,7 @@ type EntityProps = {
   highlightText?: string;
   sendMessage?: (uuid: string, username: string) => void;
   infoText?: string;
+  onInfoTextClick?: (userId: string) => void;
 };
 
 const deleteMessage = (
@@ -136,6 +137,11 @@ export const ChatEntity = (props: EntityProps) => {
                     omitSendMessage={!props.sendMessage}
                     sendMessage={props.sendMessage}
                     infoText={props.infoText}
+                    handleInfoText={
+                      props.onInfoTextClick && props.senderId
+                        ? () => props.onInfoTextClick!(props.senderId!)
+                        : undefined
+                    }
                     showDeleteMessage
                     showModTools
                     deleteMessage={() => {

--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -562,6 +562,12 @@ export const LeaguePage = (props: Props) => {
                   defaultDescription={`League Chat: ${league.name}`}
                   leagueID={league.uuid}
                   playerInfoMap={playerInfoMap}
+                  onInfoTextClick={(userId) => {
+                    const division = playerToDivisionMap.get(userId);
+                    if (division?.uuid) {
+                      setSelectedDivisionId(division.uuid);
+                    }
+                  }}
                 />
               </div>
             )}


### PR DESCRIPTION
## Summary
- Clicking the division info text in chat player menu jumps to that division's standings (follow-up to #1728)

## Test plan
- [ ] In league chat, click a player's username context menu
- [ ] Click the "Division X (rank Y)" text — navigates to that division's standings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>