### PR TITLE
Consolidate nav: add More tab, switch dropdowns to hover

### DIFF
--- a/liwords-ui/src/navigation/topbar.tsx
+++ b/liwords-ui/src/navigation/topbar.tsx
@@ -139,7 +139,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: playMenuItems }}
           placement="bottom"
-          trigger={["hover"]}
+          trigger={["hover", "click"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
@@ -152,7 +152,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: studyMenuItems }}
           placement="bottom"
-          trigger={["hover"]}
+          trigger={["hover", "click"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
@@ -168,7 +168,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: moreMenuItems }}
           placement="bottom"
-          trigger={["hover"]}
+          trigger={["hover", "click"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }

--- a/liwords-ui/src/navigation/topbar.tsx
+++ b/liwords-ui/src/navigation/topbar.tsx
@@ -113,7 +113,11 @@ const TopMenu = React.memo((props: Props) => {
     {
       key: "blog",
       label: (
-        <a href="https://blog.woogles.io" target="_blank" rel="noopener noreferrer">
+        <a
+          href="https://blog.woogles.io"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Blog
         </a>
       ),

--- a/liwords-ui/src/navigation/topbar.tsx
+++ b/liwords-ui/src/navigation/topbar.tsx
@@ -105,14 +105,19 @@ const TopMenu = React.memo((props: Props) => {
     },
   ];
 
-  const watchMenuItems = [
+  const moreMenuItems = [
     {
       key: "broadcasts",
       label: <Link to="/broadcasts">Broadcasts</Link>,
     },
-  ];
-
-  const aboutMenuItems = [
+    {
+      key: "blog",
+      label: (
+        <a href="https://blog.woogles.io" target="_blank" rel="noopener noreferrer">
+          Blog
+        </a>
+      ),
+    },
     {
       key: "team",
       label: <Link to="/team">Meet the Woogles team</Link>,
@@ -130,7 +135,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: playMenuItems }}
           placement="bottom"
-          trigger={["click"]}
+          trigger={["hover"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
@@ -139,27 +144,11 @@ const TopMenu = React.memo((props: Props) => {
         </Dropdown>
       </div>
       <div>
-        <a href="/donate">Donate</a>
-      </div>
-      <div>
-        <Dropdown
-          overlayClassName="user-menu"
-          menu={{ items: watchMenuItems }}
-          placement="bottom"
-          trigger={["click"]}
-          getPopupContainer={() =>
-            document.getElementById("root") as HTMLElement
-          }
-        >
-          <p>Watch</p>
-        </Dropdown>
-      </div>
-      <div>
         <Dropdown
           overlayClassName="user-menu"
           menu={{ items: studyMenuItems }}
           placement="bottom"
-          trigger={["click"]}
+          trigger={["hover"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
@@ -168,19 +157,19 @@ const TopMenu = React.memo((props: Props) => {
         </Dropdown>
       </div>
       <div>
-        <a href="https://blog.woogles.io">Blog</a>
+        <a href="/donate">Donate</a>
       </div>
       <div className="top-header-left-frame-special-land">
         <Dropdown
           overlayClassName="user-menu"
-          menu={{ items: aboutMenuItems }}
+          menu={{ items: moreMenuItems }}
           placement="bottom"
-          trigger={["click"]}
+          trigger={["hover"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
         >
-          <p>About</p>
+          <p>More</p>
         </Dropdown>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Removes Watch, Blog, and About as separate top-level nav items
- Adds a **More** dropdown containing: Broadcasts, Blog, Meet the Woogles team, Terms of Service
- Switches all nav dropdowns (Play, Study, More) from click to **hover** trigger
- Nav order: Play · Study · Donate · More

## Screenshots

Before: Play · Donate · Watch · Study · Blog · About
After: Play · Study · Donate · More ▾

🤖 Generated with [Claude Code](https://claude.com/claude-code)