### PR TITLE
add missing game end reason labels

### DIFF
--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -22,8 +22,12 @@ const endReasonLabel = (reason: GameEndReason): string => {
       return "adjudicated";
     case GameEndReason.ABORTED:
       return "aborted";
-    default:
+    case GameEndReason.CANCELLED:
+      return "cancelled";
+    case GameEndReason.STANDARD:
       return "";
+    default:
+      return "other";
   }
 };
 

--- a/liwords-ui/src/lobby/correspondence_games.tsx
+++ b/liwords-ui/src/lobby/correspondence_games.tsx
@@ -293,14 +293,51 @@ export const CorrespondenceGames = (props: Props) => {
               resultText = `to ${opponentName} via forfeit`;
             }
             break;
-          default:
-            // Standard completion - show scores
+          case GameEndReason.ADJUDICATED:
+            if (userWon) {
+              resultText = `over ${opponentName} ${userScore}–${opponentScore} (adjudicated)`;
+            } else if (isTie) {
+              resultText = `with ${opponentName} ${userScore}–${opponentScore} (adjudicated)`;
+            } else {
+              resultText = `to ${opponentName} ${userScore}–${opponentScore} (adjudicated)`;
+            }
+            break;
+          case GameEndReason.CONSECUTIVE_ZEROES:
+            if (userWon) {
+              resultText = `over ${opponentName} ${userScore}–${opponentScore} (six-zero)`;
+            } else if (isTie) {
+              resultText = `with ${opponentName} ${userScore}–${opponentScore} (six-zero)`;
+            } else {
+              resultText = `to ${opponentName} ${userScore}–${opponentScore} (six-zero)`;
+            }
+            break;
+          case GameEndReason.TRIPLE_CHALLENGE:
+            if (userWon) {
+              resultText = `over ${opponentName} (triple challenge)`;
+            } else {
+              resultText = `to ${opponentName} (triple challenge)`;
+            }
+            break;
+          case GameEndReason.ABORTED:
+            resultText = `vs ${opponentName} (aborted)`;
+            break;
+          case GameEndReason.STANDARD:
             if (userWon) {
               resultText = `over ${opponentName} ${userScore}–${opponentScore}`;
             } else if (isTie) {
               resultText = `with ${opponentName} ${userScore}–${opponentScore}`;
             } else {
               resultText = `to ${opponentName} ${userScore}–${opponentScore}`;
+            }
+            break;
+          default:
+            // Covers NONE, CANCELLED, and any future end reasons
+            if (userWon) {
+              resultText = `over ${opponentName} ${userScore}–${opponentScore} (other)`;
+            } else if (isTie) {
+              resultText = `with ${opponentName} ${userScore}–${opponentScore} (other)`;
+            } else {
+              resultText = `to ${opponentName} ${userScore}–${opponentScore} (other)`;
             }
         }
 

--- a/liwords-ui/src/profile/gameCard.tsx
+++ b/liwords-ui/src/profile/gameCard.tsx
@@ -83,8 +83,14 @@ export const GameCard = React.memo((props: GameCardProps) => {
     case GameEndReason.TRIPLE_CHALLENGE:
       endReason = "Triple challenge";
       break;
+    case GameEndReason.ADJUDICATED:
+      endReason = "Adjudicated";
+      break;
     case GameEndReason.STANDARD:
       endReason = "Completed";
+      break;
+    default:
+      endReason = "Other";
   }
 
   const getDetails = (

--- a/liwords-ui/src/profile/games_history.tsx
+++ b/liwords-ui/src/profile/games_history.tsx
@@ -143,8 +143,14 @@ export const GamesHistoryCard = React.memo((props: Props) => {
         case GameEndReason.TRIPLE_CHALLENGE:
           endReason = "Triple challenge";
           break;
+        case GameEndReason.ADJUDICATED:
+          endReason = "Adjudicated";
+          break;
         case GameEndReason.STANDARD:
           endReason = "Completed";
+          break;
+        default:
+          endReason = "Other";
       }
       let time: string;
       if (item.gameRequest?.gameMode === 1) {

--- a/liwords-ui/src/tournament/recent_games.tsx
+++ b/liwords-ui/src/tournament/recent_games.tsx
@@ -88,8 +88,17 @@ export const RecentTourneyGames = React.memo((props: Props) => {
         case GameEndReason.TRIPLE_CHALLENGE:
           endReason = "Triple";
           break;
+        case GameEndReason.FORCE_FORFEIT:
+          endReason = "Forfeit";
+          break;
+        case GameEndReason.ADJUDICATED:
+          endReason = "Adjudicated";
+          break;
         case GameEndReason.STANDARD:
           endReason = "Complete";
+          break;
+        default:
+          endReason = "Other";
       }
 
       return {


### PR DESCRIPTION
## Summary
- Add ADJUDICATED label to gameCard, games_history, recent_games
- Add FORCE_FORFEIT label to recent_games
- Add ADJUDICATED (with scores), CONSECUTIVE_ZEROES (with scores), TRIPLE_CHALLENGE, ABORTED to correspondence_games
- Add CANCELLED and explicit STANDARD to player_game_history_modal
- Add "Other"/"other" default case to all switch statements for future-proofing

## Test plan
- [ ] View profile game history — adjudicated games show "Adjudicated"
- [ ] View tournament recent games — forfeited games show "Forfeit"
- [ ] View correspondence games list — adjudicated games show scores with "(adjudicated)"
- [ ] View league player games popup — all end reasons have labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>