### PR TITLE
fix: discard partial game_turns rows for in-flight games at deploy time

### DIFF
--- a/pkg/stores/game/db.go
+++ b/pkg/stores/game/db.go
@@ -305,9 +305,16 @@ func (s *DBStore) shadowCompareTurns(
 	}
 
 	if len(turns) != wantEventCount {
+		if len(turns) < wantEventCount {
+			// In-flight at dual-write cutover — partial rows, tolerated temporarily.
+			log.Warn().Str("gameID", gameID).
+				Int("want", wantEventCount).Int("got", len(turns)).
+				Msg("shadow-turns-skip: in-flight at dual-write cutover")
+			return
+		}
 		log.Error().Str("gameID", gameID).
 			Int("want", wantEventCount).Int("got", len(turns)).
-			Msg("shadow-turns-mismatch: event count")
+			Msg("shadow-turns-mismatch: more rows than events")
 		return
 	}
 

--- a/pkg/stores/game/s3.go
+++ b/pkg/stores/game/s3.go
@@ -32,6 +32,7 @@ const (
 type archiveStore interface {
 	GetTurns(ctx context.Context, gameUUID string) ([]models.GetGameTurnsRow, error)
 	CommitArchival(ctx context.Context, gameUUID string, s3Key string) error
+	DeleteTurns(ctx context.Context, gameUUID string) error
 }
 
 // HistoryArchiver assembles a GameHistory from game_turns rows, uploads it to S3
@@ -61,6 +62,25 @@ func (h *HistoryArchiver) ArchiveAndCleanup(ctx context.Context, g *entity.Game)
 	if len(turns) == 0 {
 		l.Warn().Str("gameID", g.GameID()).Msg("archive-no-turns: predates dual-write, skipping")
 		return nil
+	}
+
+	expected := len(g.History().Events)
+	if len(turns) < expected {
+		// The game was in flight when dual-write was enabled: turns only cover
+		// the post-cutover events. Drop the partial rows so they don't accumulate;
+		// the game remains authoritative in the bytea history (like predates-dual-write
+		// games) and can be archived later by a bytea-fed backfill.
+		l.Warn().Str("gameID", g.GameID()).
+			Int("got", len(turns)).Int("want", expected).
+			Msg("archive-partial-turns: in-flight at dual-write cutover, discarding rows")
+		if err := h.store.DeleteTurns(ctx, g.GameID()); err != nil {
+			return fmt.Errorf("archive-discard-partial: %w", err)
+		}
+		return nil
+	}
+	if len(turns) > expected {
+		return fmt.Errorf("archive-extra-turns: have %d rows but history has %d events for %s",
+			len(turns), expected, g.GameID())
 	}
 
 	assembled, err := assembleHistory(g, turns)


### PR DESCRIPTION
When DUAL_WRITE_TURNS is enabled mid-deploy, games that were already in progress accumulate game_turns rows only for post-cutover events. At archive time, ArchiveAndCleanup now detects this case (0 < len(turns) < len(history.Events)), deletes the partial rows, and returns nil — identical to the existing "predates dual-write, skip" branch.

The game stays authoritative in its bytea history and becomes invisible to ListPendingArchival (which JOINs on game_turns), just like a true predates-dual-write game. A bytea-fed backfill can archive it later.

Also: shadow-compare now treats "fewer turns than events" as WARN instead of ERROR, since this is an expected transient state between deploy and the game ending.