### PR TITLE
allow viewing any player's h2h in league roster

### DIFF
--- a/liwords-ui/src/leagues/league_roster.tsx
+++ b/liwords-ui/src/leagues/league_roster.tsx
@@ -207,14 +207,14 @@ export const LeagueRoster: React.FC<Props> = ({
             title: (
               <Tooltip
                 title={
-                  h2hUsername
-                    ? `Head-to-head record for ${h2hUsername}`
-                    : "Your head-to-head record in league games"
+                  h2hUserId === currentUserId
+                    ? "Your head-to-head record in league games"
+                    : `Head-to-head record for ${h2hUsername}`
                 }
               >
                 <span>
                   H2H
-                  {h2hUsername && h2hUserId !== currentUserId && (
+                  {h2hUserId !== currentUserId && h2hUsername && (
                     <span style={{ fontSize: 10, opacity: 0.7 }}>
                       {" "}
                       ({h2hUsername})


### PR DESCRIPTION
## Summary
- Click "View H2H" in a player's context menu to see their head-to-head records against all opponents (extends #1755)
- Column header shows whose H2H is being viewed when viewing another player
- Non-participants don't see H2H column until they explicitly click "View H2H"
- Participants auto-show their own H2H on load (same as before)

## Test plan
- [ ] Logged-in participant sees own H2H column on load
- [ ] Click "View H2H" on another player — column switches to their records
- [ ] Column header shows "(username)" when viewing another player's H2H
- [ ] Logged-in non-participant sees no H2H column until clicking "View H2H"
- [ ] Not logged in — no H2H column until clicking "View H2H"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>