### PR TITLE
set HTTP IdleTimeout to 90s on all servers to prevent ALB 502s

### DIFF
--- a/cmd/liwords-api/main.go
+++ b/cmd/liwords-api/main.go
@@ -503,7 +503,8 @@ func main() {
 		Addr:         cfg.ListenAddr,
 		Handler:      router,
 		WriteTimeout: 120 * time.Second,
-		ReadTimeout:  10 * time.Second}
+		ReadTimeout:  10 * time.Second,
+		IdleTimeout:  90 * time.Second}
 
 	go pubsubBus.ProcessMessages(ctx)
 	go vdoWebhookService.Start(ctx)

--- a/cmd/socketsrv/main.go
+++ b/cmd/socketsrv/main.go
@@ -73,7 +73,8 @@ func main() {
 		Addr:         cfg.WebsocketAddress,
 		Handler:      router,
 		WriteTimeout: 10 * time.Second,
-		ReadTimeout:  10 * time.Second}
+		ReadTimeout:  10 * time.Second,
+		IdleTimeout:  90 * time.Second}
 
 	idleConnsClosed := make(chan struct{})
 	sig := make(chan os.Signal, 1)


### PR DESCRIPTION
Go's IdleTimeout defaults to ReadTimeout (10s) when unset. The ALB idle timeout is 60s. When Go closes an idle connection first, the ALB doesn't know and tries to reuse it — the resulting TCP RST produces a 502 for the user. Setting IdleTimeout > 60s ensures the ALB always closes first and never reuses a dead connection.