### PR TITLE
Fix COP hopefulness threshold truncation bug

### DIFF
--- a/pkg/tournament/classic_division.go
+++ b/pkg/tournament/classic_division.go
@@ -977,21 +977,17 @@ func (t *ClassicDivision) pairRoundWithCOP(round int, preserveByes bool) (*pb.Di
 
 	// Build COPIntermediateConfig from the RoundControl
 	rc := t.RoundControls[round]
-	numRounds := len(rc.GibsonSpreads)
 
 	// Convert gibson_spreads and hopefulness_thresholds from repeated fields to slices
-	gibsonSpread := make([]int, numRounds)
+	gibsonSpread := make([]int, len(rc.GibsonSpreads))
 	for i, gs := range rc.GibsonSpreads {
 		gibsonSpread[i] = int(gs)
 	}
 
-	hopefulnessThreshold := make([]float64, numRounds)
-	copy(hopefulnessThreshold, rc.HopefulnessThresholds)
-
 	cfg := &COPIntermediateConfig{
 		GibsonSpread:               gibsonSpread,
 		ControlLossThreshold:       rc.ControlLossThreshold,
-		HopefulnessThreshold:       hopefulnessThreshold,
+		HopefulnessThreshold:       rc.HopefulnessThresholds,
 		DivisionSims:               int(rc.DivisionSims),
 		ControlLossSims:            int(rc.ControlLossSims),
 		ControlLossActivationRound: int(rc.ControlLossActivationRound),


### PR DESCRIPTION
The hopefulness_thresholds array was being truncated to match the length of gibson_spreads (typically 2), causing only the first two thresholds [0.1, 0.1] to be passed to COP instead of the full array [0.1, 0.1, 0.05, 0.02, 0.01].

This caused all COP rounds to use threshold 0.1 instead of the intended decreasing thresholds for earlier rounds (0.05, 0.02, 0.01).

The fix passes the full hopefulness_thresholds array directly from the round controls, allowing the backward indexing logic in TournamentDivisionToCOPRequest to work correctly.