### PR TITLE
feat: user-alias OBS URLs that auto-track latest annotated game

### DIFF
--- a/cmd/liwords-api/main.go
+++ b/cmd/liwords-api/main.go
@@ -473,6 +473,7 @@ func main() {
 	}
 	tournamentService.SetEventChannel(pubsubBus.TournamentEventChannel())
 	omgwordsService.SetEventChannel(pubsubBus.GameEventChannel())
+	omgwordsService.SetNatsConn(natsconn)
 	analysisService.SetNatsConn(natsconn)
 	gameCreatorAdapter.eventChan = pubsubBus.GameEventChannel()
 	broadcastService.SetEventChannel(pubsubBus.GameEventChannel())
@@ -487,6 +488,11 @@ func main() {
 	router.Handle(broadcasts.OBSGameHandlerPrefix, otelhttp.NewHandler(
 		http.HandlerFunc(obsHandler.ServeGameHTTP),
 		"obs-game-api",
+		otelhttp.WithSpanNameFormatter(customHTTPSpanNameFormatter),
+	))
+	router.Handle(broadcasts.OBSUserHandlerPrefix, otelhttp.NewHandler(
+		http.HandlerFunc(obsHandler.ServeUserHTTP),
+		"obs-user-api",
 		otelhttp.WithSpanNameFormatter(customHTTPSpanNameFormatter),
 	))
 

--- a/db/queries/games.sql
+++ b/db/queries/games.sql
@@ -16,6 +16,17 @@ FROM annotated_game_metadata agm
 JOIN users u ON agm.creator_uuid = u.uuid
 WHERE agm.game_uuid = @game_uuid;
 
+-- name: GetUserUUIDByUsername :one
+SELECT uuid FROM users WHERE lower(username) = lower(@username);
+
+-- name: GetLatestAnnotatedGameForUsername :one
+SELECT agm.game_uuid, agm.creator_uuid
+FROM annotated_game_metadata agm
+JOIN games g ON g.uuid = agm.game_uuid
+WHERE agm.creator_uuid = (SELECT uuid FROM users WHERE lower(username) = lower(@username))
+ORDER BY g.updated_at DESC
+LIMIT 1;
+
 -- name: GetGameMetadata :one
 SELECT
     id, uuid, type, player0_id, player1_id,

--- a/liwords-ui/src/boardwizard/editor_control.tsx
+++ b/liwords-ui/src/boardwizard/editor_control.tsx
@@ -2,6 +2,7 @@
 
 import {
   Button,
+  Collapse,
   Form,
   Input,
   Popconfirm,
@@ -9,10 +10,9 @@ import {
   Typography,
   Card,
   Space,
-  Tag,
   message,
 } from "antd";
-import { BookOutlined, CloseOutlined, FolderOutlined } from "@ant-design/icons";
+import { BookOutlined, CloseOutlined } from "@ant-design/icons";
 import { Store } from "antd/lib/form/interface";
 import { useEffect, useState, useCallback } from "react";
 import { ChallengeRule } from "../gen/api/proto/ipc/omgwords_pb";
@@ -50,19 +50,8 @@ type Props = {
 export const EditorControl = (props: Props) => {
   const navigate = useNavigate();
   const { loginState } = useLoginStateStoreContext();
-  let form;
 
-  if (!props.gameID) {
-    form = <CreationForm createNewGame={props.createNewGame} />;
-  } else {
-    form = <EditForm editGame={props.editGame} />;
-  }
-
-  let gameURL = "";
-
-  if (props.gameID) {
-    gameURL = `${baseURL}/anno/${props.gameID}`;
-  }
+  const gameURL = props.gameID ? `${baseURL}/anno/${props.gameID}` : "";
 
   const { data: broadcastCtx } = useQuery(
     getBroadcastGameContext,
@@ -111,11 +100,7 @@ export const EditorControl = (props: Props) => {
           collectionUuid,
           gameId: props.gameID,
         });
-
-        // Refresh the collections list
         await fetchGameCollections();
-
-        // Show success message
         message.success(`Game removed from "${collectionTitle}"`);
       } catch (err) {
         console.error("Failed to remove game from collection:", err);
@@ -129,22 +114,59 @@ export const EditorControl = (props: Props) => {
     [props.gameID, collectionsClient, fetchGameCollections],
   );
 
-  // Fetch collections that contain this game
   useEffect(() => {
     if (props.gameID) {
       fetchGameCollections();
     }
   }, [props.gameID, fetchGameCollections]);
 
-  return (
-    <div className="editor-control">
-      {form}
-      {props.gameID && (
-        <>
-          Link to game:
-          <Typography.Paragraph copyable className="readable-text-color">
-            {gameURL}
-          </Typography.Paragraph>
+  if (!props.gameID) {
+    return (
+      <div className="editor-control">
+        <CreationForm createNewGame={props.createNewGame} />
+      </div>
+    );
+  }
+
+  const collectionsExtra = (
+    <Button
+      size="small"
+      icon={<BookOutlined />}
+      onClick={(e) => {
+        e.stopPropagation();
+        setCollectionModalVisible(true);
+      }}
+    >
+      Add
+    </Button>
+  );
+
+  const collapseItems = [
+    {
+      key: "details",
+      label: "Game details",
+      children: <EditForm editGame={props.editGame} />,
+    },
+    {
+      key: "share",
+      label: "Share & broadcast",
+      children: (
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <Typography.Text
+              type="secondary"
+              style={{ fontSize: 12 }}
+            >
+              Link to game
+            </Typography.Text>
+            <Typography.Paragraph
+              copyable
+              className="readable-text-color"
+              style={{ marginBottom: 0 }}
+            >
+              {gameURL}
+            </Typography.Paragraph>
+          </div>
           <OBSPanel
             gameID={props.gameID}
             broadcastSlug={broadcastCtx?.broadcastSlug}
@@ -156,150 +178,128 @@ export const EditorControl = (props: Props) => {
                 : "game"
             }
           />
-          {gameCollections.length > 0 && (
-            <Card
-              size="small"
-              title={
-                <>
-                  <FolderOutlined /> In Collections
-                </>
-              }
-              style={{ marginBottom: 16 }}
-            >
-              <Space wrap style={{ paddingLeft: 4, paddingBottom: 4 }}>
-                {gameCollections.map((collection) => (
-                  <div
-                    key={collection.uuid}
-                    style={{ display: "inline-block" }}
+        </Space>
+      ),
+    },
+    {
+      key: "collections",
+      label: "Collections",
+      extra: collectionsExtra,
+      children:
+        gameCollections.length === 0 ? (
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            This game is not in any collection yet.
+          </Typography.Text>
+        ) : (
+          <Space direction="vertical" style={{ width: "100%" }}>
+            {gameCollections.map((collection) => (
+              <Card
+                key={collection.uuid}
+                size="small"
+                style={{ background: "rgba(255,255,255,0.04)" }}
+              >
+                <Space
+                  style={{ width: "100%", justifyContent: "space-between" }}
+                >
+                  <Link
+                    to={`/collections/${collection.uuid}`}
+                    style={{ fontSize: 13 }}
                   >
-                    <Tag
-                      color="blue"
-                      style={{
-                        margin: "2px",
-                        cursor: "default",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "8px",
+                    {collection.title}
+                    {collection.games?.[0]?.chapterTitle &&
+                      ` (Ch. ${collection.games[0].chapterNumber})`}
+                  </Link>
+                  <Popconfirm
+                    title={`Remove game from "${collection.title}"?`}
+                    description="This will remove the game from this collection."
+                    onConfirm={() =>
+                      removeGameFromCollection(
+                        collection.uuid,
+                        collection.title,
+                      )
+                    }
+                    okText="Remove"
+                    cancelText="Cancel"
+                    okButtonProps={{ danger: true }}
+                  >
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<CloseOutlined />}
+                      loading={removingCollectionId === collection.uuid}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
                       }}
-                    >
-                      <Link
-                        to={`/collections/${collection.uuid}`}
-                        style={{ color: "inherit", textDecoration: "none" }}
-                      >
-                        <span style={{ cursor: "pointer" }}>
-                          {collection.title}
-                          {collection.games &&
-                            collection.games[0] &&
-                            collection.games[0].chapterTitle &&
-                            ` (Ch. ${collection.games[0].chapterNumber})`}
-                        </span>
-                      </Link>
-                      <Popconfirm
-                        title={`Remove game from "${collection.title}"?`}
-                        description="This will remove the game from this collection."
-                        onConfirm={() =>
-                          removeGameFromCollection(
-                            collection.uuid,
-                            collection.title,
-                          )
-                        }
-                        okText="Remove"
-                        cancelText="Cancel"
-                        okButtonProps={{ danger: true }}
-                      >
-                        <Button
-                          type="text"
-                          size="small"
-                          icon={<CloseOutlined />}
-                          loading={removingCollectionId === collection.uuid}
-                          style={{
-                            padding: "0 4px",
-                            height: "16px",
-                            minWidth: "16px",
-                            fontSize: "10px",
-                            color: "rgba(255, 255, 255, 0.7)",
-                          }}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                        />
-                      </Popconfirm>
-                    </Tag>
-                  </div>
-                ))}
-              </Space>
-            </Card>
-          )}
-          <p>
-            <Button
-              onClick={() => setCollectionModalVisible(true)}
-              type="default"
-              icon={<BookOutlined />}
-              style={{ marginBottom: 8, marginRight: 8 }}
-            >
-              Add to Collection
+                    />
+                  </Popconfirm>
+                </Space>
+              </Card>
+            ))}
+          </Space>
+        ),
+    },
+  ];
+
+  return (
+    <div className="editor-control">
+      <Collapse
+        accordion
+        defaultActiveKey={["details"]}
+        items={collapseItems}
+      />
+      <div style={{ textAlign: "right", marginTop: 12 }}>
+        {broadcastCtx ? (
+          <Popconfirm
+            title="Unclaim this game? The annotation will be deleted."
+            onConfirm={() =>
+              unclaimMutation.mutate({
+                slug: broadcastCtx.broadcastSlug,
+                round: broadcastCtx.round,
+                tableNumber: broadcastCtx.tableNumber,
+                division: broadcastCtx.division,
+              })
+            }
+            okText="Unclaim"
+            cancelText="Cancel"
+            okButtonProps={{ danger: true }}
+          >
+            <Button type="primary" danger loading={unclaimMutation.isPending}>
+              Unclaim this game
             </Button>
-          </p>
-          <p>
-            {broadcastCtx ? (
-              <Popconfirm
-                title="Unclaim this game? The annotation will be deleted."
-                onConfirm={() =>
-                  unclaimMutation.mutate({
-                    slug: broadcastCtx.broadcastSlug,
-                    round: broadcastCtx.round,
-                    tableNumber: broadcastCtx.tableNumber,
-                    division: broadcastCtx.division,
-                  })
-                }
-                okText="Unclaim"
-                cancelText="Cancel"
-                okButtonProps={{ danger: true }}
-              >
-                <Button
-                  type="primary"
-                  danger
-                  loading={unclaimMutation.isPending}
-                >
-                  Unclaim this game
-                </Button>
-              </Popconfirm>
-            ) : (
-              <Popconfirm
-                title="Are you sure you wish to delete this game? This action can not be undone!"
-                onConfirm={() => {
-                  props.deleteGame(props.gameID!);
-                  setConfirmDelVisible(false);
-                }}
-                onCancel={() => setConfirmDelVisible(false)}
-                okText="Yes"
-                cancelText="No"
-                open={confirmDelVisible}
-              >
-                <Button
-                  onClick={() => setConfirmDelVisible(true)}
-                  type="primary"
-                  danger
-                >
-                  Delete this game
-                </Button>
-              </Popconfirm>
-            )}
-          </p>
-          <AddToCollectionModal
-            visible={collectionModalVisible}
-            gameId={props.gameID}
-            isAnnotated={true}
-            onClose={() => setCollectionModalVisible(false)}
-            onSuccess={(collectionUuid) => {
-              // Refresh the collections list
-              fetchGameCollections();
-              console.log("Game added to collection:", collectionUuid);
+          </Popconfirm>
+        ) : (
+          <Popconfirm
+            title="Are you sure you wish to delete this game? This action can not be undone!"
+            onConfirm={() => {
+              props.deleteGame(props.gameID!);
+              setConfirmDelVisible(false);
             }}
-          />
-        </>
-      )}
+            onCancel={() => setConfirmDelVisible(false)}
+            okText="Yes"
+            cancelText="No"
+            open={confirmDelVisible}
+          >
+            <Button
+              onClick={() => setConfirmDelVisible(true)}
+              type="primary"
+              danger
+            >
+              Delete this game
+            </Button>
+          </Popconfirm>
+        )}
+      </div>
+      <AddToCollectionModal
+        visible={collectionModalVisible}
+        gameId={props.gameID}
+        isAnnotated={true}
+        onClose={() => setCollectionModalVisible(false)}
+        onSuccess={(collectionUuid) => {
+          fetchGameCollections();
+          console.log("Game added to collection:", collectionUuid);
+        }}
+      />
     </div>
   );
 };
@@ -315,6 +315,7 @@ type CreationFormProps = {
 const CreationForm = (props: CreationFormProps) => {
   return (
     <Form
+      layout="vertical"
       onFinish={(vals: Store) =>
         props.createNewGame(
           vals.p1name,
@@ -410,6 +411,7 @@ const EditForm = (props: EditFormProps) => {
 
   return (
     <Form
+      layout="vertical"
       form={formref}
       initialValues={{
         p1name: gameContext.gameDocument.players[0].realName,
@@ -429,9 +431,6 @@ const EditForm = (props: EditFormProps) => {
       <Form.Item label="Game description" name="description">
         <Input.TextArea maxLength={140} rows={2} />
       </Form.Item>
-      {/* <Form.Item label="Show in lobby" name="private">
-        <Switch />
-      </Form.Item> */}
       <Form.Item>
         <Button type="primary" htmlType="submit">
           Save settings

--- a/liwords-ui/src/boardwizard/editor_control.tsx
+++ b/liwords-ui/src/boardwizard/editor_control.tsx
@@ -153,10 +153,7 @@ export const EditorControl = (props: Props) => {
       children: (
         <Space direction="vertical" style={{ width: "100%" }}>
           <div>
-            <Typography.Text
-              type="secondary"
-              style={{ fontSize: 12 }}
-            >
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
               Link to game
             </Typography.Text>
             <Typography.Paragraph

--- a/liwords-ui/src/boardwizard/editor_control.tsx
+++ b/liwords-ui/src/boardwizard/editor_control.tsx
@@ -17,7 +17,10 @@ import { Store } from "antd/lib/form/interface";
 import { useEffect, useState, useCallback } from "react";
 import { ChallengeRule } from "../gen/api/proto/ipc/omgwords_pb";
 import { LexiconFormItem } from "../shared/lexicon_display";
-import { useGameContextStoreContext } from "../store/store";
+import {
+  useGameContextStoreContext,
+  useLoginStateStoreContext,
+} from "../store/store";
 import { baseURL, useClient, flashError } from "../utils/hooks/connect";
 import { AddToCollectionModal } from "../collections/AddToCollectionModal";
 import {
@@ -46,6 +49,7 @@ type Props = {
 
 export const EditorControl = (props: Props) => {
   const navigate = useNavigate();
+  const { loginState } = useLoginStateStoreContext();
   let form;
 
   if (!props.gameID) {
@@ -145,6 +149,14 @@ export const EditorControl = (props: Props) => {
             gameID={props.gameID}
             broadcastSlug={broadcastCtx?.broadcastSlug}
             slotName={broadcastCtx?.slotName}
+            username={
+              loginState.loggedIn ? loginState.username : undefined
+            }
+            defaultMode={
+              broadcastCtx?.broadcastSlug && broadcastCtx?.slotName
+                ? "slot"
+                : "game"
+            }
           />
           {gameCollections.length > 0 && (
             <Card

--- a/liwords-ui/src/boardwizard/editor_control.tsx
+++ b/liwords-ui/src/boardwizard/editor_control.tsx
@@ -149,9 +149,7 @@ export const EditorControl = (props: Props) => {
             gameID={props.gameID}
             broadcastSlug={broadcastCtx?.broadcastSlug}
             slotName={broadcastCtx?.slotName}
-            username={
-              loginState.loggedIn ? loginState.username : undefined
-            }
+            username={loginState.loggedIn ? loginState.username : undefined}
             defaultMode={
               broadcastCtx?.broadcastSlug && broadcastCtx?.slotName
                 ? "slot"

--- a/liwords-ui/src/broadcasts/BroadcastDirectorPanel.tsx
+++ b/liwords-ui/src/broadcasts/BroadcastDirectorPanel.tsx
@@ -300,7 +300,12 @@ export const BroadcastDirectorPanel: React.FC<Props> = ({
           </div>
           <div>
             <Typography.Text
-              style={{ fontSize: 11, display: "block", marginBottom: 2, visibility: "hidden" }}
+              style={{
+                fontSize: 11,
+                display: "block",
+                marginBottom: 2,
+                visibility: "hidden",
+              }}
             >
               &nbsp;
             </Typography.Text>

--- a/liwords-ui/src/broadcasts/BroadcastDirectorPanel.tsx
+++ b/liwords-ui/src/broadcasts/BroadcastDirectorPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import "./broadcasts.scss";
 import {
   Card,
   Button,
@@ -149,6 +150,7 @@ export const BroadcastDirectorPanel: React.FC<Props> = ({
     <Card
       title="Director Panel"
       size="small"
+      className="director-panel"
       style={{ marginTop: 24 }}
       styles={{ header: { paddingBlock: 10 } }}
       extra={
@@ -296,15 +298,23 @@ export const BroadcastDirectorPanel: React.FC<Props> = ({
               style={{ width: 80 }}
             />
           </div>
-          <Button
-            size="small"
-            icon={<PlusOutlined />}
-            loading={createSlotMutation.isPending}
-            onClick={doCreateSlot}
-            disabled={!newSlotName.trim() || !newSlotDivision}
-          >
-            Add slot
-          </Button>
+          <div>
+            <Typography.Text
+              style={{ fontSize: 11, display: "block", marginBottom: 2, visibility: "hidden" }}
+            >
+              &nbsp;
+            </Typography.Text>
+            <Button
+              size="small"
+              icon={<PlusOutlined />}
+              loading={createSlotMutation.isPending}
+              onClick={doCreateSlot}
+              disabled={!newSlotName.trim() || !newSlotDivision}
+              style={{ height: 24 }}
+            >
+              Add slot
+            </Button>
+          </div>
         </Space>
       </Space>
 

--- a/liwords-ui/src/broadcasts/OBSPanel.tsx
+++ b/liwords-ui/src/broadcasts/OBSPanel.tsx
@@ -102,11 +102,17 @@ function BlankPreview({
   return <>{parts}</>;
 }
 
+type OBSMode = "game" | "slot" | "user";
+
 type OBSPanelProps = {
-  /** Game UUID for direct per-game URLs. Unused when broadcastSlug+slotName are set. */
+  /** Game UUID for direct per-game URLs. */
   gameID?: string;
   broadcastSlug?: string;
   slotName?: string;
+  /** Username for user-alias URLs (follows the user's latest annotated game). */
+  username?: string;
+  /** Which mode to default to. Inferred from props when not specified. */
+  defaultMode?: OBSMode;
   /** When true renders only a button; when false (default) renders a Card wrapper. */
   compact?: boolean;
 };
@@ -115,6 +121,8 @@ export const OBSPanel: React.FC<OBSPanelProps> = ({
   gameID,
   broadcastSlug,
   slotName,
+  username,
+  defaultMode,
   compact = false,
 }) => {
   const { notification } = App.useApp();
@@ -130,10 +138,35 @@ export const OBSPanel: React.FC<OBSPanelProps> = ({
   const [blankColor, setBlankColor] = useState("#d33300");
   const [wrap, setWrap] = useState(0);
 
-  const useSlot = !!(broadcastSlug && slotName);
-  const urlBase = useSlot
-    ? `/api/broadcasts/obs/${broadcastSlug}/${slotName}`
-    : `/api/annotations/obs/game/${gameID}`;
+  // Determine which modes are available based on props.
+  const hasSlot = !!(broadcastSlug && slotName);
+  const hasUser = !!username;
+  const hasGame = !!gameID;
+
+  // Resolve the default mode: explicit prop > broadcast slot > game > user alias.
+  const resolvedDefault: OBSMode =
+    defaultMode ??
+    (hasSlot ? "slot" : hasGame ? "game" : hasUser ? "user" : "game");
+
+  const [mode, setMode] = useState<OBSMode>(resolvedDefault);
+
+  // Build the available mode options for the dropdown.
+  const modeOptions: { value: OBSMode; label: string }[] = [];
+  if (hasGame) modeOptions.push({ value: "game", label: "This game" });
+  if (hasSlot)
+    modeOptions.push({
+      value: "slot",
+      label: `Broadcast slot (${slotName})`,
+    });
+  if (hasUser)
+    modeOptions.push({ value: "user", label: `My alias (${username})` });
+
+  const urlBase =
+    mode === "slot"
+      ? `/api/broadcasts/obs/${broadcastSlug}/${slotName}`
+      : mode === "user"
+        ? `/api/annotations/obs/user/${username}`
+        : `/api/annotations/obs/game/${gameID}`;
 
   const isMarquee = suffix === "last_play";
   const isBlankField = suffix === "blank1" || suffix === "blank2";
@@ -237,7 +270,7 @@ export const OBSPanel: React.FC<OBSPanelProps> = ({
 
       <Modal
         open={modalOpen}
-        title={useSlot ? `OBS URL Builder — ${slotName}` : "OBS URL Builder"}
+        title="OBS URL Builder"
         width={720}
         zIndex={1100}
         onCancel={() => setModalOpen(false)}
@@ -251,6 +284,19 @@ export const OBSPanel: React.FC<OBSPanelProps> = ({
         }
       >
         <Space direction="vertical" style={{ width: "100%" }} size="middle">
+          {/* Context / mode selector — only shown when multiple sources are available */}
+          {modeOptions.length > 1 && (
+            <div>
+              <Typography.Text strong>Source</Typography.Text>
+              <br />
+              <Select<OBSMode>
+                value={mode}
+                onChange={setMode}
+                style={{ width: "100%", marginTop: 4 }}
+                options={modeOptions}
+              />
+            </div>
+          )}
           {/* Field selector */}
           <div>
             <Typography.Text strong>Field</Typography.Text>

--- a/liwords-ui/src/broadcasts/broadcasts.scss
+++ b/liwords-ui/src/broadcasts/broadcasts.scss
@@ -1,0 +1,65 @@
+@use "../base.scss" as *;
+
+.director-panel {
+  .ant-input,
+  .ant-input-affix-wrapper,
+  input {
+    @include colorModed() {
+      background: m($background);
+      color: m($gray-extreme);
+    }
+  }
+
+  .ant-input-number {
+    @include colorModed() {
+      background: m($background);
+    }
+    .ant-input-number-input {
+      @include colorModed() {
+        background: m($background);
+        color: m($gray-extreme);
+      }
+    }
+    .ant-input-number-handler-wrap {
+      @include colorModed() {
+        background: m($off-background);
+        border-color: m($gray-subtle);
+      }
+      .ant-input-number-handler {
+        @include colorModed() {
+          border-color: m($gray-subtle);
+          color: m($gray-medium);
+        }
+      }
+    }
+  }
+
+  .ant-select-selector,
+  .ant-select-item,
+  .ant-select-dropdown {
+    @include colorModed() {
+      background: m($background);
+      color: m($gray-extreme);
+    }
+  }
+
+  .ant-select:not(.ant-select-disabled) .ant-select-selector {
+    @include colorModed() {
+      background: m($background);
+      color: m($gray-extreme);
+      border-color: m($gray-subtle);
+    }
+  }
+
+  .ant-input-affix-wrapper {
+    @include colorModed() {
+      border-color: m($gray-subtle);
+    }
+    input {
+      @include colorModed() {
+        background: m($background);
+        color: m($gray-extreme);
+      }
+    }
+  }
+}

--- a/liwords-ui/src/themes.tsx
+++ b/liwords-ui/src/themes.tsx
@@ -14,6 +14,9 @@ const componentOverrides = {
   Input: {
     colorBorder: "#b9b9b9",
   },
+  InputNumber: {
+    colorBorder: "#b9b9b9",
+  },
   Dropdown: {
     paddingBlock: 10,
   },

--- a/pkg/broadcasts/obs_handler.go
+++ b/pkg/broadcasts/obs_handler.go
@@ -25,6 +25,14 @@ const OBSHandlerPrefix = "/api/broadcasts/obs/"
 // OBSGameHandlerPrefix is the URL prefix for direct per-game OBS endpoints.
 const OBSGameHandlerPrefix = "/api/annotations/obs/game/"
 
+// OBSUserHandlerPrefix is the URL prefix for user-alias OBS endpoints.
+// The URL resolves dynamically to the user's most-recently-edited annotated game.
+const OBSUserHandlerPrefix = "/api/annotations/obs/user/"
+
+// natsUserAnnoSubjectPrefix mirrors omgwords.NatsUserAnnoSubjectPrefix to avoid
+// a circular package import. Must stay in sync with pkg/omgwords/service.go.
+const natsUserAnnoSubjectPrefix = "user.anno."
+
 // validSuffixes lists the accepted display suffixes.
 var validSuffixes = map[string]bool{
 	"score":        true,
@@ -578,6 +586,177 @@ func (h *OBSHandler) rebindAnnoSub(stream *obsStream, key, newGameUUID string) {
 		return
 	}
 	stream.annoSub = newSub
+	stream.mu.Unlock()
+	h.mu.Unlock()
+}
+
+// ---------------------------------------------------------------------------
+// User-alias handler
+// ---------------------------------------------------------------------------
+
+// ServeUserHTTP dispatches user-alias requests:
+//
+//	/api/annotations/obs/user/<username>/<suffix>[.txt]
+//
+// The username is resolved to the user's most-recently-edited annotated game.
+// If no annotated game exists yet the placeholder text is returned, but the
+// SSE stream is still connectable — it will push data once a game appears.
+func (h *OBSHandler) ServeUserHTTP(w http.ResponseWriter, r *http.Request) {
+	tail := strings.TrimPrefix(r.URL.Path, OBSUserHandlerPrefix)
+	parts := strings.SplitN(tail, "/", 2)
+	if len(parts) != 2 {
+		http.Error(w, "usage: /api/annotations/obs/user/<username>/<suffix>", http.StatusBadRequest)
+		return
+	}
+	username, rawSuffix := parts[0], parts[1]
+	if username == "" {
+		http.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
+
+	rawText := strings.HasSuffix(rawSuffix, ".txt")
+	suffix := strings.TrimSuffix(rawSuffix, ".txt")
+	if !validSuffixes[suffix] {
+		http.Error(w, fmt.Sprintf("unknown suffix %q", suffix), http.StatusBadRequest)
+		return
+	}
+
+	streamKey := "user/" + strings.ToLower(username)
+
+	if suffix == "events" {
+		h.serveUserSSE(w, r, streamKey, username)
+		return
+	}
+
+	ctx := r.Context()
+	gameUUID := h.resolveUserGame(ctx, username)
+
+	var value string
+	if gameUUID == "" {
+		value = obsPlaceholder
+	} else {
+		value = h.computeField(ctx, gameUUID, suffix)
+	}
+
+	eventsURL := OBSUserHandlerPrefix + username + "/events"
+	h.serveResponse(w, suffix, value, eventsURL, rawText)
+}
+
+// resolveUserGame returns the game UUID of the user's most-recently-edited
+// annotated game, or "" if none exists.
+func (h *OBSHandler) resolveUserGame(ctx context.Context, username string) string {
+	row, err := h.queries.GetLatestAnnotatedGameForUsername(ctx, username)
+	if err != nil {
+		return ""
+	}
+	return row.GameUuid
+}
+
+// serveUserSSE opens a Server-Sent Events stream for the user-alias endpoint.
+func (h *OBSHandler) serveUserSSE(w http.ResponseWriter, r *http.Request, streamKey, username string) {
+	ctx := r.Context()
+
+	// Resolve username → userUUID once at connect time (needed for NATS subject).
+	userUUID, err := h.queries.GetUserUUIDByUsername(ctx, username)
+	if err != nil || !userUUID.Valid || userUUID.String == "" {
+		// Unknown username — still serve an open SSE so the browser source doesn't
+		// error out. It will just receive heartbeats until data appears.
+		flusher, ok := sseSetup(w)
+		if !ok {
+			return
+		}
+		heartbeat := time.NewTicker(20 * time.Second)
+		defer heartbeat.Stop()
+		for {
+			select {
+			case <-heartbeat.C:
+				fmt.Fprintf(w, ": heartbeat\n\n")
+				flusher.Flush()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	gameUUID := h.resolveUserGame(ctx, username)
+
+	flusher, ok := sseSetup(w)
+	if !ok {
+		return
+	}
+
+	ch := make(chan OBSData, 8)
+	stream := h.addSubscriber(streamKey, ch)
+	defer h.removeSubscriber(streamKey, ch)
+
+	h.ensureUserNATSSubs(stream, streamKey, userUUID.String, gameUUID, username)
+
+	h.serveSSELoop(w, ctx, ch, flusher, gameUUID)
+}
+
+// ensureUserNATSSubs subscribes once to:
+//  1. channel.anno<gameUUID>   — per-turn events for the current game
+//  2. user.anno.<userUUID>     — activity signal; fires when the user's latest game may change
+func (h *OBSHandler) ensureUserNATSSubs(stream *obsStream, key, userUUID, gameUUID, username string) {
+	stream.mu.Lock()
+	if stream.initialized {
+		stream.mu.Unlock()
+		return
+	}
+	stream.initialized = true
+	stream.currentGameID = gameUUID
+	stream.mu.Unlock()
+
+	// Per-turn subscription for the currently-resolved game.
+	var annoSub *nats.Subscription
+	if gameUUID != "" {
+		var err error
+		annoSub, err = h.natsConn.Subscribe("channel.anno"+gameUUID, func(_ *nats.Msg) {
+			h.reloadAndFanout(key, gameUUID)
+		})
+		if err != nil {
+			log.Err(err).Str("gameUUID", gameUUID).Msg("obs-user-anno-sub-error")
+			annoSub = nil
+		}
+	}
+
+	// User-level activity subscription — re-queries and rebinds if the latest game changed.
+	userSub, err := h.natsConn.Subscribe(natsUserAnnoSubjectPrefix+userUUID, func(_ *nats.Msg) {
+		ctx := context.Background()
+		newGameUUID := h.resolveUserGame(ctx, username)
+
+		stream.mu.Lock()
+		currentGameID := stream.currentGameID
+		stream.mu.Unlock()
+
+		if newGameUUID != currentGameID {
+			h.rebindAnnoSub(stream, key, newGameUUID)
+		}
+		if newGameUUID != "" {
+			h.reloadAndFanout(key, newGameUUID)
+		}
+	})
+	if err != nil {
+		log.Err(err).Str("userUUID", userUUID).Msg("obs-user-sub-error")
+		if annoSub != nil {
+			annoSub.Unsubscribe()
+		}
+		return
+	}
+
+	// Atomically assign both subs only if the stream is still live.
+	h.mu.Lock()
+	if h.streams[key] != stream {
+		h.mu.Unlock()
+		if annoSub != nil {
+			annoSub.Unsubscribe()
+		}
+		userSub.Unsubscribe()
+		return
+	}
+	stream.mu.Lock()
+	stream.annoSub = annoSub
+	stream.broadcastSub = userSub // reuse broadcastSub slot for the user-level sub
 	stream.mu.Unlock()
 	h.mu.Unlock()
 }

--- a/pkg/omgwords/service.go
+++ b/pkg/omgwords/service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
@@ -28,12 +29,19 @@ import (
 	pb "github.com/woogles-io/liwords/rpc/api/proto/omgwords_service"
 )
 
+// NatsUserAnnoSubjectPrefix is the NATS subject prefix published whenever a
+// user's annotated-game activity changes (new game, events sent, game marked
+// done). The OBS user-alias stream subscribes to this subject to know when to
+// rebind to a different game.
+const NatsUserAnnoSubjectPrefix = "user.anno."
+
 type OMGWordsService struct {
 	userStore     user.Store
 	cfg           *config.Config
 	gameStore     *stores.GameDocumentStore
 	metadataStore *stores.DBStore
 	gameEventChan chan *entity.EventWrapper
+	natsConn      *nats.Conn
 }
 
 func NewOMGWordsService(u user.Store, cfg *config.Config, gs *stores.GameDocumentStore,
@@ -71,6 +79,29 @@ func (gs *OMGWordsService) failIfSessionDoesntOwn(ctx context.Context, gameID st
 
 func (gs *OMGWordsService) SetEventChannel(c chan *entity.EventWrapper) {
 	gs.gameEventChan = c
+}
+
+func (gs *OMGWordsService) SetNatsConn(nc *nats.Conn) {
+	gs.natsConn = nc
+}
+
+// UserAnnoChannelName returns the NATS subject for user-level annotated-game
+// activity notifications.
+func UserAnnoChannelName(userUUID string) string {
+	return NatsUserAnnoSubjectPrefix + userUUID
+}
+
+// publishUserAnnoActivity fires a zero-byte NATS message on the user-level
+// annotated-game activity subject. OBS user-alias streams subscribe to this
+// to know when to rebind to a new game. Errors are logged and ignored — this
+// is best-effort.
+func (gs *OMGWordsService) publishUserAnnoActivity(creatorUUID string) {
+	if gs.natsConn == nil {
+		return
+	}
+	if err := gs.natsConn.Publish(UserAnnoChannelName(creatorUUID), nil); err != nil {
+		log.Err(err).Str("creatorUUID", creatorUUID).Msg("user-anno-publish-error")
+	}
 }
 
 func (gs *OMGWordsService) createGDoc(ctx context.Context, u *entity.User, req *pb.CreateAnnotatedGameRequest) (*ipc.GameDocument, error) {
@@ -225,7 +256,7 @@ func (gs *OMGWordsService) CreateAnnotatedGame(ctx context.Context, req *connect
 	if err != nil {
 		return nil, err
 	}
-
+	gs.publishUserAnnoActivity(u.UUID)
 	return connect.NewResponse(&pb.CreateAnnotatedGameResponse{
 		GameId: gdoc.Uid,
 	}), nil
@@ -261,7 +292,7 @@ func (gs *OMGWordsService) SendGameEvent(ctx context.Context, req *connect.Reque
 			return nil, err
 		}
 	}
-
+	gs.publishUserAnnoActivity(req.Msg.UserId)
 	return connect.NewResponse(&pb.GameEventResponse{}), nil
 }
 
@@ -276,8 +307,11 @@ func (gs *OMGWordsService) ReplaceGameDocument(ctx context.Context, req *connect
 	}
 	gid := req.Msg.Document.Uid
 
-	err := gs.failIfSessionDoesntOwn(ctx, gid)
+	u, err := apiserver.AuthUser(ctx, gs.userStore)
 	if err != nil {
+		return nil, err
+	}
+	if err = gs.failIfSessionDoesntOwn(ctx, gid); err != nil {
 		return nil, err
 	}
 
@@ -293,7 +327,7 @@ func (gs *OMGWordsService) ReplaceGameDocument(ctx context.Context, req *connect
 	wrapped := entity.WrapEvent(evt, ipc.MessageType_OMGWORDS_GAMEDOCUMENT)
 	wrapped.AddAudience(entity.AudChannel, AnnotatedChannelName(gid))
 	gs.gameEventChan <- wrapped
-
+	gs.publishUserAnnoActivity(u.UUID)
 	return connect.NewResponse(&pb.GameEventResponse{}), nil
 }
 

--- a/pkg/stores/models/games.sql.go
+++ b/pkg/stores/models/games.sql.go
@@ -290,6 +290,27 @@ func (q *Queries) GetHistory(ctx context.Context, argUuid pgtype.Text) ([]byte, 
 	return history, err
 }
 
+const getLatestAnnotatedGameForUsername = `-- name: GetLatestAnnotatedGameForUsername :one
+SELECT agm.game_uuid, agm.creator_uuid
+FROM annotated_game_metadata agm
+JOIN games g ON g.uuid = agm.game_uuid
+WHERE agm.creator_uuid = (SELECT uuid FROM users WHERE lower(username) = lower($1))
+ORDER BY g.updated_at DESC
+LIMIT 1
+`
+
+type GetLatestAnnotatedGameForUsernameRow struct {
+	GameUuid    string
+	CreatorUuid string
+}
+
+func (q *Queries) GetLatestAnnotatedGameForUsername(ctx context.Context, username string) (GetLatestAnnotatedGameForUsernameRow, error) {
+	row := q.db.QueryRow(ctx, getLatestAnnotatedGameForUsername, username)
+	var i GetLatestAnnotatedGameForUsernameRow
+	err := row.Scan(&i.GameUuid, &i.CreatorUuid)
+	return i, err
+}
+
 const getRecentCorrespondenceGamesByUserId = `-- name: GetRecentCorrespondenceGamesByUserId :many
 WITH recent_game_uuids AS (
   SELECT gp.game_uuid, gp.updated_at
@@ -580,6 +601,17 @@ func (q *Queries) GetRematchStreak(ctx context.Context, originalRequestID string
 		return nil, err
 	}
 	return items, nil
+}
+
+const getUserUUIDByUsername = `-- name: GetUserUUIDByUsername :one
+SELECT uuid FROM users WHERE lower(username) = lower($1)
+`
+
+func (q *Queries) GetUserUUIDByUsername(ctx context.Context, username string) (pgtype.Text, error) {
+	row := q.db.QueryRow(ctx, getUserUUIDByUsername, username)
+	var uuid pgtype.Text
+	err := row.Scan(&uuid)
+	return uuid, err
 }
 
 const insertGamePlayers = `-- name: InsertGamePlayers :exec


### PR DESCRIPTION
Adds a third OBS URL family tied to a username so broadcasters can set up OBS browser sources once and never change them between games or tournaments.

- New SQL queries: GetUserUUIDByUsername, GetLatestAnnotatedGameForUsername (orders by games.updated_at DESC, annotated games only)
- New NATS subject prefix user.anno.<userUUID>: published from CreateAnnotatedGame, SendGameEvent, and ReplaceGameDocument so the OBS stream knows when to rebind to a different game
- New backend endpoint /api/annotations/obs/user/<username>/<suffix>[.txt] with SSE support; resolves username → latest annotated game on connect, then rebinds automatically via ensureUserNATSSubs (mirrors the existing broadcast-slot rebind pattern)
- OBSPanel: new username + defaultMode props; adds a "Source" dropdown (game / broadcast slot / my alias) when multiple contexts are available; defaults to broadcast slot when in a broadcast context
- editor_control.tsx: passes logged-in username to OBSPanel