### PR TITLE
show register link next to current user in standings

### DIFF
--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -840,6 +840,13 @@ export const LeaguePage = (props: Props) => {
                         promotionFormula={displayedSeason?.promotionFormula}
                         timeBankWarnings={timeBankWarningsMap}
                         nextSeasonRegistrations={nextSeasonRegistrations}
+                        onRegister={
+                          registrationOpenSeason &&
+                          !isUserRegisteredForRegistrationOpenSeason
+                            ? () =>
+                                setSelectedSeasonId(registrationOpenSeason.uuid)
+                            : undefined
+                        }
                       />
                     ))}
                   <div className="standings-legend">

--- a/liwords-ui/src/leagues/standings.tsx
+++ b/liwords-ui/src/leagues/standings.tsx
@@ -100,6 +100,7 @@ type DivisionStandingsProps = {
   promotionFormula?: PromotionFormula;
   timeBankWarnings?: Map<string, number>; // Map of userId to count of low timebank games
   nextSeasonRegistrations?: SeasonRegistrationsResponse;
+  onRegister?: () => void; // Callback to navigate to registration
 };
 
 export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
@@ -111,6 +112,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
   promotionFormula = PromotionFormula.PROMO_N_DIV_6,
   timeBankWarnings,
   nextSeasonRegistrations,
+  onRegister,
 }) => {
   const [selectedPlayer, setSelectedPlayer] = useState<{
     userId: string;
@@ -391,6 +393,19 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
                 <span style={{ marginLeft: 4, opacity: 0.7 }}>
                   <ReloadOutlined style={{ fontSize: 10 }} />
                 </span>
+              </Tooltip>
+            )}
+            {isCurrentUser && onRegister && !registeredForNextSeason && (
+              <Tooltip title="Register for next season">
+                <a
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRegister();
+                  }}
+                  style={{ marginLeft: 4, fontSize: 11 }}
+                >
+                  Register
+                </a>
               </Tooltip>
             )}
           </span>


### PR DESCRIPTION
## Summary
- When registration is open for the next season and the current user hasn't registered yet, show a "Register" link next to their name in the standings table
- Clicking the link navigates to the registration-open season

## Test plan
- [ ] View standings while logged in and not registered for next season — "Register" link appears next to your name
- [ ] Click "Register" — navigates to the registration-open season
- [ ] Already registered — no link shown, reload icon shown instead
- [ ] No registration-open season — no link shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>