### PR TITLE
fix bestRank over-counting guaranteed-below players

### DIFF
--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -450,6 +450,12 @@ func bestRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *f
 		}
 	}
 
+	// Count guaranteed below: Q cannot finish above P no matter what happens.
+	// Q's maximum points (with P winning all) = Q.points + nonPGamesCnt*2,
+	// since games vs P yield 0 to Q. These players don't compete for flow
+	// capacity and must not be removed during feasibility iteration.
+	guaranteedBelow := 0
+
 	// Build the "stay below P" set with per-player constraints:
 	//
 	//   Q.spread < P.spread, can reach B via draws (maxBelow ≤ games):
@@ -474,6 +480,26 @@ func bestRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *f
 		if standings[i].points == B && !pHasGames && gi.nonPGamesCnt[i] == 0 &&
 			standings[i].spread > standings[p].spread {
 			continue // guaranteed above via spread tiebreak
+		}
+
+		// Q's ceiling when P wins all: games vs P yield 0, non-P games up to 2.
+		maxPts := standings[i].points + gi.nonPGamesCnt[i]*2
+		if maxPts < B {
+			guaranteedBelow++
+			continue // Q cannot reach B on points
+		}
+		if maxPts == B {
+			if pHasGames {
+				// P's best spread is unbounded (wins by huge margins).
+				// Q at B loses the spread tiebreak to P.
+				guaranteedBelow++
+				continue
+			}
+			if gi.nonPGamesCnt[i] == 0 && standings[i].spread < standings[p].spread {
+				// Q finished at B with worse spread. Loses tiebreak to P.
+				guaranteedBelow++
+				continue
+			}
 		}
 
 		// Determine whether Q at exactly B points could be above P.
@@ -535,7 +561,7 @@ func bestRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *f
 		}
 	}
 
-	minForcedAbove := guaranteedAbove + ((n - 1 - guaranteedAbove) - len(belowCandidates))
+	minForcedAbove := guaranteedAbove + ((n - 1 - guaranteedAbove - guaranteedBelow) - len(belowCandidates))
 	return max(1, 1+minForcedAbove)
 }
 

--- a/pkg/league/rank_bounds_test.go
+++ b/pkg/league/rank_bounds_test.go
@@ -306,6 +306,41 @@ func TestEqualPointsAndSpread(t *testing.T) {
 	}
 }
 
+func TestBestRankIgnoresGuaranteedBelow(t *testing.T) {
+	// Reproduces the liwords Collins S11 Div1 bug: a finished player with
+	// absorb capacity 0 and no remaining games was being removed during
+	// feasibility iteration and counted as "forced above P", inflating P's
+	// bestRank.
+	//
+	// P (player 0): 4 pts, 0 spread, 0 games remaining.
+	// Q1 (1): 2 pts, +10 spread, 2 games remaining (vs Q2, vs Q3).
+	// Q2 (2): 2 pts, +10 spread, 1 game remaining (vs Q1).
+	// Q3 (3): 2 pts, +10 spread, 1 game remaining (vs Q1).
+	// Fin (4): 0 pts, 0 spread, 0 games remaining — guaranteed below P.
+	//
+	// B = P.points = 4. Q1/Q2/Q3 each have spread > P's, so maxBelow=1 after
+	// decrement, absorb capped at 1. Sum absorb = 3. Within-set games = 2
+	// (Q1-Q2, Q1-Q3) × 2 = 4. 4 > 3 → infeasible by 1 pt, so exactly 1 of
+	// Q1/Q2/Q3 must exceed cap. Truth: bestRank = 2.
+	//
+	// Before fix: Fin entered belowCandidates with absorb=0, got removed as
+	// smallest-absorb without improving feasibility, then a Q was removed.
+	// Final len=2, both Fin and one Q counted as forced above → bestRank=3.
+	standings := []standingInfo{
+		si(0, 4, 0, 0),
+		si(1, 2, 10, 2),
+		si(2, 2, 10, 1),
+		si(3, 2, 10, 1),
+		si(4, 0, 0, 0),
+	}
+	games := []unfinishedGame{uf(1, 2), uf(1, 3)}
+	bounds := CalculatePossibleRanks(standings, games)
+
+	if bounds[0].BestRank != 2 {
+		t.Errorf("P best rank: got %d, want 2", bounds[0].BestRank)
+	}
+}
+
 func TestEqualPointsAndSpreadThreePlayers(t *testing.T) {
 	// Three players, all finished with same points and spread.
 	// Each should show range 1-3.


### PR DESCRIPTION
## Summary
- Fix bestRank inflating when finished players have no path to P's ceiling (follow-up to #1766)
- Add guaranteed-below pre-check symmetric to existing guaranteed-above checks in `bestRankForPlayer`
- Subtract guaranteed-below from the `minForcedAbove` formula

## Bug
Finished players with `Q.points + nonPGamesCnt*2 < B` entered belowCandidates with absorb=0, got removed by `checkBestFeasibility` as smallest-absorb without improving feasibility, then counted toward minForcedAbove.

Observed in Collins S11 Div1: jellomochas (rank 5, 8-6, 16 pts, done) showed a 10-10 tooltip. 4 players with 12/10/6/6 pts and no games left couldn't possibly reach 16 but were treated as potentially forced above, pushing bestRank from ~6 up to 10.

## Test plan
- [ ] `go test ./pkg/league/ -run TestBestRank` -- all pass
- [ ] New `TestBestRankIgnoresGuaranteedBelow` reproduces the bug (5 players, asserts bestRank=2 where pre-fix returned 3)
- [ ] `gofmt -l pkg/league/rank_bounds.go` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>