### PR TITLE
Prevent IRL mode toggle when players exist

### DIFF
--- a/pkg/tournament/tournament.go
+++ b/pkg/tournament/tournament.go
@@ -193,6 +193,29 @@ func SetTournamentMetadata(ctx context.Context, ts TournamentStore, meta *pb.Tou
 	}
 	log.Info().Interface("t", t).Bool("merge", merge).Interface("meta", meta).Msg("tournament-before-set-meta")
 
+	// Validate IRL mode changes: prevent changing IRL mode if players already exist
+	changingIRLMode := meta.IrlMode != (t.ExtraMeta != nil && t.ExtraMeta.IRLMode)
+	if changingIRLMode {
+		// Check if any divisions have players
+		hasPlayers := false
+		for _, div := range t.Divisions {
+			if div.DivisionManager != nil {
+				players := div.DivisionManager.GetPlayers()
+				if players != nil && len(players.Persons) > 0 {
+					hasPlayers = true
+					break
+				}
+			}
+		}
+		if hasPlayers {
+			if meta.IrlMode {
+				return errors.New("cannot enable IRL mode after players have been added. Please remove all players first or create a new tournament.")
+			} else {
+				return errors.New("cannot disable IRL mode after players have been added. Please remove all players first or create a new tournament.")
+			}
+		}
+	}
+
 	// Not all fields need to be specified if we're merging.
 	t.Name = ternary(merge && name == "", t.Name, name)
 	t.Description = ternary(merge && meta.Description == "", t.Description, meta.Description)
@@ -2012,7 +2035,7 @@ func OpenRegistration(ctx context.Context, ts TournamentStore, tid string) error
 		return entity.NewWooglesError(ipc.WooglesError_TOURNAMENT_OPENREGISTRATIONS_AFTER_START, t.Name)
 	}
 	if t.ExtraMeta.IRLMode {
-		return errors.New("cannot open registrations for IRL tournaments")
+		return errors.New("cannot open self-registration for IRL tournaments. Players must be added manually by the director.")
 	}
 	t.ExtraMeta.RegistrationOpen = true
 	err = ts.Set(ctx, t)


### PR DESCRIPTION
Add validation to prevent changing a tournament's IRL mode (enabling or disabling) after players have been added to any division. This prevents ID format mismatches that occur when:
1. Players register with online format (uuid:username)
2. Director enables IRL mode
3. System expects IRL format (md5hash:username)
4. Player removal/management fails with "player not found" errors

Changes:
- Add check in SetTournamentMetadata to detect IRL mode changes
- Iterate through all divisions to check for existing players
- Return clear error message directing user to remove players first
- Improve OpenRegistration error message for IRL tournaments

This fixes the issue where directors could accidentally create tournaments with mixed player ID formats, making player management impossible via the UI.