### PR TITLE
guarantee promotion/stay outcomes and recompute status on manual move

### DIFF
--- a/pkg/league/manual_division_ops.go
+++ b/pkg/league/manual_division_ops.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
 
 	"github.com/woogles-io/liwords/pkg/stores"
 	"github.com/woogles-io/liwords/pkg/stores/models"
+	ipc "github.com/woogles-io/liwords/rpc/api/proto/ipc"
 )
 
 // ManualDivisionManager provides tools for manual division management
@@ -140,9 +142,11 @@ func (mdm *ManualDivisionManager) MergeDivisions(
 
 // MovePlayer moves a single player from one division to another.
 // This is useful for manual corrections and balancing.
+// After moving, placement_status is recomputed based on actual movement vs previous season.
 func (mdm *ManualDivisionManager) MovePlayer(
 	ctx context.Context,
 	userID string, // UUID string
+	leagueID uuid.UUID,
 	seasonID uuid.UUID,
 	fromDivID uuid.UUID,
 	toDivID uuid.UUID,
@@ -192,12 +196,92 @@ func (mdm *ManualDivisionManager) MovePlayer(
 		return nil, fmt.Errorf("failed to move player: %w", err)
 	}
 
+	// Recompute placement_status based on actual movement vs previous season.
+	mdm.recomputePlacementStatus(ctx, userID, userDBID, leagueID, seasonID, reg, toDiv.DivisionNumber)
+
 	return &MoveResult{
 		Success:            true,
 		UserID:             userID,
 		PreviousDivisionID: fromDivID,
 		NewDivisionID:      toDivID,
 	}, nil
+}
+
+// recomputePlacementStatus recalculates and persists the placement_status after a
+// manual move.  NEW / HIATUS statuses are preserved (they describe entry, not movement).
+// Errors are logged and swallowed so a status-update hiccup does not fail the move.
+func (mdm *ManualDivisionManager) recomputePlacementStatus(
+	ctx context.Context,
+	username string,
+	userDBID int32,
+	leagueID uuid.UUID,
+	seasonID uuid.UUID,
+	reg models.LeagueRegistration,
+	newDivNumber int32,
+) {
+	oldStatus := ipc.PlacementStatus_PLACEMENT_NONE
+	if reg.PlacementStatus.Valid {
+		oldStatus = ipc.PlacementStatus(reg.PlacementStatus.Int32)
+	}
+
+	// Find the player's division number from their previous season.
+	history, err := mdm.stores.LeagueStore.GetPlayerSeasonHistory(ctx, models.GetPlayerSeasonHistoryParams{
+		UserID:   userDBID,
+		LeagueID: leagueID,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("userID", username).
+			Msg("recomputePlacementStatus: failed to get season history, skipping")
+		return
+	}
+
+	prevDivNumber := int32(0)
+	for _, h := range history {
+		if h.SeasonID == seasonID {
+			continue // Skip the current season.
+		}
+		if !h.DivisionID.Valid {
+			continue
+		}
+		div, err := mdm.stores.LeagueStore.GetDivision(ctx, h.DivisionID.Bytes)
+		if err != nil {
+			continue
+		}
+		prevDivNumber = div.DivisionNumber
+		break
+	}
+
+	if prevDivNumber == 0 {
+		// No previous season found — player is new; status stays as-is.
+		return
+	}
+
+	newStatus := CorrectPlacementStatus(oldStatus, prevDivNumber, newDivNumber)
+	if newStatus == oldStatus {
+		return
+	}
+
+	err = mdm.stores.LeagueStore.UpdatePlacementStatus(ctx, models.UpdatePlacementStatusParams{
+		UserID:               userDBID,
+		PlacementStatus:      pgtype.Int4{Int32: int32(newStatus), Valid: true},
+		PreviousDivisionRank: reg.PreviousDivisionRank,
+		SeasonID:             seasonID,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("userID", username).
+			Str("old_status", oldStatus.String()).
+			Str("new_status", newStatus.String()).
+			Msg("recomputePlacementStatus: failed to update placement status")
+		return
+	}
+
+	log.Info().
+		Str("username", username).
+		Str("old_status", oldStatus.String()).
+		Str("new_status", newStatus.String()).
+		Int32("previous_div", prevDivNumber).
+		Int32("new_div", newDivNumber).
+		Msg("recomputed placement status after manual move")
 }
 
 // CreateDivision creates a new division at the specified number.

--- a/pkg/league/manual_division_ops_test.go
+++ b/pkg/league/manual_division_ops_test.go
@@ -254,7 +254,7 @@ func TestMovePlayer_Success(t *testing.T) {
 	is.NoErr(err)
 
 	// Move player from Division 1 to Division 2
-	result, err := mdm.MovePlayer(ctx, playerUUID, seasonID, div1ID, div2ID)
+	result, err := mdm.MovePlayer(ctx, playerUUID, league, seasonID, div1ID, div2ID)
 	is.NoErr(err)
 	is.Equal(result.Success, true)
 	is.Equal(result.UserID, playerUUID)
@@ -327,7 +327,7 @@ func TestMovePlayer_InvalidDivision(t *testing.T) {
 
 	// Try to move player from wrong division - should fail
 	wrongDivID := uuid.New()
-	_, err = mdm.MovePlayer(ctx, playerUUID, seasonID, wrongDivID, div1ID)
+	_, err = mdm.MovePlayer(ctx, playerUUID, league, seasonID, wrongDivID, div1ID)
 	is.True(err != nil) // Should return error
 }
 
@@ -464,4 +464,151 @@ func TestCreateDivision_InsertMiddle(t *testing.T) {
 	oldDiv2, err := store.GetDivision(ctx, divIDs[1])
 	is.NoErr(err)
 	is.Equal(oldDiv2.DivisionNumber, int32(3)) // Was 2, now 3
+}
+
+// TestMovePlayer_StatusRecomputed_StayedToPromoted verifies that moving a STAYED
+// player up one division recalculates placement_status to PROMOTED.
+func TestMovePlayer_StatusRecomputed_StayedToPromoted(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	allStores, store, cleanup := setupTest(t)
+	defer cleanup()
+
+	mdm := NewManualDivisionManager(allStores)
+
+	league := uuid.New()
+	_, err := store.CreateLeague(ctx, models.CreateLeagueParams{
+		Uuid: league, Name: "Test", Slug: "test-stp",
+		Settings: []byte(`{}`), IsActive: pgtype.Bool{Bool: true, Valid: true},
+		CreatedBy: pgtype.Int8{Int64: 1, Valid: true},
+	})
+	is.NoErr(err)
+
+	// Season 1: player was in div 2.
+	s1ID := uuid.New()
+	_, err = store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid: s1ID, LeagueID: league, SeasonNumber: 1,
+		StartDate: pgtype.Timestamptz{Time: time.Now().AddDate(0, -2, 0), Valid: true},
+		EndDate:   pgtype.Timestamptz{Time: time.Now().AddDate(0, -1, 0), Valid: true},
+		Status:    int32(ipc.SeasonStatus_SEASON_COMPLETED),
+	})
+	is.NoErr(err)
+	s1Div1 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: s1Div1, SeasonID: s1ID, DivisionNumber: 1,
+		DivisionName: pgtype.Text{String: "Division 1", Valid: true},
+	})
+	is.NoErr(err)
+	s1Div2 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: s1Div2, SeasonID: s1ID, DivisionNumber: 2,
+		DivisionName: pgtype.Text{String: "Division 2", Valid: true},
+	})
+	is.NoErr(err)
+	_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+		UserID: 1, SeasonID: s1ID, DivisionID: pgtype.UUID{Bytes: s1Div2, Valid: true},
+		Status: pgtype.Text{String: "REGISTERED", Valid: true},
+	})
+	is.NoErr(err)
+
+	// Season 2: player initially placed in div 2 with STAYED status.
+	s2ID := uuid.New()
+	_, err = store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid: s2ID, LeagueID: league, SeasonNumber: 2,
+		StartDate: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		EndDate:   pgtype.Timestamptz{Time: time.Now().AddDate(0, 1, 0), Valid: true},
+		Status:    int32(ipc.SeasonStatus_SEASON_SCHEDULED),
+	})
+	is.NoErr(err)
+	s2Div1 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: s2Div1, SeasonID: s2ID, DivisionNumber: 1,
+		DivisionName: pgtype.Text{String: "Division 1", Valid: true},
+	})
+	is.NoErr(err)
+	s2Div2 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: s2Div2, SeasonID: s2ID, DivisionNumber: 2,
+		DivisionName: pgtype.Text{String: "Division 2", Valid: true},
+	})
+	is.NoErr(err)
+	_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+		UserID: 1, SeasonID: s2ID, DivisionID: pgtype.UUID{Bytes: s2Div2, Valid: true},
+		Status:          pgtype.Text{String: "REGISTERED", Valid: true},
+		PlacementStatus: pgtype.Int4{Int32: int32(ipc.PlacementStatus_PLACEMENT_STAYED), Valid: true},
+	})
+	is.NoErr(err)
+
+	// Admin moves the player from div2 up to div1.
+	result, err := mdm.MovePlayer(ctx, "test-uuid-1", league, s2ID, s2Div2, s2Div1)
+	is.NoErr(err)
+	is.True(result.Success)
+
+	// placement_status should now be PROMOTED (final div 1 < prev div 2).
+	reg, err := store.GetPlayerRegistration(ctx, models.GetPlayerRegistrationParams{
+		SeasonID: s2ID, UserID: 1,
+	})
+	is.NoErr(err)
+	is.True(reg.PlacementStatus.Valid)
+	is.Equal(ipc.PlacementStatus(reg.PlacementStatus.Int32), ipc.PlacementStatus_PLACEMENT_PROMOTED)
+}
+
+// TestMovePlayer_StatusPreserved_NewPlayer verifies that moving a PLACEMENT_NEW
+// player leaves their status unchanged.
+func TestMovePlayer_StatusPreserved_NewPlayer(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	allStores, store, cleanup := setupTest(t)
+	defer cleanup()
+
+	mdm := NewManualDivisionManager(allStores)
+
+	league := uuid.New()
+	_, err := store.CreateLeague(ctx, models.CreateLeagueParams{
+		Uuid: league, Name: "Test", Slug: "test-spnp",
+		Settings: []byte(`{}`), IsActive: pgtype.Bool{Bool: true, Valid: true},
+		CreatedBy: pgtype.Int8{Int64: 1, Valid: true},
+	})
+	is.NoErr(err)
+
+	// No season 1 — player is brand new to the league.
+	s1ID := uuid.New()
+	_, err = store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid: s1ID, LeagueID: league, SeasonNumber: 1,
+		StartDate: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		EndDate:   pgtype.Timestamptz{Time: time.Now().AddDate(0, 1, 0), Valid: true},
+		Status:    int32(ipc.SeasonStatus_SEASON_SCHEDULED),
+	})
+	is.NoErr(err)
+	div1 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: div1, SeasonID: s1ID, DivisionNumber: 1,
+		DivisionName: pgtype.Text{String: "Division 1", Valid: true},
+	})
+	is.NoErr(err)
+	div2 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: div2, SeasonID: s1ID, DivisionNumber: 2,
+		DivisionName: pgtype.Text{String: "Division 2", Valid: true},
+	})
+	is.NoErr(err)
+	_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+		UserID: 1, SeasonID: s1ID, DivisionID: pgtype.UUID{Bytes: div2, Valid: true},
+		Status:          pgtype.Text{String: "REGISTERED", Valid: true},
+		PlacementStatus: pgtype.Int4{Int32: int32(ipc.PlacementStatus_PLACEMENT_NEW), Valid: true},
+	})
+	is.NoErr(err)
+
+	// Move the new player from div2 to div1.
+	result, err := mdm.MovePlayer(ctx, "test-uuid-1", league, s1ID, div2, div1)
+	is.NoErr(err)
+	is.True(result.Success)
+
+	// PLACEMENT_NEW must be preserved regardless of which division the admin moves them to.
+	reg, err := store.GetPlayerRegistration(ctx, models.GetPlayerRegistrationParams{
+		SeasonID: s1ID, UserID: 1,
+	})
+	is.NoErr(err)
+	is.True(reg.PlacementStatus.Valid)
+	is.Equal(ipc.PlacementStatus(reg.PlacementStatus.Int32), ipc.PlacementStatus_PLACEMENT_NEW)
 }

