### PR TITLE
Two-column scorecard view + examination navigation

### DIFF
--- a/liwords-ui/src/boardwizard/editor.tsx
+++ b/liwords-ui/src/boardwizard/editor.tsx
@@ -511,7 +511,9 @@ export const BoardEditor = () => {
           <ScoreCard
             isExamining={true}
             events={examinableGameContext.turns}
+            allEvents={gameContext.turns}
             board={examinableGameContext.board}
+            allBoard={gameContext.board}
             playerMeta={gameInfo.players}
             poolFormat={poolFormat}
             showComments={true}

--- a/liwords-ui/src/boardwizard/editor.tsx
+++ b/liwords-ui/src/boardwizard/editor.tsx
@@ -113,10 +113,11 @@ export const BoardEditor = () => {
     gameContext.gameID,
   ]);
 
-  // Convert GameEvents to Turn objects
+  // Convert GameEvents to Turn objects — use full game context, not examinable
+  // (examinableGameContext.turns is truncated during examination, which breaks comment indexing)
   const turns = useMemo(
-    () => gameEventsToTurns(examinableGameContext.turns),
-    [examinableGameContext.turns],
+    () => gameEventsToTurns(gameContext.turns),
+    [gameContext.turns],
   );
 
   // Comments drawer handlers

--- a/liwords-ui/src/gameroom/TurnCommentPreview.tsx
+++ b/liwords-ui/src/gameroom/TurnCommentPreview.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MessageOutlined } from "@ant-design/icons";
+import { EditOutlined, MessageOutlined } from "@ant-design/icons";
 import { GameComment } from "../gen/api/proto/comments_service/comments_service_pb";
 
 type Props = {
@@ -19,7 +19,7 @@ export const TurnCommentPreview: React.FC<Props> = ({
         className={`turn-comment-preview no-comments ${className}`}
         onClick={onExpandComments}
       >
-        <MessageOutlined className="comment-icon-subtle" />
+        <EditOutlined className="comment-icon-subtle" />
       </div>
     );
   }
@@ -30,7 +30,6 @@ export const TurnCommentPreview: React.FC<Props> = ({
       onClick={onExpandComments}
     >
       <MessageOutlined className="comment-icon" />
-      <span className="comment-count">{comments.length}</span>
     </div>
   );
 };

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -6,7 +6,8 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Card, Tooltip } from "antd";
+import { Card, Dropdown, Tooltip } from "antd";
+import { Link } from "react-router";
 import {
   GameEvent,
   GameEvent_Type,
@@ -30,7 +31,10 @@ import { Analyzer } from "./analyzer";
 import { HeartFilled, HourglassOutlined } from "@ant-design/icons";
 import { PlayerInfo } from "../gen/api/proto/ipc/omgwords_pb";
 import { GameComment } from "../gen/api/proto/comments_service/comments_service_pb";
-import { useGameContextStoreContext } from "../store/store";
+import {
+  useExamineStoreContext,
+  useGameContextStoreContext,
+} from "../store/store";
 import { TurnCommentPreview } from "./TurnCommentPreview";
 import {
   Alphabet,
@@ -44,6 +48,8 @@ const { screenSizeDesktop, screenSizeLaptop, screenSizeTablet } = variables;
 type Props = {
   isExamining?: boolean;
   events: Array<GameEvent>;
+  allEvents?: Array<GameEvent>; // full game events, used for two-col view in examination mode
+  allBoard?: Board; // full final board, used for two-col view in examination mode
   board: Board;
   poolFormat: PoolFormatType;
   playerMeta: Array<PlayerInfo>;
@@ -382,15 +388,109 @@ const ScorecardTurn = (props: turnProps) => {
   );
 };
 
+type ScorecardViewType = "single" | "two-col";
+const SCORECARD_VIEW_KEY = "scorecardView";
+
+type TwoColTurnProps = {
+  turn: Turn;
+  board: Board;
+  alphabet: Alphabet;
+  onSeek?: () => void;
+  isSelected?: boolean;
+  showComments?: boolean;
+  comments?: Array<GameComment>;
+  onOpenCommentsDrawer?: (turnIndex: number) => void;
+  turnIndex?: number;
+};
+
+const TwoColTurn = React.memo((props: TwoColTurnProps) => {
+  const { turn, board, alphabet, onSeek, isSelected } = props;
+  const evt = turn.events[0];
+
+  let coords = evt.position || "";
+  let play: React.ReactNode = displaySummary(evt, board, alphabet);
+  let score = `${evt.score}`;
+  let cumulative = evt.cumulative;
+
+  // Handle multi-event turns (challenges, etc.)
+  if (turn.events.length > 1) {
+    const evt1 = turn.events[1];
+    if (evt1.type === GameEvent_Type.PHONY_TILES_RETURNED) {
+      score = "0";
+      cumulative = evt1.cumulative;
+      play = <span className="challenge successful">Challenge!</span>;
+    } else {
+      for (let i = 1; i < turn.events.length; i++) {
+        switch (turn.events[i].type) {
+          case GameEvent_Type.CHALLENGE_BONUS:
+            score = `${score}+${turn.events[i].bonus}`;
+            break;
+          case GameEvent_Type.END_RACK_PTS:
+            score = `${score}+${turn.events[i].endRackPoints}`;
+            break;
+        }
+        cumulative = turn.events[i].cumulative;
+      }
+    }
+  }
+
+  const rack = sortStringRack(
+    turn.events.length > 1 &&
+      turn.events[1].type === GameEvent_Type.PHONY_TILES_RETURNED
+      ? ""
+      : evt.rack,
+    alphabet,
+  );
+
+  return (
+    <div
+      className={`two-col-turn${isSelected ? " two-col-turn-selected" : ""}`}
+    >
+      <div className="two-col-coord">{coords}</div>
+      <div
+        className={`two-col-word${onSeek ? " two-col-word-seekable" : ""}`}
+        onClick={onSeek}
+      >
+        {play}
+      </div>
+      <div className="two-col-scores">
+        <div className="two-col-score">{score}</div>
+        <div className="two-col-cumulative">{cumulative}</div>
+      </div>
+      <div className="two-col-comment-spot">
+        {props.showComments && (
+          <TurnCommentPreview
+            comments={props.comments ?? []}
+            onExpandComments={() =>
+              props.onOpenCommentsDrawer?.(props.turnIndex ?? 0)
+            }
+            className="two-col-bubble"
+          />
+        )}
+      </div>
+      <div className="two-col-rack">{rack}</div>
+    </div>
+  );
+});
+
 export const ScoreCard = React.memo((props: Props) => {
   const el = useRef<HTMLDivElement>(null);
   const [cardHeight, setCardHeight] = useState(0);
   const [flipHidden, setFlipHidden] = useState(true);
   const [flipEnabled, setEnableFlip] = useState(isTablet());
+  const [scorecardView, setScorecardView] = useState<ScorecardViewType>(
+    () =>
+      (localStorage?.getItem(SCORECARD_VIEW_KEY) as ScorecardViewType) ||
+      "single",
+  );
   const notepadHasContent = useNotepadHasContent();
   // Autoscroll code removed - comments now use drawer
 
   const turns = useMemo(() => gameEventsToTurns(props.events), [props.events]);
+  const allTurns = useMemo(
+    () => (props.allEvents ? gameEventsToTurns(props.allEvents) : turns),
+    [props.allEvents, turns],
+  );
 
   // Calculate time bank history for all events
   const timeBankHistory = useMemo(() => {
@@ -407,13 +507,13 @@ export const ScoreCard = React.memo((props: Props) => {
   // Scroll to bottom when turns change (after DOM updates)
   useEffect(() => {
     const currentEl = el.current;
-    if (currentEl && flipHidden) {
+    if (currentEl && flipHidden && scorecardView !== "two-col") {
       // Use requestAnimationFrame to ensure DOM has updated
       requestAnimationFrame(() => {
         currentEl.scrollTop = currentEl.scrollHeight;
       });
     }
-  }, [turns, flipHidden]);
+  }, [turns, flipHidden, scorecardView]);
 
   const toggleFlipVisibility = useCallback(() => {
     setFlipHidden((x) => !x);
@@ -427,7 +527,9 @@ export const ScoreCard = React.memo((props: Props) => {
       setFlipHidden(true);
     }
     if (currentEl) {
-      currentEl.scrollTop = currentEl.scrollHeight || 0;
+      if (scorecardView !== "two-col") {
+        currentEl.scrollTop = currentEl.scrollHeight || 0;
+      }
       const boardHeight =
         document.getElementById("board-container")?.clientHeight;
       const poolTop = document.getElementById("pool")?.clientHeight || 0;
@@ -456,7 +558,7 @@ export const ScoreCard = React.memo((props: Props) => {
         setCardHeight(0);
       }
     }
-  }, [props.hideExtraInteractions]);
+  }, [props.hideExtraInteractions, scorecardView]);
   useEffect(() => {
     resizeListener();
   }, [props.events, props.poolFormat, resizeListener]);
@@ -512,65 +614,215 @@ export const ScoreCard = React.memo((props: Props) => {
   }
   let contents = null;
   const { gameContext } = useGameContextStoreContext();
+  const { handleExamineGoTo, examinedTurn } = useExamineStoreContext();
+
+  const viewMenuItems = [
+    { label: "One column", key: "single" },
+    { label: "Two columns", key: "two-col" },
+  ];
+
+  const viewDropdown = (
+    <Dropdown
+      menu={{
+        items: viewMenuItems,
+        onClick: ({ key }) => {
+          localStorage?.setItem(SCORECARD_VIEW_KEY, key);
+          setScorecardView(key as ScorecardViewType);
+        },
+      }}
+      trigger={["click"]}
+      placement="bottomRight"
+      overlayClassName="format-dropdown"
+    >
+      <Link to="/" onClick={(e) => e.preventDefault()}>
+        Rearrange
+      </Link>
+    </Dropdown>
+  );
+
+  // Two-col player header (rendered outside the scroll container)
+  let twoColHeader: React.ReactNode = null;
+  if (flipHidden && scorecardView === "two-col") {
+    const firstPlayerIdx =
+      allTurns.length > 0 ? allTurns[0].events[0].playerIndex : 0;
+    const leftPlayer = props.playerMeta[firstPlayerIdx];
+    const rightPlayer = props.playerMeta[1 - firstPlayerIdx];
+    twoColHeader = (
+      <div className="two-col-header">
+        <div className="two-col-player-name">{leftPlayer?.nickname || ""}</div>
+        <div className="two-col-player-name">{rightPlayer?.nickname || ""}</div>
+      </div>
+    );
+  }
 
   if (flipHidden) {
-    const turnDisplay = (t: Turn, idx: number) => {
-      if (t.events.length === 0) {
-        return null;
+    if (scorecardView === "two-col") {
+      // Determine which player went first (left column)
+      const firstPlayerIdx =
+        allTurns.length > 0 ? allTurns[0].events[0].playerIndex : 0;
+
+      // Group turns into pairs: [leftTurn, rightTurn]
+      // turns alternate players, starting with firstPlayerIdx
+      const pairs: Array<
+        [{ turn: Turn; idx: number } | null, { turn: Turn; idx: number } | null]
+      > = [];
+      let i = 0;
+      while (i < allTurns.length) {
+        const t = allTurns[i];
+        const tPlayerIdx = t.events[0].playerIndex;
+        if (tPlayerIdx === firstPlayerIdx) {
+          const hasNext =
+            i + 1 < allTurns.length &&
+            allTurns[i + 1].events[0].playerIndex !== firstPlayerIdx;
+          pairs.push([
+            { turn: t, idx: i },
+            hasNext ? { turn: allTurns[i + 1], idx: i + 1 } : null,
+          ]);
+          i += hasNext ? 2 : 1;
+        } else {
+          pairs.push([null, { turn: t, idx: i }]);
+          i += 1;
+        }
       }
-      // for each turn, show only the relevant comments - comments for
-      // event indexes encompassed by those turns.
 
-      // Get time bank state for this turn's first event
-      const eventIdx = t.firstEvtIdx;
-      const timeBankState = timeBankHistory?.get(eventIdx);
-
-      return (
-        <ScorecardTurn
-          turn={t}
-          board={props.board}
-          key={`t_${idx + 0}`}
-          playerMeta={props.playerMeta}
-          showComments={props.showComments ?? false}
-          comments={
-            props.comments
-              ? props.comments.filter(
-                  (c) =>
-                    c.eventNumber >= t.firstEvtIdx &&
-                    c.eventNumber < t.firstEvtIdx + t.events.length,
-                )
-              : []
-          }
-          alphabet={gameContext.alphabet}
-          turnIndex={idx}
-          onOpenCommentsDrawer={props.onOpenCommentsDrawer}
-          isCorrespondence={props.isCorrespondence}
-          timeBankP0={timeBankState?.p0TimeBank}
-          timeBankP1={timeBankState?.p1TimeBank}
-          eventIndex={eventIdx}
-        />
+      const firstPlayerForOpening = props.playerMeta[firstPlayerIdx];
+      contents = (
+        <>
+          <div
+            className={`two-col-scorecard${allTurns.length === 0 ? " two-col-scorecard-empty" : ""}`}
+          >
+            {allTurns.length === 0 && (
+              <div className="two-col-opening-state">
+                {firstPlayerForOpening?.nickname || "Player 1"} is first
+              </div>
+            )}
+            {pairs.map(([left, right], pairIdx) => (
+              <div className="two-col-row" key={pairIdx}>
+                <div className="two-col-col">
+                  {left ? (
+                    <TwoColTurn
+                      turn={left.turn}
+                      board={props.allBoard ?? props.board}
+                      alphabet={gameContext.alphabet}
+                      onSeek={
+                        props.isExamining
+                          ? () => handleExamineGoTo(left.idx + 1)
+                          : undefined
+                      }
+                      isSelected={
+                        props.isExamining && examinedTurn === left.idx + 1
+                      }
+                      showComments={props.showComments}
+                      comments={
+                        props.comments?.filter(
+                          (c) =>
+                            c.eventNumber >= left.turn.firstEvtIdx &&
+                            c.eventNumber <
+                              left.turn.firstEvtIdx + left.turn.events.length,
+                        ) ?? []
+                      }
+                      onOpenCommentsDrawer={props.onOpenCommentsDrawer}
+                      turnIndex={left.idx}
+                    />
+                  ) : (
+                    <div className="two-col-turn two-col-turn-empty" />
+                  )}
+                </div>
+                <div className="two-col-col">
+                  {right ? (
+                    <TwoColTurn
+                      turn={right.turn}
+                      board={props.allBoard ?? props.board}
+                      alphabet={gameContext.alphabet}
+                      onSeek={
+                        props.isExamining
+                          ? () => handleExamineGoTo(right.idx + 1)
+                          : undefined
+                      }
+                      isSelected={
+                        props.isExamining && examinedTurn === right.idx + 1
+                      }
+                      showComments={props.showComments}
+                      comments={
+                        props.comments?.filter(
+                          (c) =>
+                            c.eventNumber >= right.turn.firstEvtIdx &&
+                            c.eventNumber <
+                              right.turn.firstEvtIdx + right.turn.events.length,
+                        ) ?? []
+                      }
+                      onOpenCommentsDrawer={props.onOpenCommentsDrawer}
+                      turnIndex={right.idx}
+                    />
+                  ) : (
+                    <div className="two-col-turn two-col-turn-empty" />
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+          {props.gameEpilog}
+        </>
       );
-    };
-    contents = (
-      <>
-        {turns.map(turnDisplay)}
-        {props.gameEpilog}
-      </>
-    );
+    } else {
+      const turnDisplay = (t: Turn, idx: number) => {
+        if (t.events.length === 0) {
+          return null;
+        }
+        const eventIdx = t.firstEvtIdx;
+        const timeBankState = timeBankHistory?.get(eventIdx);
+
+        return (
+          <ScorecardTurn
+            turn={t}
+            board={props.board}
+            key={`t_${idx + 0}`}
+            playerMeta={props.playerMeta}
+            showComments={props.showComments ?? false}
+            comments={
+              props.comments
+                ? props.comments.filter(
+                    (c) =>
+                      c.eventNumber >= t.firstEvtIdx &&
+                      c.eventNumber < t.firstEvtIdx + t.events.length,
+                  )
+                : []
+            }
+            alphabet={gameContext.alphabet}
+            turnIndex={idx}
+            onOpenCommentsDrawer={props.onOpenCommentsDrawer}
+            isCorrespondence={props.isCorrespondence}
+            timeBankP0={timeBankState?.p0TimeBank}
+            timeBankP1={timeBankState?.p1TimeBank}
+            eventIndex={eventIdx}
+          />
+        );
+      };
+      contents = (
+        <>
+          {turns.map(turnDisplay)}
+          {props.gameEpilog}
+        </>
+      );
+    }
   }
 
   return (
     <Card
-      className={`score-card${flipHidden ? "" : " flipped"}`}
+      className={`score-card${flipHidden ? "" : " flipped"}${scorecardView === "two-col" ? " two-col-active" : ""}`}
       title={title}
       extra={
-        isTablet() ? (
-          <button className="link" onClick={toggleFlipVisibility}>
-            {extra}
-          </button>
-        ) : null
+        <div className="score-card-extra">
+          {viewDropdown}
+          {isTablet() && extra ? (
+            <button className="link" onClick={toggleFlipVisibility}>
+              {extra}
+            </button>
+          ) : null}
+        </div>
       }
     >
+      {twoColHeader}
       <div ref={el} style={cardStyle}>
         {props.isExamining ? (
           <Analyzer style={analyzerStyle} />

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -83,6 +83,8 @@ type turnProps = {
   timeBankP0?: number;
   timeBankP1?: number;
   eventIndex: number; // Index in the full events array (not turn index)
+  onSeek?: () => void;
+  isSelected?: boolean;
 };
 
 type MoveEntityObj = {
@@ -315,15 +317,17 @@ const ScorecardTurn = (props: turnProps) => {
     scoreChange = `${memoizedTurn.oldScore} +${memoizedTurn.score}`;
   }
 
-  const divProps: {
-    className: string;
-  } = {
-    className: `turn${memoizedTurn.isBingo ? " bingo" : ""}`,
-  };
+  const divClassName = [
+    "turn",
+    memoizedTurn.isBingo ? "bingo" : "",
+    props.isSelected ? "turn-selected" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <>
-      <div {...divProps}>
+      <div className={divClassName}>
         <PlayerAvatar player={memoizedTurn.player} withTooltip />
         <div
           className={`coords-time${props.isCorrespondence ? " correspondence" : ""}`}
@@ -341,7 +345,10 @@ const ScorecardTurn = (props: turnProps) => {
           </p>
         </div>
         <div className="play">
-          <p className="main-word">
+          <p
+            className={`main-word${props.onSeek ? " main-word-seekable" : ""}`}
+            onClick={props.onSeek}
+          >
             {memoizedTurn.play}
             {memoizedTurn.isBingo && <HeartFilled />}
           </p>
@@ -507,13 +514,18 @@ export const ScoreCard = React.memo((props: Props) => {
   // Scroll to bottom when turns change (after DOM updates)
   useEffect(() => {
     const currentEl = el.current;
-    if (currentEl && flipHidden && scorecardView !== "two-col") {
+    if (
+      currentEl &&
+      flipHidden &&
+      scorecardView !== "two-col" &&
+      !props.isExamining
+    ) {
       // Use requestAnimationFrame to ensure DOM has updated
       requestAnimationFrame(() => {
         currentEl.scrollTop = currentEl.scrollHeight;
       });
     }
-  }, [turns, flipHidden, scorecardView]);
+  }, [allTurns, flipHidden, scorecardView, props.isExamining]);
 
   const toggleFlipVisibility = useCallback(() => {
     setFlipHidden((x) => !x);
@@ -527,7 +539,7 @@ export const ScoreCard = React.memo((props: Props) => {
       setFlipHidden(true);
     }
     if (currentEl) {
-      if (scorecardView !== "two-col") {
+      if (scorecardView !== "two-col" && !props.isExamining) {
         currentEl.scrollTop = currentEl.scrollHeight || 0;
       }
       const boardHeight =
@@ -558,7 +570,7 @@ export const ScoreCard = React.memo((props: Props) => {
         setCardHeight(0);
       }
     }
-  }, [props.hideExtraInteractions, scorecardView]);
+  }, [props.hideExtraInteractions, scorecardView, props.isExamining]);
   useEffect(() => {
     resizeListener();
   }, [props.events, props.poolFormat, resizeListener]);
@@ -706,11 +718,12 @@ export const ScoreCard = React.memo((props: Props) => {
                       alphabet={gameContext.alphabet}
                       onSeek={
                         props.isExamining
-                          ? () => handleExamineGoTo(left.idx + 1)
+                          ? () => handleExamineGoTo(left.turn.firstEvtIdx)
                           : undefined
                       }
                       isSelected={
-                        props.isExamining && examinedTurn === left.idx + 1
+                        props.isExamining &&
+                        examinedTurn === left.turn.firstEvtIdx
                       }
                       showComments={props.showComments}
                       comments={
@@ -736,11 +749,12 @@ export const ScoreCard = React.memo((props: Props) => {
                       alphabet={gameContext.alphabet}
                       onSeek={
                         props.isExamining
-                          ? () => handleExamineGoTo(right.idx + 1)
+                          ? () => handleExamineGoTo(right.turn.firstEvtIdx)
                           : undefined
                       }
                       isSelected={
-                        props.isExamining && examinedTurn === right.idx + 1
+                        props.isExamining &&
+                        examinedTurn === right.turn.firstEvtIdx
                       }
                       showComments={props.showComments}
                       comments={
@@ -775,7 +789,7 @@ export const ScoreCard = React.memo((props: Props) => {
         return (
           <ScorecardTurn
             turn={t}
-            board={props.board}
+            board={props.allBoard ?? props.board}
             key={`t_${idx + 0}`}
             playerMeta={props.playerMeta}
             showComments={props.showComments ?? false}
@@ -795,12 +809,18 @@ export const ScoreCard = React.memo((props: Props) => {
             timeBankP0={timeBankState?.p0TimeBank}
             timeBankP1={timeBankState?.p1TimeBank}
             eventIndex={eventIdx}
+            onSeek={
+              props.isExamining
+                ? () => handleExamineGoTo(t.firstEvtIdx)
+                : undefined
+            }
+            isSelected={props.isExamining && examinedTurn === t.firstEvtIdx}
           />
         );
       };
       contents = (
         <>
-          {turns.map(turnDisplay)}
+          {allTurns.map(turnDisplay)}
           {props.gameEpilog}
         </>
       );

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -407,7 +407,7 @@ const TwoColTurn = React.memo((props: TwoColTurnProps) => {
   const { turn, board, alphabet, onSeek, isSelected } = props;
   const evt = turn.events[0];
 
-  let coords = evt.position || "";
+  const coords = evt.position || "";
   let play: React.ReactNode = displaySummary(evt, board, alphabet);
   let score = `${evt.score}`;
   let cumulative = evt.cumulative;

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -2034,7 +2034,7 @@ p.rune {
   .ant-card-body {
     padding: 0;
 
-    & > div {
+    & > div:not(.two-col-header) {
       min-height: 300px;
       max-height: 300px;
       padding: 8px 0px 16px;
@@ -2367,7 +2367,7 @@ p.rune {
       }
     }
 
-    &.no-comments:not(.inline-comment-bubble) {
+    &.no-comments:not(.inline-comment-bubble):not(.two-col-bubble) {
       @include colorModed() {
         color: m($gray-medium);
         background-color: transparent;
@@ -2387,38 +2387,209 @@ p.rune {
     }
 
     &.has-comments {
-      // Use proper color variables - different ones for light vs dark mode
-      .mode--default & {
-        background-color: map.get(
-          map.get($modes, default),
-          color-primary-dark
-        ); // #11659e in light mode
-        color: white;
-      }
-
-      .mode--dark & {
-        background-color: map.get(
-          map.get($modes, dark),
-          color-primary-middle
-        ); // #2786cb in dark mode
-        color: white;
-      }
-
-      &:hover {
-        @include colorModed() {
-          background-color: m($primary-dark);
-        }
+      @include colorModed() {
+        color: m($primary-dark);
+        background: transparent;
+        border: none;
       }
 
       .comment-icon {
         font-size: 11px;
       }
+    }
+  }
 
-      .comment-count {
-        font-weight: 600;
-        min-width: 12px;
-        text-align: center;
-        font-size: 10px;
+  &.two-col-active {
+    .ant-card-body > div:not(.two-col-header) {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  .score-card-extra {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  // Two-column scorecard view
+  .two-col-scorecard {
+    @include type-monospace;
+    font-size: 13px;
+    position: relative;
+
+    @include colorModed() {
+      color: m($gray-extreme);
+    }
+
+    &:not(.two-col-scorecard-empty)::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      width: 1px;
+      @include colorModed() {
+        background-color: m($gray-subtle);
+      }
+    }
+
+    .two-col-opening-state {
+      padding: 16px 16px;
+      font-weight: 400;
+    }
+  }
+
+  .two-col-header {
+    display: flex;
+    padding: 8px 0;
+
+    @include colorModed() {
+      border-bottom: 1px solid m($gray-subtle);
+      color: m($gray-extreme);
+    }
+
+    .two-col-player-name {
+      flex: 1;
+      min-width: 0;
+      padding-left: 16px;
+      @include type-default;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: normal;
+      letter-spacing: 0;
+      text-transform: none;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .two-col-row {
+    display: flex;
+
+    @include colorModed() {
+      border-bottom: 1px solid m($gray-subtle);
+    }
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  .two-col-col {
+    flex: 1;
+    min-width: 0;
+
+    &:first-child {
+      border-right: none;
+    }
+  }
+
+  .two-col-turn {
+    display: grid;
+    grid-template-columns: 36px 1fr auto;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+      "coord word scores"
+      "comment rack scores";
+    padding: 8px 16px;
+    column-gap: 4px;
+    min-height: 38px;
+
+    &.two-col-turn-empty {
+      min-height: 38px;
+    }
+
+    &.two-col-turn-selected {
+      @include colorModed() {
+        background: m($primary-light);
+      }
+    }
+
+    .two-col-coord {
+      grid-area: coord;
+      font-weight: 800;
+      line-height: 1.2em;
+    }
+
+    .two-col-word {
+      grid-area: word;
+      font-weight: 800;
+      line-height: 1.2em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+
+      &.two-col-word-seekable {
+        cursor: pointer;
+        @include colorModed() {
+          color: m($primary-dark);
+        }
+      }
+
+      .challenge.successful {
+        @include colorModed() {
+          color: m($timer-out-dark);
+        }
+      }
+
+      .challenge.unsuccessful {
+        @include colorModed() {
+          color: m($timer-dark);
+        }
+      }
+
+      .pass,
+      .exchanged,
+      .time-penalty {
+        @include colorModed() {
+          color: m($timer-out-dark);
+        }
+      }
+    }
+
+    .two-col-comment-spot {
+      grid-area: comment;
+      display: flex;
+      align-items: center;
+    }
+
+    .two-col-rack {
+      grid-area: rack;
+      line-height: 1.2em;
+      min-width: 0;
+    }
+
+    .two-col-scores {
+      grid-area: scores;
+      text-align: right;
+      min-width: 38px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+
+      .two-col-score {
+        line-height: 1.2em;
+      }
+
+      .two-col-cumulative {
+        font-weight: 800;
+        line-height: 1.2em;
+      }
+    }
+
+    .two-col-bubble {
+      padding: 0;
+      border-radius: 0;
+
+      &.no-comments {
+        @include colorModed() {
+          color: m($primary-dark);
+          background: transparent;
+          border: none;
+        }
       }
     }
   }
@@ -2928,7 +3099,7 @@ p.rune {
 
   .score-card {
     .ant-card-body {
-      & > div {
+      & > div:not(.two-col-header) {
         max-height: 140px;
         min-height: 140px;
       }
@@ -3205,7 +3376,7 @@ p.rune {
     .ant-card-body {
       padding: 0;
 
-      & > div {
+      & > div:not(.two-col-header) {
         min-height: 110px;
         max-height: 110px;
       }
@@ -3286,7 +3457,7 @@ p.rune {
     }
 
     .ant-card-body {
-      & > div {
+      & > div:not(.two-col-header) {
         max-height: 152px;
         min-height: 152px;
       }
@@ -3305,7 +3476,7 @@ p.rune {
 
   .score-card {
     .ant-card-body {
-      & > div {
+      & > div:not(.two-col-header) {
         max-height: 241px;
         min-height: 241px;
       }

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -2066,7 +2066,7 @@ p.rune {
       color: m($gray-extreme);
     }
 
-    &:hover {
+    &.turn-selected {
       @include colorModed() {
         background: m($primary-light);
       }
@@ -2080,12 +2080,6 @@ p.rune {
         @include colorModed() {
           color: m($timer-out-dark);
         }
-      }
-    }
-
-    &:hover {
-      @include colorModed() {
-        background: m($primary-light);
       }
     }
 
@@ -2106,6 +2100,13 @@ p.rune {
 
       @include colorModed() {
         color: m($gray-extreme);
+      }
+
+      &.main-word-seekable {
+        cursor: pointer;
+        @include colorModed() {
+          color: m($primary-dark);
+        }
       }
     }
 
@@ -2354,7 +2355,7 @@ p.rune {
 
       &.no-comments {
         @include colorModed() {
-          color: m($gray-medium);
+          color: m($primary-dark);
           background-color: transparent;
           border: none; // Remove outline
         }

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -1387,6 +1387,8 @@ export const Table = React.memo((props: Props) => {
           <ScoreCard
             isExamining={isExamining}
             events={examinableGameContext.turns}
+            allEvents={gameContext.turns}
+            allBoard={gameContext.board}
             board={examinableGameContext.board}
             playerMeta={gameInfo.players}
             poolFormat={poolFormat}

--- a/liwords-ui/src/navigation/topbar.scss
+++ b/liwords-ui/src/navigation/topbar.scss
@@ -35,6 +35,9 @@ body {
   }
   .user-info {
     white-space: nowrap;
+    min-width: 200px;
+    display: flex;
+    justify-content: flex-end;
 
     button.link {
       font-weight: 900;
@@ -47,7 +50,7 @@ body {
 }
 
 .top-header-menu {
-  width: 100%;
+  flex: 1;
   display: flex;
   margin: 0 auto;
   padding-bottom: 0;
@@ -99,6 +102,7 @@ body {
   display: flex;
   /* Inside Auto Layout */
   flex: none;
+  min-width: 200px;
   align-self: center;
   margin: 0;
   .site-icon-rect {


### PR DESCRIPTION
## Summary

- **Two-column scorecard view** — side-by-side layout with player names header, Courier Prime monospace, CSS grid alignment. Toggled via "Rearrange" dropdown; preference saved to localStorage.
- **Examination navigation (both views)** — in examine/annotate mode, the play word turns blue and is clickable. Clicking seeks to that turn's game state (correct rack shown). Selected turn gets a `$primary-light` background highlight.
- **Comment integration** — pencil icon (no comment) / speech bubble (has comment), both in `$primary-dark` blue. Clicking opens the annotation drawer correctly regardless of examine position.
- **Opening state** — when no turns yet, two-col shows player names header + "[player] is first".
- **Bug fixes**:
  - Full game history visible during examination in both views (was truncated to examined turn)
  - Blank played-through tiles resolve correctly via `allBoard` prop
  - Scroll position preserved on play click in examination mode
  - Board editor `turns` derived from full `gameContext` so comment indexing doesn't break mid-examination
  - ESLint deps fixed to avoid CI failures

## Files changed
- `src/gameroom/scorecard.tsx` — main scorecard component
- `src/gameroom/scss/gameroom.scss` — two-col + examination styles
- `src/gameroom/table.tsx` — passes `allEvents`/`allBoard` props
- `src/boardwizard/editor.tsx` — passes `allEvents`/`allBoard`, fixes `turns` derivation
- `src/gameroom/TurnCommentPreview.tsx` — pencil icon for empty state

## Test plan
- [ ] Two-col view toggles and persists across reload
- [ ] Opening state shows correct first player
- [ ] Board editor: clicking a play word seeks to correct game state (rack matches that turn)
- [ ] Board editor: clicking pencil opens annotation drawer for correct turn
- [ ] Board editor: scrolling up and clicking a play does not jump scroll position
- [ ] Blank tiles (parenthesized) display correctly in two-col
- [ ] Single-col shows full game history when examining (not truncated)
- [ ] Selected row highlight matches clicked play in both views
- [ ] Live game autoscrolls to bottom normally (not examining)
- [ ] Dark mode: lines, header, hover states all themed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)