### PR TITLE
fix: attach game ID to all game-error log sites

### DIFF
--- a/cmd/find-corrupted-games/main.go
+++ b/cmd/find-corrupted-games/main.go
@@ -1,0 +1,154 @@
+// find-corrupted-games scans active correspondence games and calls
+// NewFromHistory on each one, reporting any games where history replay fails.
+// These games cannot be loaded by the server and are effectively invisible
+// to players. Output: one line per corrupted game: uuid, error.
+//
+// Requires the same DB env vars as liwords-api: DB_CONN_DSN.
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/proto"
+
+	macondogame "github.com/domino14/macondo/game"
+	macondopb "github.com/domino14/macondo/gen/api/proto/macondo"
+	"github.com/woogles-io/liwords/pkg/config"
+	"github.com/woogles-io/liwords/pkg/stores/models"
+)
+
+func main() {
+	batchSize := flag.Int("batch-size", 200, "Number of rows per DB fetch")
+	workers := flag.Int("workers", 4, "Concurrent workers")
+	flag.Parse()
+
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg := &config.Config{}
+	cfg.Load(nil)
+
+	poolCfg, err := pgxpool.ParseConfig(cfg.DBConnUri)
+	if err != nil {
+		log.Fatal().Err(err).Msg("db-parse-config-failed")
+	}
+	poolCfg.MaxConns = int32(*workers) + 2
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("db-connect-failed")
+	}
+	defer pool.Close()
+
+	queries := models.New(pool)
+
+	var (
+		mu           sync.Mutex
+		totalScanned int64
+		corrupted    []string
+	)
+
+	sem := make(chan struct{}, *workers)
+	var wg sync.WaitGroup
+	afterUUID := ""
+
+	for {
+		if ctx.Err() != nil {
+			log.Info().Msg("interrupted")
+			break
+		}
+
+		rows, err := queries.ListActiveCorrespondenceForArchivalAudit(ctx, models.ListActiveCorrespondenceForArchivalAuditParams{
+			AfterUuid: pgtype.Text{String: afterUUID, Valid: true},
+			Lim:       int32(*batchSize),
+		})
+		if err != nil {
+			log.Fatal().Err(err).Str("cursor", afterUUID).Msg("db-list-failed")
+		}
+		if len(rows) == 0 {
+			break
+		}
+
+		for _, r := range rows {
+			row := r
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				hist := &macondopb.GameHistory{}
+				if err := proto.Unmarshal(row.History, hist); err != nil {
+					mu.Lock()
+					totalScanned++
+					log.Error().Err(err).Str("uuid", row.Uuid.String).Msg("unmarshal-failed")
+					corrupted = append(corrupted, row.Uuid.String+"\tunmarshal: "+err.Error())
+					mu.Unlock()
+					return
+				}
+
+				lexicon := hist.GetLexicon()
+				boardLayout := hist.GetBoardLayout()
+				letterDist := hist.GetLetterDistribution()
+				variant := hist.GetVariant()
+
+				if boardLayout == "" {
+					boardLayout = "CrosswordGame"
+				}
+				if letterDist == "" {
+					letterDist = "english"
+				}
+				if variant == "" {
+					variant = "classic"
+				}
+
+				rules, err := macondogame.NewBasicGameRules(
+					cfg.MacondoConfig(), lexicon, boardLayout,
+					letterDist, macondogame.CrossScoreOnly,
+					macondogame.Variant(variant))
+				if err != nil {
+					mu.Lock()
+					totalScanned++
+					log.Error().Err(err).Str("uuid", row.Uuid.String).Str("lexicon", lexicon).Msg("rules-failed")
+					corrupted = append(corrupted, row.Uuid.String+"\trules: "+err.Error())
+					mu.Unlock()
+					return
+				}
+
+				_, replayErr := macondogame.NewFromHistory(hist, rules, len(hist.Events))
+
+				mu.Lock()
+				totalScanned++
+				if replayErr != nil {
+					log.Error().Err(replayErr).Str("uuid", row.Uuid.String).Msg("corrupted-game")
+					corrupted = append(corrupted, row.Uuid.String+"\t"+replayErr.Error())
+				}
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		afterUUID = rows[len(rows)-1].Uuid.String
+	}
+
+	log.Info().
+		Int64("scanned", totalScanned).
+		Int("corrupted", len(corrupted)).
+		Msg("scan-complete")
+
+	for _, line := range corrupted {
+		os.Stdout.WriteString(line + "\n")
+	}
+}

