### PR TITLE
refactor: rename NATS anno subject prefix from user.anno. to anno.user.

### DIFF
--- a/pkg/broadcasts/obs_handler.go
+++ b/pkg/broadcasts/obs_handler.go
@@ -31,7 +31,7 @@ const OBSUserHandlerPrefix = "/api/annotations/obs/user/"
 
 // natsUserAnnoSubjectPrefix mirrors omgwords.NatsUserAnnoSubjectPrefix to avoid
 // a circular package import. Must stay in sync with pkg/omgwords/service.go.
-const natsUserAnnoSubjectPrefix = "user.anno."
+const natsUserAnnoSubjectPrefix = "anno.user."
 
 // validSuffixes lists the accepted display suffixes.
 var validSuffixes = map[string]bool{
@@ -696,7 +696,7 @@ func (h *OBSHandler) serveUserSSE(w http.ResponseWriter, r *http.Request, stream
 
 // ensureUserNATSSubs subscribes once to:
 //  1. channel.anno<gameUUID>   — per-turn events for the current game
-//  2. user.anno.<userUUID>     — activity signal; fires when the user's latest game may change
+//  2. anno.user.<userUUID>     — activity signal; fires when the user's latest game may change
 func (h *OBSHandler) ensureUserNATSSubs(stream *obsStream, key, userUUID, gameUUID, username string) {
 	stream.mu.Lock()
 	if stream.initialized {

--- a/pkg/omgwords/service.go
+++ b/pkg/omgwords/service.go
@@ -33,7 +33,7 @@ import (
 // user's annotated-game activity changes (new game, events sent, game marked
 // done). The OBS user-alias stream subscribes to this subject to know when to
 // rebind to a different game.
-const NatsUserAnnoSubjectPrefix = "user.anno."
+const NatsUserAnnoSubjectPrefix = "anno.user."
 
 type OMGWordsService struct {
 	userStore     user.Store


### PR DESCRIPTION
The old prefix user.anno.<userUUID> was inadvertently caught by the socket server's user.> subscription, which misrouted it to a nonexistent user ID "anno" and silently dropped it. The new anno.user.<userUUID> prefix lives outside the socket server's topic list entirely, making clear this is internal liwords-api-only IPC.