### PR TITLE
mark user's division with star in division dropdown

### DIFF
--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -685,6 +685,10 @@ export const LeaguePage = (props: Props) => {
                         >
                           {division.divisionName ||
                             `Division ${division.divisionNumber}`}
+                          {userSeasonInfo?.divisionNumber ===
+                          division.divisionNumber
+                            ? " \u2605"
+                            : ""}
                           {totalGamesRemaining
                             ? ` (${totalGamesPlayed}/${totalGamesPlayed + totalGamesRemaining})`
                             : ""}


### PR DESCRIPTION
## Summary
- Show a ★ next to the user's division in the standings division dropdown
- Uses the existing `userSeasonInfo` computed in the league page

## Test plan
- [ ] Open league standings while logged in — your division shows ★ in the dropdown
- [ ] Not logged in — no star
- [ ] User not in any division — no star

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>