### PR TITLE
Implement just-in-time MI subtraction for analysis requeues

### DIFF
--- a/db/queries/analysis.sql
+++ b/db/queries/analysis.sql
@@ -188,17 +188,34 @@ SELECT COUNT(*) as total
 FROM analysis_jobs
 WHERE status = 'completed';
 
--- name: ResetAnalysisJob :exec
--- Reset an analysis job back to pending so it can be re-processed
+-- name: GetJobByID :one
+SELECT id, game_id, status, result
+FROM analysis_jobs
+WHERE id = $1;
+
+-- name: ResetAnalysisJobKeepResult :exec
+-- Resets job to pending but keeps result for JIT MI subtraction
 UPDATE analysis_jobs
 SET status = 'pending',
-    result = NULL,
     error_message = NULL,
     claimed_by_user_uuid = NULL,
     claimed_at = NULL,
     heartbeat_at = NULL,
     completed_at = NULL,
     retry_count = 0
+WHERE id = $1;
+
+-- name: ResetAnalysisJobWithPriority :exec
+-- Resets job and sets custom priority (for batch requeue)
+UPDATE analysis_jobs
+SET status = 'pending',
+    error_message = NULL,
+    claimed_by_user_uuid = NULL,
+    claimed_at = NULL,
+    heartbeat_at = NULL,
+    completed_at = NULL,
+    retry_count = 0,
+    priority = $2
 WHERE id = $1;
 
 -- name: GetAnalyzedGameIds :many

--- a/pkg/analysis/admin_service.go
+++ b/pkg/analysis/admin_service.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	"google.golang.org/protobuf/encoding/protojson"
+	"github.com/jackc/pgx/v5/pgtype"
 
-	macondo "github.com/domino14/macondo/gen/api/proto/macondo"
 	"github.com/woogles-io/liwords/pkg/apiserver"
 	"github.com/woogles-io/liwords/pkg/auth/rbac"
 	"github.com/woogles-io/liwords/pkg/stores/models"
@@ -92,16 +91,8 @@ func (s *AnalysisAdminService) RequeueAnalysis(
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no analysis job found for game %s", req.Msg.GameId))
 	}
 
-	// If there's an existing completed result, subtract its mistake index contribution
-	// from league standings before resetting so it doesn't get double-counted.
-	if job.Status == "completed" && len(job.Result) > 0 {
-		var oldResult macondo.GameAnalysisResult
-		if err := protojson.Unmarshal(job.Result, &oldResult); err == nil {
-			applyLeagueMistakeIndex(ctx, s.queries, job.GameID, &oldResult, true)
-		}
-	}
-
-	if err := s.queries.ResetAnalysisJob(ctx, job.ID); err != nil {
+	// Don't subtract MI here - JIT subtraction happens in SubmitResult
+	if err := s.queries.ResetAnalysisJobKeepResult(ctx, job.ID); err != nil {
 		return nil, apiserver.InternalErr(fmt.Errorf("failed to reset analysis job: %w", err))
 	}
 
@@ -178,4 +169,24 @@ func (s *AnalysisAdminService) ListAnalyzedGames(
 		Games: games,
 		Total: int32(total),
 	}), nil
+}
+
+// RequeueJobByGameID requeues an analysis job by game ID with a specified priority.
+// This is a helper function for batch requeuing operations (e.g., requeueing all v0.12.3 analyses).
+// It performs the same logic as RequeueAnalysis RPC but without authentication.
+// The priority parameter allows setting custom priorities (e.g., -1 for low-priority batch requeues).
+// MI subtraction is handled just-in-time in SubmitResult when the new analysis completes.
+func RequeueJobByGameID(ctx context.Context, queries *models.Queries, gameID string, priority int) error {
+	job, err := queries.GetJobByGameID(ctx, gameID)
+	if err != nil {
+		return fmt.Errorf("no analysis job found for game %s: %w", gameID, err)
+	}
+
+	// Don't subtract MI here - JIT subtraction happens in SubmitResult
+
+	priorityPG := pgtype.Int4{Int32: int32(priority), Valid: true}
+	return queries.ResetAnalysisJobWithPriority(ctx, models.ResetAnalysisJobWithPriorityParams{
+		ID:       job.ID,
+		Priority: priorityPG,
+	})
 }

--- a/pkg/analysis/service.go
+++ b/pkg/analysis/service.go
@@ -272,6 +272,16 @@ func (s *AnalysisService) SubmitResult(
 		}), nil
 	}
 
+	// JIT MI subtraction: if this job has an existing result (reanalysis),
+	// subtract the old MI before storing the new result.
+	existingJob, err := s.queries.GetJobByID(ctx, jobID)
+	if err == nil && len(existingJob.Result) > 0 {
+		var oldResult macondo.GameAnalysisResult
+		if err := protojson.Unmarshal(existingJob.Result, &oldResult); err == nil {
+			applyLeagueMistakeIndex(ctx, s.queries, existingJob.GameID, &oldResult, true) // decrement
+		}
+	}
+
 	// Store result
 	userUUID := pgtype.Text{String: user.UUID, Valid: true}
 	completedJob, err := s.queries.CompleteJob(ctx, models.CompleteJobParams{
@@ -500,16 +510,9 @@ func (s *AnalysisService) RequestAnalysis(
 					JobId:   existingJob.ID.String(),
 				}), nil
 			}