--- a/pkg/league/rebalance.go
+++ b/pkg/league/rebalance.go
@@ -145,6 +145,15 @@ func (rm *RebalanceManager) RebalanceDivisions(
 		result.DivisionsCreated--
 	}
 
+	// Step 6b: Enforce promotion/stay guarantees.
+	// Runs after the merge so it operates on the final division layout.
+	// Merge only ever moves players upward (lower-numbered divisions), so it
+	// cannot introduce guarantee violations; enforcement then fixes any that
+	// remain from the initial bucketing.
+	if err := rm.enforceGuarantees(ctx, newSeasonID, playersWithPriority); err != nil {
+		return nil, fmt.Errorf("failed to enforce placement guarantees: %w", err)
+	}
+
 	// Get final division assignments for result and correct placement statuses
 	for _, p := range playersWithPriority {
 		reg, err := rm.stores.LeagueStore.GetPlayerRegistration(ctx, models.GetPlayerRegistrationParams{
@@ -160,7 +169,7 @@ func (rm *RebalanceManager) RebalanceDivisions(
 				// Step 7: Correct placement status if actual movement differs from expected
 				// PreviousDivisionNumber is where they started
 				// FinalDivision is where they actually ended up
-				correctedStatus := rm.correctPlacementStatus(p.PlacementStatus, p.PreviousDivisionNumber, div.DivisionNumber)
+				correctedStatus := CorrectPlacementStatus(p.PlacementStatus, p.PreviousDivisionNumber, div.DivisionNumber)
 				if correctedStatus != p.PlacementStatus {
 					err := rm.stores.LeagueStore.UpdatePlacementStatus(ctx, models.UpdatePlacementStatusParams{
 						UserID:               p.UserDBID,
@@ -192,15 +201,130 @@ func (rm *RebalanceManager) RebalanceDivisions(
 	return result, nil
 }
 
-// correctPlacementStatus adjusts placement status based on actual division movement
+// ceilingForStatus returns the maximum division number (highest-numbered = lowest tier)
+// that a player may land in given their status and previous division.
+// Returns (0, false) when the status carries no placement guarantee.
+func ceilingForStatus(status ipc.PlacementStatus, prevDiv int32) (int32, bool) {
+	switch status {
+	case ipc.PlacementStatus_PLACEMENT_PROMOTED:
+		if prevDiv <= 1 {
+			// Already in the top division; no room to move up.  This shouldn't
+			// occur in practice (champions are stored as STAYED), but handle
+			// defensively.
+			return 1, false
+		}
+		return prevDiv - 1, true
+	case ipc.PlacementStatus_PLACEMENT_STAYED:
+		return prevDiv, true
+	default:
+		return 0, false
+	}
+}
+
+// enforceGuarantees moves any PROMOTED or STAYED player whose final division
+// violates their earned outcome into their ceiling division.  This is called
+// after MergeUndersizedFinalDivision so that it operates on the final layout;
+// merge only ever moves players upward (into lower-numbered divisions) so it
+// cannot introduce guarantee violations.
+//
+// Division sizing may drift slightly as a result; that is intentional and left
+// to be addressed separately.
+func (rm *RebalanceManager) enforceGuarantees(
+	ctx context.Context,
+	seasonID uuid.UUID,
+	playersWithPriority []PlayerWithPriority,
+) error {
+	// Build a map from division number to UUID once, to avoid per-player DB hits.
+	allDivisions, err := rm.stores.LeagueStore.GetDivisionsBySeason(ctx, seasonID)
+	if err != nil {
+		return fmt.Errorf("enforceGuarantees: failed to get divisions: %w", err)
+	}
+	divByNumber := make(map[int32]uuid.UUID, len(allDivisions))
+	for _, d := range allDivisions {
+		divByNumber[d.DivisionNumber] = d.Uuid
+	}
+
+	for _, p := range playersWithPriority {
+		ceiling, hasGuarantee := ceilingForStatus(p.PlacementStatus, p.PreviousDivisionNumber)
+		if !hasGuarantee {
+			continue
+		}
+
+		// Special-case: PROMOTED from div 1 — nowhere to go, just warn.
+		if p.PlacementStatus == ipc.PlacementStatus_PLACEMENT_PROMOTED && p.PreviousDivisionNumber <= 1 {
+			log.Warn().
+				Str("username", p.Username).
+				Int32("previous_div", p.PreviousDivisionNumber).
+				Msg("PROMOTED player from top division — cannot enforce guarantee (should not occur)")
+			continue
+		}
+
+		reg, err := rm.stores.LeagueStore.GetPlayerRegistration(ctx, models.GetPlayerRegistrationParams{
+			SeasonID: seasonID,
+			UserID:   p.UserDBID,
+		})
+		if err != nil || !reg.DivisionID.Valid {
+			continue
+		}
+
+		div, err := rm.stores.LeagueStore.GetDivision(ctx, reg.DivisionID.Bytes)
+		if err != nil {
+			continue
+		}
+
+		if div.DivisionNumber <= ceiling {
+			continue // Already satisfies the guarantee.
+		}
+
+		// Find the ceiling division UUID.
+		targetUUID, ok := divByNumber[ceiling]
+		if !ok {
+			log.Warn().
+				Str("username", p.Username).
+				Str("status", p.PlacementStatus.String()).
+				Int32("previous_div", p.PreviousDivisionNumber).
+				Int32("ceiling", ceiling).
+				Int32("actual_div", div.DivisionNumber).
+				Msg("enforceGuarantees: ceiling division does not exist, cannot enforce")
+			continue
+		}
+
+		err = rm.stores.LeagueStore.UpdateRegistrationDivision(ctx, models.UpdateRegistrationDivisionParams{
+			UserID:      p.UserDBID,
+			SeasonID:    seasonID,
+			DivisionID:  pgtype.UUID{Bytes: targetUUID, Valid: true},
+			FirstsCount: reg.FirstsCount,
+		})
+		if err != nil {
+			log.Warn().Err(err).
+				Str("username", p.Username).
+				Msg("enforceGuarantees: failed to move player")
+			continue
+		}
+
+		log.Info().
+			Str("username", p.Username).
+			Str("status", p.PlacementStatus.String()).
+			Int32("previous_div", p.PreviousDivisionNumber).
+			Int32("old_final_div", div.DivisionNumber).
+			Int32("new_final_div", ceiling).
+			Msg("enforced guarantee")
+	}
+
+	return nil
+}
+
+// CorrectPlacementStatus adjusts placement status based on actual division movement.
 // Compares where the player started (previousDivision) to where they ended up (finalDivision)
 // and sets the status to reflect the actual movement, not the expected movement.
+//
+// Preserves NEW / HIATUS statuses — they describe how a player entered, not movement.
 //
 // Examples:
 // - Player promoted from Div 10 but ended up in Div 10 due to crowding -> STAYED
 // - Player stayed in Div 5 but ended up in Div 4 due to openings -> PROMOTED
 // - Player stayed in Div 5 but ended up in Div 6 due to league growth -> RELEGATED
-func (rm *RebalanceManager) correctPlacementStatus(
+func CorrectPlacementStatus(
 	originalStatus ipc.PlacementStatus,
 	previousDivision int32,
 	finalDivision int32,

--- a/pkg/league/rebalance_integration_test.go
+++ b/pkg/league/rebalance_integration_test.go
@@ -423,3 +423,286 @@ func TestRebalanceDivisions_8NewRookies(t *testing.T) {
 	is.Equal(len(divs), 1)
 	// All divisions are now regular divisions
 }
+
+// TestEnforceGuarantees_PromotedPlayerGuaranteed verifies that a player who earned
+// promotion is always placed in a better division, even when high-scoring STAYED
+// players would otherwise crowd them out via the priority-bucket algorithm.
+//
+// Scenario: 30 players across 2 divisions of 15.
+//   - All 15 div-1 players: RESULT_STAYED   (placement STAYED, virtual div 1, score ~240k)
+//   - Players 16-18 in div2: RESULT_PROMOTED (placement PROMOTED, virtual div 1, score ~230k)
+//   - Players 19-30 in div2: RESULT_STAYED   (virtual div 2, score ~140k)
+//
+// Without enforcement the 15 STAYED-div1 players (240k) beat the 3 PROMOTED-div2
+// players (230k), pushing the promoted players into div 2 — a guarantee violation.
+// With enforcement they must end up in div 1.
+func TestEnforceGuarantees_PromotedPlayerGuaranteed(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	allStores, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	store := allStores.LeagueStore
+	leagueID, season1ID := createLeagueAndSeason(t, ctx, allStores)
+
+	// Season 1: two divisions, 15 players each.
+	div1S1 := uuid.New()
+	_, err := store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: div1S1, SeasonID: season1ID, DivisionNumber: 1,
+		DivisionName: pgtype.Text{String: "Division 1", Valid: true},
+	})
+	is.NoErr(err)
+
+	div2S1 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: div2S1, SeasonID: season1ID, DivisionNumber: 2,
+		DivisionName: pgtype.Text{String: "Division 2", Valid: true},
+	})
+	is.NoErr(err)
+
+	// Register and create standings for 30 players.
+	for i := 1; i <= 30; i++ {
+		divID := div1S1
+		if i > 15 {
+			divID = div2S1
+		}
+		_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season1ID,
+			Status:     pgtype.Text{String: "REGISTERED", Valid: true},
+			DivisionID: pgtype.UUID{Bytes: divID, Valid: true},
+		})
+		is.NoErr(err)
+		err = store.UpsertStanding(ctx, models.UpsertStandingParams{
+			UserID: int32(i), DivisionID: divID,
+			Wins: pgtype.Int4{Int32: 5, Valid: true}, Losses: pgtype.Int4{Int32: 5, Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	// Set outcomes: players 1-15 STAYED in div1; players 16-18 PROMOTED in div2.
+	for i := 1; i <= 15; i++ {
+		err = store.UpdateStandingResult(ctx, models.UpdateStandingResultParams{
+			DivisionID: div1S1, UserID: int32(i),
+			Result: pgtype.Int4{Int32: int32(ipc.StandingResult_RESULT_STAYED), Valid: true},
+		})
+		is.NoErr(err)
+	}
+	for i := 16; i <= 18; i++ {
+		err = store.UpdateStandingResult(ctx, models.UpdateStandingResultParams{
+			DivisionID: div2S1, UserID: int32(i),
+			Result: pgtype.Int4{Int32: int32(ipc.StandingResult_RESULT_PROMOTED), Valid: true},
+		})
+		is.NoErr(err)
+	}
+	for i := 19; i <= 30; i++ {
+		err = store.UpdateStandingResult(ctx, models.UpdateStandingResultParams{
+			DivisionID: div2S1, UserID: int32(i),
+			Result: pgtype.Int4{Int32: int32(ipc.StandingResult_RESULT_STAYED), Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	// Season 2: register all 30 players.
+	season2ID := uuid.New()
+	_, err = store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid: season2ID, LeagueID: leagueID, SeasonNumber: 2,
+		StartDate: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		EndDate:   pgtype.Timestamptz{Time: time.Now().AddDate(0, 0, 14), Valid: true},
+		Status:    int32(ipc.SeasonStatus_SEASON_SCHEDULED),
+	})
+	is.NoErr(err)
+
+	for i := 1; i <= 30; i++ {
+		_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season2ID,
+			Status: pgtype.Text{String: "REGISTERED", Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	regs, err := store.GetSeasonRegistrations(ctx, season2ID)
+	is.NoErr(err)
+	is.Equal(len(regs), 30)
+
+	categorized := make([]CategorizedPlayer, 30)
+	for i, r := range regs {
+		categorized[i] = CategorizedPlayer{Registration: r, Category: PlayerCategoryReturning}
+	}
+
+	rm := NewRebalanceManager(allStores)
+	result, err := rm.RebalanceDivisions(ctx, leagueID, season1ID, season2ID, 2, categorized, 15)
+	is.NoErr(err)
+	is.Equal(result.DivisionsCreated, 2)
+
+	// Find the season-2 division with number 1.
+	s2Divs, err := store.GetDivisionsBySeason(ctx, season2ID)
+	is.NoErr(err)
+	div1S2 := uuid.UUID{}
+	for _, d := range s2Divs {
+		if d.DivisionNumber == 1 {
+			div1S2 = d.Uuid
+		}
+	}
+	is.True(div1S2 != uuid.UUID{})
+
+	// Players 16-18 (PROMOTED from div2) must all be in div1.
+	for i := 16; i <= 18; i++ {
+		reg, err := store.GetPlayerRegistration(ctx, models.GetPlayerRegistrationParams{
+			SeasonID: season2ID, UserID: int32(i),
+		})
+		is.NoErr(err)
+		is.True(reg.DivisionID.Valid)
+		is.Equal(uuid.UUID(reg.DivisionID.Bytes), div1S2) // must be div 1
+
+		is.True(reg.PlacementStatus.Valid)
+		is.Equal(ipc.PlacementStatus(reg.PlacementStatus.Int32), ipc.PlacementStatus_PLACEMENT_PROMOTED)
+	}
+}
+
+// TestEnforceGuarantees_StayedPlayerNotRelegated verifies that a STAYED player
+// is never placed in a worse division than their previous one, even when
+// relegated players crowd them out.
+//
+// Scenario: 30 players across 2 divisions of 15.
+//   - Div-1: 2 relegated (virtual div 2, score ~150k) + 13 stayed (virtual div 1, ~240k).
+//   - Div-2: 3 relegated (virtual div 3 — beyond last div, overflow to div 2)
+//             + 12 stayed (virtual div 2, ~140k).
+//
+// The 2 relegated from div1 and 3 relegated from div2 both have high relegated bonus (50k).
+// We construct a case where some STAYED-from-div1 players (ceiling=div1) are crowded out.
+//
+// Specifically: make div1 have 14 stayed + 1 relegated.  In virtual div2 there are the
+// relegated player (from div1, virtual div2, ~150k) plus 3 relegated from div2 (virtual
+// div3 = overflow to last → div2 in a 2-division league, ~150k), pushing all 4 relegated
+// into the bucket that was supposed to be div2 for the 12-stayed-from-div2 players.
+//
+// A simpler direct scenario: 16 players target div1 but only 15 bucket slots exist.
+// The 16th is a STAYED player whose ceiling is div1 — enforcement must move them up.
+func TestEnforceGuarantees_StayedPlayerNotRelegated(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	allStores, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	store := allStores.LeagueStore
+	leagueID, season1ID := createLeagueAndSeason(t, ctx, allStores)
+
+	// Season 1: one division with 16 players, all STAYED.
+	div1S1 := uuid.New()
+	_, err := store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: div1S1, SeasonID: season1ID, DivisionNumber: 1,
+		DivisionName: pgtype.Text{String: "Division 1", Valid: true},
+	})
+	is.NoErr(err)
+
+	// Extra div to satisfy the "has previous season div" constraint for the 16th player.
+	div2S1 := uuid.New()
+	_, err = store.CreateDivision(ctx, models.CreateDivisionParams{
+		Uuid: div2S1, SeasonID: season1ID, DivisionNumber: 2,
+		DivisionName: pgtype.Text{String: "Division 2", Valid: true},
+	})
+	is.NoErr(err)
+
+	// Players 1-15 stayed in div1; player 16 also stayed in div1.
+	// Season 2 idealDivisionSize=15 → bucket size 15. All 16 targeting virtual div1.
+	// Without enforcement: player 16 (lowest rank → lowest score) slips into div2.
+	// With enforcement: must be moved back to div1.
+	for i := 1; i <= 16; i++ {
+		_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season1ID,
+			Status:     pgtype.Text{String: "REGISTERED", Valid: true},
+			DivisionID: pgtype.UUID{Bytes: div1S1, Valid: true},
+		})
+		is.NoErr(err)
+		err = store.UpsertStanding(ctx, models.UpsertStandingParams{
+			UserID: int32(i), DivisionID: div1S1,
+			Wins: pgtype.Int4{Int32: int32(16 - i), Valid: true}, // Different wins to get distinct ranks.
+		})
+		is.NoErr(err)
+		err = store.UpdateStandingResult(ctx, models.UpdateStandingResultParams{
+			DivisionID: div1S1, UserID: int32(i),
+			Result: pgtype.Int4{Int32: int32(ipc.StandingResult_RESULT_STAYED), Valid: true},
+		})
+		is.NoErr(err)
+	}
+	// Also register player 17 in div2 (STAYED) so season 2 has enough players for 2 divs.
+	for i := 17; i <= 29; i++ {
+		_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season1ID,
+			Status:     pgtype.Text{String: "REGISTERED", Valid: true},
+			DivisionID: pgtype.UUID{Bytes: div2S1, Valid: true},
+		})
+		is.NoErr(err)
+		err = store.UpsertStanding(ctx, models.UpsertStandingParams{
+			UserID: int32(i), DivisionID: div2S1,
+			Wins: pgtype.Int4{Int32: 5, Valid: true},
+		})
+		is.NoErr(err)
+		err = store.UpdateStandingResult(ctx, models.UpdateStandingResultParams{
+			DivisionID: div2S1, UserID: int32(i),
+			Result: pgtype.Int4{Int32: int32(ipc.StandingResult_RESULT_STAYED), Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	// Season 2: register all 29 players.
+	season2ID := uuid.New()
+	_, err = store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid: season2ID, LeagueID: leagueID, SeasonNumber: 2,
+		StartDate: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		EndDate:   pgtype.Timestamptz{Time: time.Now().AddDate(0, 0, 14), Valid: true},
+		Status:    int32(ipc.SeasonStatus_SEASON_SCHEDULED),
+	})
+	is.NoErr(err)
+
+	for i := 1; i <= 29; i++ {
+		_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season2ID,
+			Status: pgtype.Text{String: "REGISTERED", Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	regs, err := store.GetSeasonRegistrations(ctx, season2ID)
+	is.NoErr(err)
+	is.Equal(len(regs), 29)
+
+	categorized := make([]CategorizedPlayer, 29)
+	for i, r := range regs {
+		categorized[i] = CategorizedPlayer{Registration: r, Category: PlayerCategoryReturning}
+	}
+
+	rm := NewRebalanceManager(allStores)
+	result, err := rm.RebalanceDivisions(ctx, leagueID, season1ID, season2ID, 2, categorized, 15)
+	is.NoErr(err)
+	is.Equal(result.PlayersAssigned, 29)
+
+	// Find div1 in season 2.
+	s2Divs, err := store.GetDivisionsBySeason(ctx, season2ID)
+	is.NoErr(err)
+	var div1S2UUID uuid.UUID
+	for _, d := range s2Divs {
+		if d.DivisionNumber == 1 {
+			div1S2UUID = d.Uuid
+		}
+	}
+	is.True(div1S2UUID != uuid.UUID{})
+
+	// All 16 STAYED-from-div1 players must be in div1.
+	for i := 1; i <= 16; i++ {
+		reg, err := store.GetPlayerRegistration(ctx, models.GetPlayerRegistrationParams{
+			SeasonID: season2ID, UserID: int32(i),
+		})
+		is.NoErr(err)
+		is.True(reg.DivisionID.Valid)
+		is.Equal(uuid.UUID(reg.DivisionID.Bytes), div1S2UUID)
+
+		is.True(reg.PlacementStatus.Valid)
+		// Player 16 had the lowest score (rank 16 in a 16-player div, rank component = 16-16 = 0).
+		// After enforcement they are placed in div1 — CorrectPlacementStatus labels them STAYED.
+		status := ipc.PlacementStatus(reg.PlacementStatus.Int32)
+		is.True(status == ipc.PlacementStatus_PLACEMENT_STAYED || status == ipc.PlacementStatus_PLACEMENT_PROMOTED)
+	}
+}

--- a/pkg/league/rebalance_test.go
+++ b/pkg/league/rebalance_test.go
@@ -362,6 +362,36 @@ func TestHiatusWeight_HalvesEveryTenSeasons(t *testing.T) {
 		"Weight after 20 seasons should be ~0.25, got %.4f", weight20)
 }
 
+func TestCeilingForStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        ipc.PlacementStatus
+		prevDiv       int32
+		wantCeiling   int32
+		wantGuarantee bool
+	}{
+		{"promoted from div 3", ipc.PlacementStatus_PLACEMENT_PROMOTED, 3, 2, true},
+		{"promoted from div 2", ipc.PlacementStatus_PLACEMENT_PROMOTED, 2, 1, true},
+		{"promoted from div 1 (should not occur)", ipc.PlacementStatus_PLACEMENT_PROMOTED, 1, 1, false},
+		{"stayed in div 1", ipc.PlacementStatus_PLACEMENT_STAYED, 1, 1, true},
+		{"stayed in div 4", ipc.PlacementStatus_PLACEMENT_STAYED, 4, 4, true},
+		{"relegated from div 2 (no ceiling)", ipc.PlacementStatus_PLACEMENT_RELEGATED, 2, 0, false},
+		{"new player (no ceiling)", ipc.PlacementStatus_PLACEMENT_NEW, 0, 0, false},
+		{"short hiatus (no ceiling)", ipc.PlacementStatus_PLACEMENT_SHORT_HIATUS_RETURNING, 3, 0, false},
+		{"long hiatus (no ceiling)", ipc.PlacementStatus_PLACEMENT_LONG_HIATUS_RETURNING, 3, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ceiling, hasGuarantee := ceilingForStatus(tt.status, tt.prevDiv)
+			assert.Equal(t, tt.wantGuarantee, hasGuarantee)
+			if tt.wantGuarantee {
+				assert.Equal(t, tt.wantCeiling, ceiling)
+			}
+		})
+	}
+}
+
 func TestNewRookieSplitting(t *testing.T) {
 	// Test the logic for splitting <10 new rookies between bottom 2 divisions
 	tests := []struct {

--- a/pkg/league/service.go
+++ b/pkg/league/service.go
@@ -2070,7 +2070,7 @@ func (ls *LeagueService) MovePlayerToDivision(
 
 	// Use the ManualDivisionManager to move the player
 	mdm := NewManualDivisionManager(ls.stores)
-	result, err := mdm.MovePlayer(ctx, req.Msg.UserId, seasonID, fromDivID, toDivID)
+	result, err := mdm.MovePlayer(ctx, req.Msg.UserId, season.LeagueID, seasonID, fromDivID, toDivID)
 	if err != nil {
 		return nil, apiserver.InternalErr(fmt.Errorf("failed to move player: %w", err))
 	}


### PR DESCRIPTION
Enforce that players who earned PLACEMENT_PROMOTED always land in a strictly better division than last season, and PLACEMENT_STAYED players never land in a worse one.  Previously the priority-bucket algorithm could silently crowd promoted/stayed players into wrong divisions, and correctPlacementStatus would just relabel them to match — hiding the violation.

Changes:
- Extract correctPlacementStatus to package-level CorrectPlacementStatus
- Add ceilingForStatus helper: PROMOTED → prevDiv-1, STAYED → prevDiv
- Add enforceGuarantees step (Step 6b) between merge and status correction in RebalanceDivisions; moves any violator to their ceiling division and logs "enforced guarantee"
- MovePlayer now takes leagueID and calls recomputePlacementStatus after updating division_id, so admin manual moves on the /leagues/admin page reflect the correct icon immediately; NEW/HIATUS statuses preserved