### PR TITLE
show timeout summary in season players modal

### DIFF
--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -1167,6 +1167,37 @@ export const LeaguePage = (props: Props) => {
                 ? " registered"
                 : ""}
             </p>
+            {(() => {
+              const divTimeouts = standingsData?.divisions
+                ?.map((div) => ({
+                  div,
+                  players: div.standings.filter((s) => s.timeouts > 0),
+                }))
+                .filter((d) => d.players.length > 0);
+              if (!divTimeouts?.length) return null;
+              return (
+                <div style={{ marginBottom: 16, fontSize: 13 }}>
+                  <strong>Timeouts:</strong>
+                  {divTimeouts.map(({ div, players }) => (
+                    <div key={div.uuid} style={{ marginLeft: 8 }}>
+                      <a
+                        onClick={() => {
+                          setSelectedDivisionId(div.uuid);
+                          setShowPlayersModal(false);
+                        }}
+                        style={{ cursor: "pointer" }}
+                      >
+                        {div.divisionName || `Division ${div.divisionNumber}`}
+                      </a>
+                      :{" "}
+                      {players
+                        .map((s) => `${s.username} (${s.timeouts})`)
+                        .join(", ")}
+                    </div>
+                  ))}
+                </div>
+              );
+            })()}
             <div
               style={{
                 display: "flex",


### PR DESCRIPTION
## Summary
- List divisions with timed-out games and the players who timed out in the season players modal
- Clicking a division name jumps to that division's standings

## Test plan
- [ ] Open season players modal for a season with timeouts — timeout summary section appears
- [ ] Verify timed-out players listed under their division
- [ ] Click a division name — navigates to that division's standings
- [ ] Season with no timeouts — no timeout summary section shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>