-			// Subtract old result's mistake index contribution before resetting,
-			// to avoid double-counting in league standings when new analysis completes.
-			var oldResult macondo.GameAnalysisResult
-			if len(existingJob.Result) > 0 {
-				if err := protojson.Unmarshal(existingJob.Result, &oldResult); err == nil {
-					applyLeagueMistakeIndex(ctx, s.queries, existingJob.GameID, &oldResult, true)
-				}
-			}
 			// Legacy result — reset the existing job back to pending (same as admin RequeueAnalysis)
-			if err := s.queries.ResetAnalysisJob(ctx, existingJob.ID); err != nil {
+			// Don't subtract MI here - JIT subtraction happens in SubmitResult
+			if err := s.queries.ResetAnalysisJobKeepResult(ctx, existingJob.ID); err != nil {
 				log.Error().Err(err).Str("job_id", existingJob.ID.String()).Msg("failed to reset legacy job for re-analysis")
 				return nil, apiserver.InternalErr(fmt.Errorf("failed to reset legacy job: %w", err))
 			}

--- a/pkg/stores/models/analysis.sql.go
+++ b/pkg/stores/models/analysis.sql.go
@@ -432,6 +432,31 @@ func (q *Queries) GetJobByGameID(ctx context.Context, gameID string) (GetJobByGa
 	return i, err
 }
 
+const getJobByID = `-- name: GetJobByID :one
+SELECT id, game_id, status, result
+FROM analysis_jobs
+WHERE id = $1
+`
+
+type GetJobByIDRow struct {
+	ID     uuid.UUID
+	GameID string
+	Status string
+	Result []byte
+}
+
+func (q *Queries) GetJobByID(ctx context.Context, id uuid.UUID) (GetJobByIDRow, error) {
+	row := q.db.QueryRow(ctx, getJobByID, id)
+	var i GetJobByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.GameID,
+		&i.Status,
+		&i.Result,
+	)
+	return i, err
+}
+
 const getQueuePosition = `-- name: GetQueuePosition :one
 SELECT COUNT(*) + 1 as position
 FROM analysis_jobs aj
@@ -566,10 +591,9 @@ func (q *Queries) RecordUserAnalysisRequest(ctx context.Context, arg RecordUserA
 	return err
 }
 
-const resetAnalysisJob = `-- name: ResetAnalysisJob :exec
+const resetAnalysisJobKeepResult = `-- name: ResetAnalysisJobKeepResult :exec
 UPDATE analysis_jobs
 SET status = 'pending',
-    result = NULL,
     error_message = NULL,
     claimed_by_user_uuid = NULL,
     claimed_at = NULL,
@@ -579,9 +603,33 @@ SET status = 'pending',
 WHERE id = $1
 `
 
-// Reset an analysis job back to pending so it can be re-processed
-func (q *Queries) ResetAnalysisJob(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.Exec(ctx, resetAnalysisJob, id)
+// Resets job to pending but keeps result for JIT MI subtraction
+func (q *Queries) ResetAnalysisJobKeepResult(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, resetAnalysisJobKeepResult, id)
+	return err
+}
+
+const resetAnalysisJobWithPriority = `-- name: ResetAnalysisJobWithPriority :exec
+UPDATE analysis_jobs
+SET status = 'pending',
+    error_message = NULL,
+    claimed_by_user_uuid = NULL,
+    claimed_at = NULL,
+    heartbeat_at = NULL,
+    completed_at = NULL,
+    retry_count = 0,
+    priority = $2
+WHERE id = $1
+`
+
+type ResetAnalysisJobWithPriorityParams struct {
+	ID       uuid.UUID
+	Priority pgtype.Int4
+}
+
+// Resets job and sets custom priority (for batch requeue)
+func (q *Queries) ResetAnalysisJobWithPriority(ctx context.Context, arg ResetAnalysisJobWithPriorityParams) error {
+	_, err := q.db.Exec(ctx, resetAnalysisJobWithPriority, arg.ID, arg.Priority)
 	return err
 }
 


### PR DESCRIPTION
Replace upfront mistake index subtraction with JIT approach where old MI is only subtracted right before storing new result, not at requeue time. This keeps league standings accurate during the ~8 hour reanalysis window.

Changes:
- Add GetJobByID query to fetch existing result before CompleteJob
- Add ResetAnalysisJobKeepResult (resets without clearing result field)
- Add ResetAnalysisJobWithPriority (for batch requeues with custom priority)
- SubmitResult: Subtract old MI before storing new result (JIT subtraction)
- RequestAnalysis, RequeueAnalysis: Remove upfront MI subtraction, use new queries
- RequeueJobByGameID: Accept priority parameter for batch operations