### PR TITLE
fix deprecated ant design props and nested p element

### DIFF
--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -947,7 +947,7 @@ export const Chat = React.memo((props: Props) => {
         onTabClick={handleTabClick}
         animated={false}
         items={tabItemsWithChildren}
-        destroyInactiveTabPane={false} // Keep all tab content rendered
+        destroyOnHidden={false} // Keep all tab content rendered
       />
     </Card>
   );

--- a/liwords-ui/src/profile/badge.tsx
+++ b/liwords-ui/src/profile/badge.tsx
@@ -41,7 +41,7 @@ export const Badge: React.FC<BadgeProps> = ({ name, width }) => {
     getImage(name).then(setImgSrc);
   }, [name]);
 
-  if (!imgSrc) return <p>Loading...</p>;
+  if (!imgSrc) return <span>Loading...</span>;
 
   return <img src={imgSrc} alt={name} width={width} />;
 };

--- a/liwords-ui/src/shared/usernameWithContext.tsx
+++ b/liwords-ui/src/shared/usernameWithContext.tsx
@@ -213,7 +213,7 @@ export const UsernameWithContext = (props: UsernameWithContextProps) => {
   return (
     <Dropdown
       overlayClassName="user-menu"
-      destroyPopupOnHide
+      destroyOnHidden
       menu={{
         items: userMenuOptions,
         onClick: ({ key }) => {

--- a/liwords-ui/src/tournament/monitoring/director_dashboard_modal.tsx
+++ b/liwords-ui/src/tournament/monitoring/director_dashboard_modal.tsx
@@ -420,11 +420,13 @@ export const DirectorDashboardModal = ({
       footer={null}
       width="90vw"
       style={{ top: 20 }}
-      bodyStyle={{
-        maxHeight: "calc(100vh - 200px)",
-        overflowY: "auto",
-        display: "flex",
-        flexDirection: "column",
+      styles={{
+        body: {
+          maxHeight: "calc(100vh - 200px)",
+          overflowY: "auto",
+          display: "flex",
+          flexDirection: "column",
+        },
       }}
       title={
         <Space>

--- a/liwords-ui/src/tournament/monitoring/monitoring_modal.tsx
+++ b/liwords-ui/src/tournament/monitoring/monitoring_modal.tsx
@@ -229,7 +229,7 @@ export const MonitoringModal = ({ visible, onClose }: Props) => {
         </Button>,
       ]}
       style={{ top: 20 }}
-      bodyStyle={{ maxHeight: "calc(100vh - 200px)", overflowY: "auto" }}
+      styles={{ body: { maxHeight: "calc(100vh - 200px)", overflowY: "auto" } }}
       zIndex={1100}
     >
       <Alert


### PR DESCRIPTION
## Summary
- `destroyPopupOnHide` → `destroyOnHidden` (Dropdown)
- `destroyInactiveTabPane` → `destroyOnHidden` (Tabs)
- `bodyStyle` → `styles.body` (Modal)
- `<p>Loading...</p>` → `<span>` in Badge to avoid nested `<p>` inside player name

## Test plan
- [ ] No deprecation warnings in browser console
- [ ] No "cannot be a descendant of" warnings in console
- [ ] Dropdown, Tabs, Modal, Badge still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>