### PR TITLE
show indicator on "View Notepad" when notepad has content

### DIFF
--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -49,7 +49,10 @@ const NotepadContext = React.createContext({
   feRackInfo: true,
 });
 
-export const useNotepadContext = () => React.useContext(NotepadContext);
+const NotepadHasContentContext = React.createContext(false);
+
+export const useNotepadHasContent = () =>
+  React.useContext(NotepadHasContentContext);
 
 export const NotepadContextProvider = ({
   children,
@@ -95,7 +98,15 @@ export const NotepadContextProvider = ({
     [curNotepad, setCurNotepad, feRackInfo],
   );
 
-  return <NotepadContext.Provider value={contextValue} children={children} />;
+  const hasContent = curNotepad.length > 0;
+
+  return (
+    <NotepadContext.Provider value={contextValue}>
+      <NotepadHasContentContext.Provider value={hasContent}>
+        {children}
+      </NotepadHasContentContext.Provider>
+    </NotepadContext.Provider>
+  );
 };
 const defaultFunction = () => {};
 

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -23,7 +23,7 @@ import {
 } from "../utils/cwgame/game_event";
 import { Turn, gameEventsToTurns } from "../store/reducers/turns";
 import { PoolFormatType } from "../constants/pool_formats";
-import { Notepad, useNotepadContext } from "./notepad";
+import { Notepad, useNotepadHasContent } from "./notepad";
 import { sortTiles } from "../store/constants";
 import { getVW, isTablet } from "../utils/cwgame/common";
 import { Analyzer } from "./analyzer";
@@ -387,7 +387,7 @@ export const ScoreCard = React.memo((props: Props) => {
   const [cardHeight, setCardHeight] = useState(0);
   const [flipHidden, setFlipHidden] = useState(true);
   const [flipEnabled, setEnableFlip] = useState(isTablet());
-  const { curNotepad } = useNotepadContext();
+  const notepadHasContent = useNotepadHasContent();
   // Autoscroll code removed - comments now use drawer
 
   const turns = useMemo(() => gameEventsToTurns(props.events), [props.events]);
@@ -507,7 +507,7 @@ export const ScoreCard = React.memo((props: Props) => {
       title = !flipHidden ? "Notepad" : `Turn ${turns.length + 1}`;
       extra = !flipHidden
         ? "View Scorecard"
-        : `View Notepad${curNotepad ? " \u25cf" : ""}`;
+        : `View Notepad${notepadHasContent ? " \u25cf" : ""}`;
     }
   }
   let contents = null;


### PR DESCRIPTION
## Summary
- Add a dot indicator (●) to the "View Notepad" toggle on small screens when the notepad has saved content
- Use a separate boolean context to avoid re-rendering the scorecard on every notepad keystroke

## Test plan
- [ ] On a tablet-sized screen, open a game and add notes to the notepad
- [ ] Flip to scorecard view — "View Notepad ●" shows the dot
- [ ] Clear the notepad — dot disappears
- [ ] Return to a correspondence game with saved notes — dot appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>