--- a/cmd/find-pre-archival-games/main.go
+++ b/cmd/find-pre-archival-games/main.go
@@ -1,0 +1,201 @@
+// find-pre-archival-games identifies active correspondence games whose
+// game_turns row count is less than the number of events in their bytea history.
+// These games predate or crossed the dual-write cutover; when they finish,
+// ArchiveAndCleanup falls back to uploading the bytea history directly.
+//
+// Output: CSV to --csv-out (default stdout), one line per flagged game:
+//
+//	uuid,created_at,updated_at,turns_count,event_count,missing
+//
+// Requires the same DB env vars as liwords-api: DB_CONN_DSN.
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/proto"
+
+	macondopb "github.com/domino14/macondo/gen/api/proto/macondo"
+	"github.com/woogles-io/liwords/pkg/config"
+	"github.com/woogles-io/liwords/pkg/stores/models"
+)
+
+func main() {
+	batchSize := flag.Int("batch-size", 500, "Number of rows per DB fetch")
+	workers := flag.Int("workers", 8, "Concurrent unmarshal workers")
+	csvOut := flag.String("csv-out", "", "CSV output path (default: stdout)")
+	flag.Parse()
+
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg := &config.Config{}
+	cfg.Load(nil)
+
+	poolCfg, err := pgxpool.ParseConfig(cfg.DBConnUri)
+	if err != nil {
+		log.Fatal().Err(err).Msg("db-parse-config-failed")
+	}
+	poolCfg.MaxConns = int32(*workers) + 4
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		log.Fatal().Err(err).Msg("db-connect-failed")
+	}
+	defer pool.Close()
+
+	var out *os.File
+	if *csvOut == "" {
+		out = os.Stdout
+	} else {
+		out, err = os.Create(*csvOut)
+		if err != nil {
+			log.Fatal().Err(err).Str("path", *csvOut).Msg("csv-create-failed")
+		}
+		defer out.Close()
+	}
+
+	w := csv.NewWriter(out)
+	if err := w.Write([]string{"uuid", "created_at", "updated_at", "turns_count", "event_count", "missing"}); err != nil {
+		log.Fatal().Err(err).Msg("csv-header-failed")
+	}
+
+	queries := models.New(pool)
+
+	type result struct {
+		uuid       string
+		createdAt  time.Time
+		updatedAt  time.Time
+		turnsCount int
+		eventCount int
+	}
+
+	var (
+		mu          sync.Mutex
+		results     []result
+		totalScanned int64
+		zeroTurns   int64
+		partialTurns int64
+	)
+
+	sem := make(chan struct{}, *workers)
+	var wg sync.WaitGroup
+	afterUUID := ""
+
+	for {
+		if ctx.Err() != nil {
+			log.Info().Msg("find-pre-archival-games: interrupted")
+			break
+		}
+
+		rows, err := queries.ListActiveCorrespondenceForArchivalAudit(ctx, models.ListActiveCorrespondenceForArchivalAuditParams{
+			AfterUuid: pgtype.Text{String: afterUUID, Valid: true},
+			Lim:       int32(*batchSize),
+		})
+		if err != nil {
+			log.Fatal().Err(err).Str("cursor", afterUUID).Msg("db-list-failed")
+		}
+		if len(rows) == 0 {
+			break
+		}
+
+		for _, r := range rows {
+			row := r
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				hist := &macondopb.GameHistory{}
+				if err := proto.Unmarshal(row.History, hist); err != nil {
+					log.Error().Err(err).Str("uuid", row.Uuid.String).Msg("unmarshal-failed")
+					return
+				}
+				eventCount := len(hist.Events)
+				turnsCount := int(row.TurnsCount)
+
+				mu.Lock()
+				totalScanned++
+				if turnsCount < eventCount {
+					res := result{
+						uuid:       row.Uuid.String,
+						createdAt:  row.CreatedAt.Time,
+						updatedAt:  row.UpdatedAt.Time,
+						turnsCount: turnsCount,
+						eventCount: eventCount,
+					}
+					if turnsCount == 0 {
+						zeroTurns++
+					} else {
+						partialTurns++
+					}
+					results = append(results, res)
+				}
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		afterUUID = rows[len(rows)-1].Uuid.String
+	}
+
+	// Write CSV sorted by creation date (results are in UUID order; sort by createdAt).
+	for _, r := range results {
+		missing := r.eventCount - r.turnsCount
+		if err := w.Write([]string{
+			r.uuid,
+			r.createdAt.UTC().Format(time.RFC3339),
+			r.updatedAt.UTC().Format(time.RFC3339),
+			strconv.Itoa(r.turnsCount),
+			strconv.Itoa(r.eventCount),
+			strconv.Itoa(missing),
+		}); err != nil {
+			log.Error().Err(err).Str("uuid", r.uuid).Msg("csv-write-failed")
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		log.Error().Err(err).Msg("csv-flush-failed")
+	}
+
+	flagged := int64(len(results))
+	log.Info().
+		Int64("scanned", totalScanned).
+		Int64("flagged", flagged).
+		Int64("zero_turns", zeroTurns).
+		Int64("partial_turns", partialTurns).
+		Msg("find-pre-archival-games-done")
+
+	if flagged > 0 {
+		var oldestFlagged, newestFlagged time.Time
+		for _, r := range results {
+			if oldestFlagged.IsZero() || r.createdAt.Before(oldestFlagged) {
+				oldestFlagged = r.createdAt
+			}
+			if r.createdAt.After(newestFlagged) {
+				newestFlagged = r.createdAt
+			}
+		}
+		log.Info().
+			Time("oldest_flagged_created_at", oldestFlagged).
+			Time("newest_flagged_created_at", newestFlagged).
+			Msg("flagged-range")
+	}
+}
+

--- a/db/queries/games.sql
+++ b/db/queries/games.sql
@@ -361,3 +361,23 @@ WHERE history_s3_key IS NULL
 ORDER BY uuid
 LIMIT @lim;
 
+-- name: ListActiveCorrespondenceForArchivalAudit :many
+-- Active started correspondence games with their game_turns count, keyset-paginated.
+-- Used by cmd/find-pre-archival-games to identify games where game_turns rows are
+-- fewer than the bytea history's event count (they predate or crossed the dual-write
+-- cutover and will hit the bytea-fallback path in ArchiveAndCleanup when they end).
+SELECT g.uuid, g.created_at, g.updated_at, g.history,
+       COALESCE(gt.cnt, 0)::int AS turns_count
+FROM games g
+LEFT JOIN (
+    SELECT game_uuid, COUNT(*)::int AS cnt
+    FROM game_turns
+    GROUP BY game_uuid
+) gt ON gt.game_uuid = g.uuid
+WHERE g.game_end_reason = 0
+  AND (g.game_request->>'game_mode')::int = 1
+  AND g.started = true
+  AND g.uuid > @after_uuid
+ORDER BY g.uuid
+LIMIT @lim;
+

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -264,7 +264,7 @@ outerfor:
 			resp := &macondo.BotResponse{}
 			err := proto.Unmarshal(msg.Data, resp)
 			if err != nil {
-				log.Err(err).Msg("unmarshal-bot-response-error")
+				log.Err(err).Str("gid", gid).Msg("unmarshal-bot-response-error")
 				break
 			}
 			b.goHandleBotMove(ctx, resp, gid, msg.Reply)
