### PR TITLE
persist rack order in localStorage

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -583,12 +583,14 @@ export const BoardPanel = React.memo((props: Props) => {
       localStorage.removeItem(`rack_${gameID}`);
       return;
     }
-    // Don't save if rack is in server order (user hasn't rearranged).
+    // Remove stale entry if rack is in server order (user hasn't rearranged).
     if (
       displayedRack.length === props.currentRack.length &&
       displayedRack.every((v, i) => v === props.currentRack[i])
-    )
+    ) {
+      localStorage.removeItem(`rack_${gameID}`);
       return;
+    }
     const timer = setTimeout(() => {
       localStorage.setItem(`rack_${gameID}`, JSON.stringify(displayedRack));
     }, 500);


### PR DESCRIPTION
## Summary
- Save the displayed rack order to localStorage keyed by game ID
- On page load, restore the saved order if the tile multiset matches the server rack
- Falls back to auto-shuffle (if enabled) or server order when no saved order exists
- Clean up localStorage entry when game ends

## Test plan
- [ ] Arrange rack tiles in a custom order, reload the page — order is preserved
- [ ] With auto-shuffle enabled: shuffle happens on new rack, rearrange, reload — rearranged order preserved
- [ ] Play a move that changes tiles — old order discarded, new rack used
- [ ] Game ends — localStorage entry removed
- [ ] Opponent makes a move — our rack arrangement preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>