@@ -453,6 +453,7 @@ func (b *Bus) handleNatsRequest(ctx context.Context, topic string,
 			gameID := strings.TrimPrefix(path, "/game/")
 			game, err := b.stores.GameStore.Get(ctx, gameID)
 			if err != nil {
+				log.Err(err).Str("gid", gameID).Msg("register-realm-get-game-failed")
 				return err
 			}
 			var foundPlayer bool

--- a/pkg/bus/gameplay.go
+++ b/pkg/bus/gameplay.go
@@ -125,7 +125,7 @@ func (b *Bus) instantiateAndStartGame(ctx context.Context, accUser *entity.User,
 
 	err = b.broadcastGameCreation(g, accUser, reqUser)
 	if err != nil {
-		log.Err(err).Msg("broadcasting-game-creation")
+		log.Err(err).Str("gid", g.GameID()).Msg("broadcasting-game-creation")
 	}
 
 	// Auto-start correspondence games immediately (skip ready flag)
@@ -202,23 +202,23 @@ func (b *Bus) goHandleBotMove(ctx context.Context, resp *macondo.BotResponse,
 
 			m, err := game.MoveFromEvent(r.Move, g.Alphabet(), g.Board())
 			if err != nil {
-				log.Err(err).Msg("move-from-event-error")
+				log.Err(err).Str("gid", gid).Msg("move-from-event-error")
 				return
 			}
 			err = gameplay.PlayMove(ctx, g, b.stores, userID, onTurn, timeRemaining, m)
 			if err != nil {
-				log.Err(err).Msg("bot-cant-move-play-error")
+				log.Err(err).Str("gid", gid).Msg("bot-cant-move-play-error")
 				return
 			}
 		case *macondopb.BotResponse_Error:
-			log.Error().Str("error", r.Error).Msg("bot-error")
+			log.Error().Str("gid", gid).Str("error", r.Error).Msg("bot-error")
 			return
 		}
 		// And save the game after playing the move. Note that PlayMove doesn't do
 		// this.
 		err = b.stores.GameStore.Set(ctx, g)
 		if err != nil {
-			log.Err(err).Msg("setting-game-after-bot-move")
+			log.Err(err).Str("gid", gid).Msg("setting-game-after-bot-move")
 		}
 	}()
 }
@@ -230,6 +230,7 @@ func (b *Bus) readyForGame(ctx context.Context, evt *pb.ReadyForGame, userID str
 
 	g, err := b.stores.GameStore.Get(ctx, evt.GameId)
 	if err != nil {
+		log.Err(err).Str("gid", evt.GameId).Msg("ready-for-game-get-failed")
 		return err
 	}
 	g.Lock()
@@ -448,7 +449,7 @@ func (b *Bus) readyForTournamentGame(ctx context.Context, evt *pb.ReadyForTourna
 
 	err = b.broadcastGameCreation(g, reqUser, users[otherUserIdx])
 	if err != nil {
-		log.Err(err).Msg("broadcasting-game-creation")
+		log.Err(err).Str("gid", g.GameID()).Msg("broadcasting-game-creation")
 	}
 
 	// redirect users to the right game
@@ -485,6 +486,7 @@ func (b *Bus) sendGameRefresher(ctx context.Context, gameID, connID, userID stri
 	// Get a game refresher event.
 	entGame, err := b.stores.GameStore.Get(ctx, string(gameID))
 	if err != nil {
+		log.Err(err).Str("gid", gameID).Msg("send-game-refresher-get-failed")
 		return err
 	}
 	entGame.RLock()
@@ -543,6 +545,7 @@ func (b *Bus) adjudicateGames(ctx context.Context, correspondenceOnly bool) erro
 		// These will likely be in the cache.
 		entGame, err := b.stores.GameStore.Get(ctx, g.GameId)
 		if err != nil {
+			log.Err(err).Str("gid", g.GameId).Msg("adjudicate-get-game-failed")
 			return err
 		}
 		entGame.RLock()
@@ -554,7 +557,7 @@ func (b *Bus) adjudicateGames(ctx context.Context, correspondenceOnly bool) erro
 		if started && timeRanOut {
 			log.Debug().Str("gid", g.GameId).Msg("adjudicating-time-ran-out")
 			err = gameplay.TimedOut(ctx, b.stores, entGame.Game.PlayerIDOnTurn(), g.GameId)
-			log.Err(err).Msg("adjudicating-after-gameplay-timed-out")
+			log.Err(err).Str("gid", g.GameId).Msg("adjudicating-after-gameplay-timed-out")
 		} else if !started && !entGame.IsCorrespondence() {
 			// Only real-time games can be "not started" - correspondence games
 			// are auto-started immediately when accepted, so they never enter this state.
@@ -575,7 +578,7 @@ func (b *Bus) adjudicateGames(ctx context.Context, correspondenceOnly bool) erro
 				b.stores.GameStore.LockGame(g.GameId)
 				entGame.Lock()
 				err = gameplay.AbortGame(ctx, b.stores, entGame, pb.GameEndReason_CANCELLED)
-				log.Err(err).Msg("adjudicating-after-abort-game")
+				log.Err(err).Str("gid", g.GameId).Msg("adjudicating-after-abort-game")
 				entGame.Unlock()
 				b.stores.GameStore.UnlockGame(g.GameId)
 				log.Debug().Str("gid", g.GameId).Msg("unlocking")
@@ -663,7 +666,7 @@ func (b *Bus) adjudicateCorrespondenceGames(ctx context.Context) error {
 		playerID := g.Quickdata.PlayerInfo[playerOnTurn].UserId
 
 		err = gameplay.TimedOut(ctx, b.stores, playerID, gameID)
-		log.Err(err).Msg("adjudicating-after-gameplay-timed-out")
+		log.Err(err).Str("gid", gameID).Msg("adjudicating-after-gameplay-timed-out")
 	}
 
 	log.Debug().Msg("exiting-correspondence-adjudication")

--- a/pkg/gameplay/end.go
+++ b/pkg/gameplay/end.go
@@ -223,12 +223,12 @@ func performEndgameDuties(ctx context.Context, g *entity.Game,
 	// Compute stats for the player and for the game.
 	variantKey, err := g.RatingKey()
 	if err != nil {
-		log.Err(err).Msg("getting variant key")
+		log.Err(err).Str("gid", g.GameID()).Msg("getting variant key")
 	} else {
 		gameStats, err := ComputeGameStats(ctx, g.History(), g.GameReq.GameRequest, variantKey,
 			evt, stores)
 		if err != nil {
-			log.Err(err).Msg("computing stats")
+			log.Err(err).Str("gid", g.GameID()).Msg("computing stats")
 		} else {
 			g.Stats = gameStats
 		}
@@ -248,14 +248,14 @@ func performEndgameDuties(ctx context.Context, g *entity.Game,
 	if g.TournamentData != nil && g.TournamentData.Id != "" {
 		err := tournament.HandleTournamentGameEnded(ctx, stores.TournamentStore, stores.UserStore, g, stores.Queries)
 		if err != nil {
-			log.Err(err).Msg("error-tourney-game-ended")
+			log.Err(err).Str("gid", g.GameID()).Msg("error-tourney-game-ended")
 		}
 	} else if g.GameReq.RatingMode == pb.RatingMode_RATED {
 		// Applies penalties to players who have misbehaved during the game
 		// Does not apply for tournament games
 		err = mod.Automod(ctx, stores.UserStore, stores.NotorietyStore, users[0], users[1], g)
 		if err != nil {
-			log.Err(err).Msg("automod-error")
+			log.Err(err).Str("gid", g.GameID()).Msg("automod-error")
 		}
 	}
 
@@ -286,7 +286,7 @@ func performEndgameDuties(ctx context.Context, g *entity.Game,
 		err = stores.LeagueStandingsUpdater.UpdateGameStandings(ctx, g)
 		if err != nil {
 			// Log error but don't fail - standings can be recalculated later
-			log.Err(err).Msg("failed-to-update-league-standings")
+			log.Err(err).Str("gid", g.GameID()).Msg("failed-to-update-league-standings")
 		}
 	}
 
@@ -296,7 +296,7 @@ func performEndgameDuties(ctx context.Context, g *entity.Game,
 		err = analysis.EnqueueGameForAnalysis(ctx, stores.Queries, g.GameID(), priority)
 		if err != nil {
 			// Log error but don't fail - analysis can be retried later
-			log.Err(err).Msg("failed-to-enqueue-game-for-analysis")
+			log.Err(err).Str("gid", g.GameID()).Msg("failed-to-enqueue-game-for-analysis")
 		}
 	}
 
@@ -474,7 +474,7 @@ func AbortGame(ctx context.Context, stores *stores.Stores,
 	if gameEndReason == pb.GameEndReason_ABORTED {
 		err = stores.GameStore.InsertGamePlayers(ctx, g)
 		if err != nil {
-			log.Err(err).Msg("failed to insert game_players entries for aborted game")
+			log.Err(err).Str("gid", g.GameID()).Msg("failed to insert game_players entries for aborted game")
 			// Don't fail the abort if game_players insert fails
 		}
 	}
@@ -514,7 +514,7 @@ func AbortGame(ctx context.Context, stores *stores.Stores,
 	// mode, we must allow the players to try to play again.
 	if g.TournamentData != nil && g.TournamentData.Id != "" {
 		err = redoCancelledGamePairings(ctx, stores.TournamentStore, g)
-		log.Err(err).Msg("redo-cancelled-game-pairings")
+		log.Err(err).Str("gid", g.GameID()).Msg("redo-cancelled-game-pairings")
 	}
 
 	return nil
@@ -549,7 +549,7 @@ func gameEndedEvent(ctx context.Context, g *entity.Game, userStore user.Store) *
 	if g.GameReq.RatingMode == pb.RatingMode_RATED {
 		ratings, err = Rate(ctx, scores, g, winner, userStore, now)
 		if err != nil {
-			log.Err(err).Msg("rating-error")
+			log.Err(err).Str("gid", g.GameID()).Msg("rating-error")
 		}
 	}
 	for u, rat := range ratings {

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -242,7 +242,7 @@ func StartGame(ctx context.Context, stores *stores.Stores, eventChan chan<- *ent
 	log.Debug().Msg("going-to-save")
 	// Save the game back to the store always.
 	if err := stores.GameStore.Set(ctx, entGame); err != nil {
-		log.Err(err).Msg("error-saving")
+		log.Err(err).Str("gid", entGame.GameID()).Msg("error-saving")
 		return err
 	}
 	log.Debug().Msg("saved-game-to-store")
@@ -480,7 +480,7 @@ func handleChallenge(ctx context.Context, entGame *entity.Game, stores *stores.S
 		// HandleEvent will skip the save for correspondence games to avoid double-saving.
 		if entGame.IsCorrespondence() {
 			if err := stores.GameStore.Set(ctx, entGame); err != nil {
-				log.Err(err).Msg("error-saving-before-bot-request")
+				log.Err(err).Str("gid", entGame.GameID()).Msg("error-saving-before-bot-request")
 				return err
 			}
 		}
@@ -603,7 +603,7 @@ func PlayMove(ctx context.Context,
 		// HandleEvent will skip the save for correspondence games to avoid double-saving.
 		if entGame.IsCorrespondence() {
 			if err := stores.GameStore.Set(ctx, entGame); err != nil {
-				log.Err(err).Msg("error-saving-before-bot-request")
+				log.Err(err).Str("gid", entGame.GameID()).Msg("error-saving-before-bot-request")
 				return err
 			}
 		}
@@ -624,6 +624,7 @@ func HandleEvent(ctx context.Context, stores *stores.Stores, userID string, cge 
 
 	entGame, err := stores.GameStore.Get(ctx, cge.GameId)
 	if err != nil {
+		log.Err(err).Str("gid", cge.GameId).Msg("handle-event-get-game-failed")
 		return nil, err
 	}
 	entGame.Lock()
@@ -761,6 +762,7 @@ func TimedOut(ctx context.Context, stores *stores.Stores, timedout string, gameI
 
 	entGame, err := stores.GameStore.Get(ctx, gameID)
 	if err != nil {
+		log.Err(err).Str("gid", gameID).Msg("timed-out-get-game-failed")
 		return err
 	}
 	entGame.Lock()
@@ -776,7 +778,7 @@ func TimedOut(ctx context.Context, stores *stores.Stores, timedout string, gameI
 		return errNotOnTurn
 	}
 	if !entGame.TimeRanOut(onTurn) {
-		log.Error().Int("TimeRemaining", entGame.TimeRemaining(onTurn)).
+		log.Error().Str("gid", gameID).Int("TimeRemaining", entGame.TimeRemaining(onTurn)).
 			Int("onturn", onTurn).Msg("time-didnt-run-out")
 		return errTimeDidntRunOut
 	}

--- a/pkg/gameplay/meta_events.go
+++ b/pkg/gameplay/meta_events.go
@@ -131,6 +131,7 @@ func HandleMetaEvent(ctx context.Context, evt *pb.GameMetaEvent, eventChan chan<
 
 	g, err := stores.GameStore.Get(ctx, evt.GameId)
 	if err != nil {
+		log.Err(err).Str("gid", evt.GameId).Msg("meta-event-get-game-failed")
 		return err
 	}
 

--- a/pkg/omgwords/service.go
+++ b/pkg/omgwords/service.go
@@ -232,7 +232,7 @@ func createAnnotatedGameDoc(
 		// the annotated game we just created. Not the best pattern, but
 		// we have different data stores.
 		if derr := metadataStore.DeleteAnnotatedGame(ctx, g.Uid); derr != nil {
-			log.Err(derr).Msg("deleting-annotated-game")
+			log.Err(derr).Str("gid", g.Uid).Msg("deleting-annotated-game")
 		}
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func createAnnotatedGameDoc(
 	// We should also send a new game event on the channel.
 	err = announceGameCreation(g, playersInfo, gameEventChan)
 	if err != nil {
-		log.Err(err).Msg("broadcasting-game-creation")
+		log.Err(err).Str("gid", g.Uid).Msg("broadcasting-game-creation")
 	}
 	return g, nil
 }

--- a/pkg/stores/game/db.go
+++ b/pkg/stores/game/db.go
@@ -105,7 +105,7 @@ func (s *DBStore) Get(ctx context.Context, id string) (*entity.Game, error) {
 	g, err := s.queries.GetGame(ctx, common.ToPGTypeText(id))
 	if err != nil {
 		span.RecordError(err)
-		log.Err(err).Msg("error-get-game")
+		log.Err(err).Str("gid", id).Msg("error-get-game")
 		return nil, err
 	}
 
@@ -243,6 +243,7 @@ func (s *DBStore) Get(ctx context.Context, id string) (*entity.Game, error) {
 	historySpan.End()
 	if err != nil {
 		span.RecordError(err)
+		log.Err(err).Str("gid", id).Msg("new-from-history-failed")
 		return nil, err
 	}
 	// XXX: We should probably move this to `NewFromHistory`:

--- a/pkg/stores/models/games.sql.go
+++ b/pkg/stores/models/games.sql.go
@@ -728,6 +728,66 @@ func (q *Queries) InsertGamePlayers(ctx context.Context, arg InsertGamePlayersPa
 	return err
 }
 
+const listActiveCorrespondenceForArchivalAudit = `-- name: ListActiveCorrespondenceForArchivalAudit :many
+SELECT g.uuid, g.created_at, g.updated_at, g.history,
+       COALESCE(gt.cnt, 0)::int AS turns_count
+FROM games g
+LEFT JOIN (
+    SELECT game_uuid, COUNT(*)::int AS cnt
+    FROM game_turns
+    GROUP BY game_uuid
+) gt ON gt.game_uuid = g.uuid
+WHERE g.game_end_reason = 0
+  AND (g.game_request->>'game_mode')::int = 1
+  AND g.started = true
+  AND g.uuid > $1
+ORDER BY g.uuid
+LIMIT $2
+`
+
+type ListActiveCorrespondenceForArchivalAuditParams struct {
+	AfterUuid pgtype.Text
+	Lim       int32
+}
+
+type ListActiveCorrespondenceForArchivalAuditRow struct {
+	Uuid       pgtype.Text
+	CreatedAt  pgtype.Timestamptz
+	UpdatedAt  pgtype.Timestamptz
+	History    []byte
+	TurnsCount int32
+}
+
+// Active started correspondence games with their game_turns count, keyset-paginated.
+// Used by cmd/find-pre-archival-games to identify games where game_turns rows are
+// fewer than the bytea history's event count (they predate or crossed the dual-write
+// cutover and will hit the bytea-fallback path in ArchiveAndCleanup when they end).
+func (q *Queries) ListActiveCorrespondenceForArchivalAudit(ctx context.Context, arg ListActiveCorrespondenceForArchivalAuditParams) ([]ListActiveCorrespondenceForArchivalAuditRow, error) {
+	rows, err := q.db.Query(ctx, listActiveCorrespondenceForArchivalAudit, arg.AfterUuid, arg.Lim)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveCorrespondenceForArchivalAuditRow
+	for rows.Next() {
+		var i ListActiveCorrespondenceForArchivalAuditRow
+		if err := rows.Scan(
+			&i.Uuid,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.History,
+			&i.TurnsCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listActiveCorrespondenceGames = `-- name: ListActiveCorrespondenceGames :many
 SELECT quickdata, uuid, started, tournament_data, game_request, player_on_turn, timers, type, updated_at, league_id, season_id, league_division_id
 FROM games


### PR DESCRIPTION
Every significant error log in the game path now carries Str("gid", <id>) so that the next corruption event (e.g. macondo "Unable to set rack") is immediately linkable to a game UUID in CloudWatch without a full DB scan.

Key sites:
- pkg/stores/game/db.go: NewFromHistory failure now logs new-from-history-failed with gid, linking it to macondo's bare "Unable to set rack" line above it
- pkg/gameplay/game.go, end.go, meta_events.go: all error/silent-propagation sites
- pkg/bus/gameplay.go, bus.go: goHandleBotMove, adjudicateGames, register-realm
- pkg/omgwords/service.go: annotated-game error sites

Also adds two diagnostic cmd/ tools from the corruption investigation:
- cmd/find-corrupted-games: scans active correspondence games for NewFromHistory failures
- cmd/find-pre-archival-games: identifies games missing game_turns rows vs bytea history