### PR TITLE
Fix challenge display, button state, and DS polish

### DIFF
--- a/liwords-ui/src/base.scss
+++ b/liwords-ui/src/base.scss
@@ -114,6 +114,16 @@ $point-size-desktop: calc($tile-font-size-desktop / 2.8);
   }
 }
 
+@mixin type-overline {
+  font-family: $font-default;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 18px;
+  letter-spacing: 1.76px;
+  text-transform: uppercase;
+}
+
 @mixin type-monospace {
   font-family: $font-monospaced;
   font-style: normal;

--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -5,12 +5,11 @@ p {
 }
 
 .breadcrumb {
+  @include type-overline;
   padding: 6px 0 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 12px;
-  letter-spacing: 1.3px;
   @include colorModed() {
     color: m($gray-medium);
   }
@@ -19,15 +18,8 @@ p {
       color: m($gray-medium);
     }
   }
-  //   .link.plain {
-  //     text-transform: none;
-  //     font-size: 14px;
-  //     @include colorModed() {
-  //       color: m($primary-dark);
-  //     }
-  //   }
   .anticon {
-    font-size: 18px;
+    font-size: 24px;
     margin-right: 12px;
   }
 }
@@ -109,17 +101,6 @@ p {
       z-index: 1;
       padding: 12px 24px 0;
     }
-    .list-trigger {
-      letter-spacing: 0;
-      cursor: pointer;
-      @include colorModed() {
-        color: m($primary-dark);
-      }
-      & {
-        font-weight: bold;
-        text-transform: none;
-      }
-    }
     .ant-select {
       width: 100%;
       max-width: 500px;
@@ -146,13 +127,12 @@ p {
     }
 
     .presence-count {
+      @include type-overline;
       position: relative;
       display: flex;
       width: 100%;
       justify-content: space-between;
-      text-transform: uppercase;
-      font-size: 12px;
-      letter-spacing: 0.16em;
+      align-items: center;
       margin: 6px 0;
       @include colorModed() {
         color: m($gray-medium);
@@ -273,10 +253,8 @@ p {
     }
   }
   .channel-list .breadcrumb {
-    text-transform: uppercase;
     padding-bottom: 12px;
     margin-top: 12px;
-    font-size: 12px;
     @include colorModed() {
       color: m($gray-medium);
     }
@@ -442,7 +420,7 @@ p {
         height: 100px;
         line-height: 1.3em;
         margin-top: 12px;
-        font-size: 13px;
+        font-size: 14px;
         .ant-card-body {
           padding: 6px 12px;
           display: flex;
@@ -459,6 +437,56 @@ p {
   }
 }
 
+@media (min-width: $screen-laptop-min) {
+  .game-table {
+    .chat-area {
+      display: flex;
+      flex-direction: column;
+      // header (60px) + game-table padding-top (12px) + game-container padding-bottom (24px)
+      height: calc(100vh - #{$header-height-desktop + 12px + 24px});
+
+      // Fixed-height cards don't participate in flex fill
+      .ant-card.left-menu,
+      .ant-card.disclaimer {
+        flex-shrink: 0;
+      }
+
+      // Chat and notepad/analyzer split the remaining space equally
+      .ant-card.chat,
+      .ant-card.notepad-card,
+      .ant-card.analyzer-card {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        margin-bottom: 12px;
+
+        .ant-card-body {
+          flex: 1;
+          min-height: 0;
+          height: auto;
+        }
+      }
+
+      // Analyzer: align content to top and let suggestions fill + scroll
+      .ant-card.analyzer-card {
+        .ant-card-body {
+          .analyzer-container {
+            align-items: flex-start;
+            justify-content: flex-start;
+
+            .suggestions {
+              max-height: 100%;
+              overflow-y: auto;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 .chat input[name="chat-input"] {
   position: absolute;
   bottom: 0;
@@ -469,130 +497,19 @@ p {
     background: m($card-background);
     color: m($gray-extreme);
   }
+  &::placeholder {
+    @include colorModed() {
+      color: m($gray-medium);
+    }
+  }
 }
 
 @media (min-width: $screen-laptop-min) {
-  .game-table {
-    .chat-area {
-      .ant-card.chat {
-        height: 355px;
-        margin-bottom: 12px;
-      }
-      &.has-disclaimer {
-        .ant-card.chat {
-          height: 328px;
-        }
-        .ant-card.notepad-card,
-        .ant-card.analyzer-card {
-          .ant-card-body {
-            height: 90px;
-          }
-        }
-      }
-    }
-  }
-  .competitor .game-table {
-    .chat-area {
-      .ant-card.chat {
-        height: 290px;
-      }
-      &.has-disclaimer {
-        .ant-card.chat {
-          height: 290px;
-        }
-        .ant-card.notepad-card,
-        .ant-card.analyzer-card {
-          .ant-card-body {
-            height: 90px;
-          }
-        }
-      }
-    }
-  }
   .chat-area {
     order: initial;
-    display: block;
     flex: 1;
     width: 25%;
     min-width: 25%;
     margin: 0;
-  }
-}
-
-@media (min-height: $screen-min-height-desktop-min) and (min-width: $screen-desktop-min) {
-  .game-table {
-    .chat-area {
-      .ant-card.chat {
-        height: 495px;
-      }
-      &.has-disclaimer {
-        .ant-card.chat {
-          height: 420px;
-        }
-        .ant-card.notepad-card,
-        .ant-card.analyzer-card {
-          .ant-card-body {
-            height: 90px;
-          }
-        }
-      }
-    }
-  }
-  .competitor .game-table {
-    .chat-area {
-      .ant-card.chat {
-        height: 430px;
-      }
-      &.has-disclaimer {
-        .ant-card.chat {
-          height: 430px;
-        }
-        .ant-card.notepad-card,
-        .ant-card.analyzer-card {
-          .ant-card-body {
-            height: 90px;
-          }
-        }
-      }
-    }
-  }
-}
-
-@media (min-height: $screen-min-height-desktop-max) and (min-width: $screen-desktop-min) {
-  .game-table {
-    .chat-area {
-      .ant-card.chat {
-        height: 564px;
-      }
-      &.has-disclaimer {
-        .ant-card.chat {
-          height: 564px;
-        }
-        .ant-card.notepad-card,
-        .ant-card.analyzer-card {
-          .ant-card-body {
-            height: 90px;
-          }
-        }
-      }
-    }
-  }
-  .competitor .game-table {
-    .chat-area {
-      .ant-card.chat {
-        height: 499px;
-      }
-      &.has-disclaimer {
-        .ant-card.chat {
-          height: 499px;
-        }
-        .ant-card.notepad-card,
-        .ant-card.analyzer-card {
-          .ant-card-body {
-            height: 90px;
-          }
-        }
-      }
-    }
   }
 }

--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -867,13 +867,13 @@ export const Chat = React.memo((props: Props) => {
                     <p className="presence-count">
                       <span>{peopleOnlineCounter}</span>
                       {presenceVisible ? (
-                        <span className="list-trigger" onClick={handleHideList}>
+                        <button className="view-mode-btn" onClick={handleHideList}>
                           Hide list
-                        </span>
+                        </button>
                       ) : (
-                        <span className="list-trigger" onClick={handleShowList}>
+                        <button className="view-mode-btn" onClick={handleShowList}>
                           Show list
-                        </span>
+                        </button>
                       )}
                     </p>
                     {presenceVisible ? (

--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -867,11 +867,17 @@ export const Chat = React.memo((props: Props) => {
                     <p className="presence-count">
                       <span>{peopleOnlineCounter}</span>
                       {presenceVisible ? (
-                        <button className="view-mode-btn" onClick={handleHideList}>
+                        <button
+                          className="view-mode-btn"
+                          onClick={handleHideList}
+                        >
                           Hide list
                         </button>
                       ) : (
-                        <button className="view-mode-btn" onClick={handleShowList}>
+                        <button
+                          className="view-mode-btn"
+                          onClick={handleShowList}
+                        >
                           Show list
                         </button>
                       )}

--- a/liwords-ui/src/chat/playerList.scss
+++ b/liwords-ui/src/chat/playerList.scss
@@ -5,7 +5,7 @@
   .breadcrumb {
     margin: 6px 0;
     @include colorModed() {
-      color: m($gray-dark);
+      color: m($gray-medium);
     }
   }
 }

--- a/liwords-ui/src/collections/collections.scss
+++ b/liwords-ui/src/collections/collections.scss
@@ -443,7 +443,7 @@
             }
 
             .chapter-title {
-              font-size: 13px;
+              font-size: 14px;
               line-height: 1.3;
               @include colorModed() {
                 color: m($gray-extreme);

--- a/liwords-ui/src/color_modes.scss
+++ b/liwords-ui/src/color_modes.scss
@@ -17,7 +17,6 @@ $card-background: "color-card-background";
 
 $gray-subtle: "color-gray-subtle";
 $gray-medium: "color-gray-medium";
-$gray-dark: "color-gray-dark";
 $gray-extreme: "color-gray-extreme";
 $grid: "color-grid";
 
@@ -101,8 +100,7 @@ $modes: (
     color-off-background: #eeeeee,
 
     color-gray-subtle: #bebebe,
-    color-gray-medium: #999999,
-    color-gray-dark: #777,
+    color-gray-medium: #707070,
     color-gray-extreme: #414141,
 
     color-grid: #c3c3c3,
@@ -174,8 +172,7 @@ $modes: (
     color-card-background: #3a3a3a,
 
     color-gray-subtle: #515151,
-    color-gray-medium: #ccc,
-    color-gray-dark: #ddd,
+    color-gray-medium: #bebebe,
     color-gray-extreme: #ffffff,
 
     color-grid: #232323,

--- a/liwords-ui/src/gameroom/CommentsDrawer.tsx
+++ b/liwords-ui/src/gameroom/CommentsDrawer.tsx
@@ -131,7 +131,7 @@ export const CommentsDrawer: React.FC<Props> = ({
         play = "End rack points";
         break;
       case GameEvent_Type.TIME_PENALTY:
-        play = "Time penalty";
+        play = "Overtime";
         break;
       case GameEvent_Type.END_RACK_PENALTY:
         play = "End rack penalty";

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -1279,6 +1279,14 @@ export const BoardPanel = React.memo((props: Props) => {
   const tileColorId =
     (props.gameDone ? null : myId) ?? examinableGameContext.onturn;
 
+  // Challenge is only valid when it's my turn AND the last event was a tile placement by the opponent.
+  const lastEvent =
+    examinableGameContext.turns[examinableGameContext.turns.length - 1];
+  const challengeAllowed =
+    isMyTurn &&
+    !!lastEvent &&
+    lastEvent.type === GameEvent_Type.TILE_PLACEMENT_MOVE;
+
   const showControlsForGame = !anonymousTourneyViewer && !props.puzzleMode;
   const authedSolvingPuzzle = props.puzzleMode && !props.anonymousViewer;
 
@@ -1307,6 +1315,9 @@ export const BoardPanel = React.memo((props: Props) => {
         onResign={handleResign}
         onRequestAbort={handleRequestAbort}
         onNudge={handleNudge}
+        challengeAllowed={
+          authedSolvingPuzzle || boardEditingMode ? true : challengeAllowed
+        }
         onChallenge={handleChallenge}
         onCommit={handleCommit}
         onRematch={props.handleAcceptRematch ?? rematch}

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -247,6 +247,7 @@ export type Props = {
   onNudge: () => void;
   onRecall: () => void;
   onChallenge: () => void;
+  challengeAllowed?: boolean;
   onCommit: () => void;
   onExamine: () => void;
   onExportGCG: () => void;
@@ -301,7 +302,8 @@ const GameControls = React.memo((props: Props) => {
   // This should match disabled= and/or hidden= props.
   const currentPopUp =
     (actualCurrentPopUp === "CHALLENGE" &&
-      (!props.myTurn || props.challengeRule === ChallengeRule.VOID)) ||
+      (!props.challengeAllowed ||
+        props.challengeRule === ChallengeRule.VOID)) ||
     (actualCurrentPopUp === "PASS" && !props.myTurn)
       ? "NONE"
       : actualCurrentPopUp;
@@ -600,7 +602,7 @@ const GameControls = React.memo((props: Props) => {
               <Button
                 ref={challengeButton}
                 onClick={props.onChallenge}
-                disabled={!props.myTurn}
+                disabled={!props.challengeAllowed}
               >
                 Challenge
                 <span className="key-command">3</span>
@@ -630,7 +632,7 @@ const GameControls = React.memo((props: Props) => {
                       setCurrentPopUp("NONE");
                     }
                   }}
-                  disabled={!props.myTurn}
+                  disabled={!props.challengeAllowed}
                   hidden={props.challengeRule === ChallengeRule.VOID}
                 >
                   Challenge

--- a/liwords-ui/src/gameroom/pool.tsx
+++ b/liwords-ui/src/gameroom/pool.tsx
@@ -120,7 +120,7 @@ const ActualPool = React.memo((props: Props & { hidePool: boolean }) => {
       overlayClassName="format-dropdown"
     >
       <button className="view-mode-btn">
-        {currentFormatLabel} <span className="view-mode-caret">▾</span>
+        <span className="view-mode-caret">▾</span> {currentFormatLabel}
       </button>
     </Dropdown>
   );

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -262,31 +262,24 @@ const ScorecardTurn = (props: turnProps) => {
       return turn;
     }
     // Otherwise, we have to make some modifications.
-    if (evts[1].type === GameEvent_Type.PHONY_TILES_RETURNED) {
+    // Search all events (not just index 1) — single challenge inserts a CHALLENGE event before PHONY/BONUS.
+    const phonyEvt = evts.find(
+      (e) => e.type === GameEvent_Type.PHONY_TILES_RETURNED,
+    );
+    const bonusEvt = evts.find(
+      (e) => e.type === GameEvent_Type.CHALLENGE_BONUS,
+    );
+    if (phonyEvt) {
       turn.score = "0";
-      turn.cumulative = evts[1].cumulative;
-      turn.play = (
-        <>
-          <span className="challenge successful">Challenge!</span>
-          <span className="main-word">
-            {displaySummary(evts[0], props.board, props.alphabet)}
-          </span>
-        </>
-      );
+      turn.cumulative = phonyEvt.cumulative;
+      turn.play = displaySummary(evts[0], props.board, props.alphabet);
       turn.rack = (
         <span className="challenge successful">Challenge! Invalid</span>
       );
     } else {
-      if (evts[1].type === GameEvent_Type.CHALLENGE_BONUS) {
-        turn.cumulative = evts[1].cumulative;
-        turn.play = (
-          <>
-            <span className="challenge unsuccessful">Challenge!</span>
-            <span className="main-word">
-              {displaySummary(evts[0], props.board, props.alphabet)}
-            </span>
-          </>
-        );
+      if (bonusEvt) {
+        turn.cumulative = bonusEvt.cumulative;
+        turn.play = displaySummary(evts[0], props.board, props.alphabet);
         turn.rack = (
           <span className="challenge unsuccessful">Challenge! Valid</span>
         );
@@ -424,7 +417,7 @@ const TwoColTurn = React.memo((props: TwoColTurnProps) => {
   const evt = turn.events[0];
 
   const coords = evt.position || "";
-  let play: React.ReactNode = displaySummary(evt, board, alphabet);
+  const play: React.ReactNode = displaySummary(evt, board, alphabet);
   let score: React.ReactNode =
     evt.type === GameEvent_Type.END_RACK_PTS
       ? `+${evt.endRackPoints}`
@@ -434,16 +427,18 @@ const TwoColTurn = React.memo((props: TwoColTurnProps) => {
   let cumulative = evt.cumulative;
 
   // Handle multi-event turns (challenges, etc.)
+  // Use find() rather than checking index 1 — single challenge inserts a CHALLENGE event before PHONY/BONUS.
+  const phonyEvt = turn.events.find(
+    (e) => e.type === GameEvent_Type.PHONY_TILES_RETURNED,
+  );
+  const bonusEvt = turn.events.find(
+    (e) => e.type === GameEvent_Type.CHALLENGE_BONUS,
+  );
   if (turn.events.length > 1) {
-    const evt1 = turn.events[1];
-    if (evt1.type === GameEvent_Type.PHONY_TILES_RETURNED) {
-      score = "0";
-      cumulative = evt1.cumulative;
-      play = displaySummary(evt, board, alphabet);
+    if (phonyEvt) {
+      score = "";
+      cumulative = phonyEvt.cumulative;
     } else {
-      if (evt1.type === GameEvent_Type.CHALLENGE_BONUS) {
-        play = displaySummary(evt, board, alphabet);
-      }
       for (let i = 1; i < turn.events.length; i++) {
         switch (turn.events[i].type) {
           case GameEvent_Type.CHALLENGE_BONUS:
@@ -463,12 +458,8 @@ const TwoColTurn = React.memo((props: TwoColTurnProps) => {
     }
   }
 
-  const isPhony =
-    turn.events.length > 1 &&
-    turn.events[1].type === GameEvent_Type.PHONY_TILES_RETURNED;
-  const isValidChallenge =
-    turn.events.length > 1 &&
-    turn.events[1].type === GameEvent_Type.CHALLENGE_BONUS;
+  const isPhony = !!phonyEvt;
+  const isValidChallenge = !!bonusEvt;
   const rack: React.ReactNode = isPhony ? (
     <span className="challenge successful">Challenge! Invalid</span>
   ) : isValidChallenge ? (

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -67,6 +67,7 @@ type Props = {
   isCorrespondence?: boolean;
   timeBankP0?: number; // Time bank in milliseconds for player 0
   timeBankP1?: number; // Time bank in milliseconds for player 1
+  isInMobileView?: boolean;
 };
 
 type turnProps = {
@@ -146,7 +147,7 @@ const displaySummary = (evt: GameEvent, board: Board, alphabet: Alphabet) => {
         </span>
       );
     case GameEvent_Type.TIME_PENALTY:
-      return <span className="time-penalty">Time penalty</span>;
+      return <span className="time-penalty">Overtime</span>;
   }
   return "";
 };
@@ -644,15 +645,17 @@ export const ScoreCard = React.memo((props: Props) => {
   const { gameContext } = useGameContextStoreContext();
   const { handleExamineGoTo, examinedTurn } = useExamineStoreContext();
 
-  // Scroll selected turn into view when examinedTurn changes (arrow navigation)
+  // Scroll selected turn into view when examinedTurn changes (arrow navigation).
+  // Skip on mobile: the scorecard is below the board in a single-column stack,
+  // so scrollIntoView would yank the page away from the board on every nav.
   useEffect(() => {
-    if (!props.isExamining || !flipHidden) return;
+    if (!props.isExamining || !flipHidden || props.isInMobileView) return;
     requestAnimationFrame(() => {
       el.current
         ?.querySelector(".turn-selected, .two-col-turn-selected")
         ?.scrollIntoView({ block: "nearest", behavior: "smooth" });
     });
-  }, [examinedTurn, props.isExamining, flipHidden]);
+  }, [examinedTurn, props.isExamining, flipHidden, props.isInMobileView]);
 
   const viewMenuItems = [
     { label: "1 column", key: "single" },
@@ -676,7 +679,7 @@ export const ScoreCard = React.memo((props: Props) => {
       overlayClassName="format-dropdown"
     >
       <button className="view-mode-btn">
-        {currentViewLabel} <span className="view-mode-caret">▾</span>
+        <span className="view-mode-caret">▾</span> {currentViewLabel}
       </button>
     </Dropdown>
   );

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -752,7 +752,9 @@ export const ScoreCard = React.memo((props: Props) => {
                       }
                       isSelected={
                         props.isExamining &&
-                        examinedTurn === left.turn.firstEvtIdx
+                        examinedTurn >= left.turn.firstEvtIdx &&
+                        examinedTurn <
+                          left.turn.firstEvtIdx + left.turn.events.length
                       }
                       showComments={props.showComments}
                       comments={
@@ -783,7 +785,9 @@ export const ScoreCard = React.memo((props: Props) => {
                       }
                       isSelected={
                         props.isExamining &&
-                        examinedTurn === right.turn.firstEvtIdx
+                        examinedTurn >= right.turn.firstEvtIdx &&
+                        examinedTurn <
+                          right.turn.firstEvtIdx + right.turn.events.length
                       }
                       showComments={props.showComments}
                       comments={
@@ -843,7 +847,11 @@ export const ScoreCard = React.memo((props: Props) => {
                 ? () => handleExamineGoTo(t.firstEvtIdx)
                 : undefined
             }
-            isSelected={props.isExamining && examinedTurn === t.firstEvtIdx}
+            isSelected={
+              props.isExamining &&
+              examinedTurn >= t.firstEvtIdx &&
+              examinedTurn < t.firstEvtIdx + t.events.length
+            }
           />
         );
       };

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -102,7 +102,7 @@ p.streak-loss {
       .ant-card-head-title,
       .ant-card-extra {
         padding: 6px 3px;
-        font-size: 13px;
+        font-size: 14px;
         line-height: 1em;
       }
 
@@ -111,7 +111,7 @@ p.streak-loss {
         & {
           font-weight: bold;
           line-height: 2em;
-          font-size: 13px;
+          font-size: 14px;
         }
       }
     }
@@ -213,6 +213,15 @@ p.streak-loss {
     }
   }
 
+  @media (min-width: $screen-laptop-min) {
+    .notepad-card,
+    .analyzer-card {
+      .ant-card-body {
+        height: auto;
+      }
+    }
+  }
+
   .analyzer-card {
     .ant-card-body {
       padding: 0;
@@ -270,7 +279,7 @@ p.streak-loss {
     }
 
     .suggestions {
-      font-family: $font-monospaced;
+      @include type-monospace;
       width: 100%;
       text-align: center;
       align-items: center;
@@ -287,14 +296,14 @@ p.streak-loss {
 
         &:hover {
           @include colorModed() {
-            background-color: m($off-background);
+            background-color: m($primary-light);
           }
         }
       }
 
       tr.move-chosen:not(:hover) {
         @include colorModed() {
-          background-color: m($gray-subtle);
+          background-color: m($primary-middle);
         }
       }
 
@@ -450,7 +459,7 @@ p.streak-loss {
 
   .ca-player-name {
     font-weight: 600;
-    font-size: 13px;
+    font-size: 14px;
   }
 
   .ca-sep {
@@ -474,7 +483,7 @@ p.streak-loss {
 
   .ca-move-row {
     font-family: $font-monospaced;
-    font-size: 13px;
+    font-size: 14px;
     display: flex;
     align-items: center;
     gap: 5px;
@@ -655,7 +664,7 @@ p.streak-loss {
 
       &:hover {
         @include colorModed() {
-          color: m($gray-dark);
+          color: m($gray-medium);
         }
       }
     }
@@ -674,7 +683,7 @@ p.streak-loss {
 
       .ca-ply-table {
         font-family: $font-monospaced;
-        font-size: 13px;
+        font-size: 14px;
         width: auto;
 
         td {
@@ -694,7 +703,7 @@ p.streak-loss {
       display: inline-flex;
       align-items: center;
       gap: 3px;
-      font-size: 13px;
+      font-size: 14px;
     }
   }
 
@@ -1853,7 +1862,6 @@ p.rune {
 
   .tiles-remaining {
     @include type-monospace;
-    font-size: 13px;
     font-weight: 800;
     padding: 6px 24px 12px;
     line-height: 1.3em;
@@ -1936,8 +1944,9 @@ p.rune {
   background: transparent;
   border: none;
   cursor: pointer;
+  font-family: $font-default;
   font-weight: 700;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.4;
   border-radius: 4px;
 
@@ -1963,10 +1972,10 @@ p.rune {
       @include type-default;
       & {
         font-weight: bold;
-        font-size: 12px;
-        height: 24px;
+        font-size: 14px;
+        height: 28px;
         min-width: 110px;
-        line-height: 2.3em;
+        line-height: 2em;
       }
 
       @include colorModed() {
@@ -1991,14 +2000,14 @@ p.rune {
     }
 
     & {
-      font-size: 13px;
+      font-size: 14px;
       letter-spacing: 1.2px;
       text-transform: uppercase;
     }
   }
 
   .league-name {
-    font-size: 13px;
+    font-size: 14px;
     letter-spacing: 1.2px;
     text-transform: uppercase;
 
@@ -2084,7 +2093,6 @@ p.rune {
 
   .turn {
     @include type-monospace;
-    font-size: 14px;
     display: flex;
     padding: 6px 16px;
     justify-content: space-between;
@@ -2093,9 +2101,15 @@ p.rune {
       color: m($gray-extreme);
     }
 
-    &.turn-selected {
+    &:hover {
       @include colorModed() {
         background: m($primary-light);
+      }
+    }
+
+    &.turn-selected {
+      @include colorModed() {
+        background: m($primary-middle);
       }
     }
 
@@ -2248,7 +2262,7 @@ p.rune {
 
         .ant-card-head-title {
           padding: 3px 0px;
-          font-size: 13px;
+          font-size: 14px;
           font-weight: 600;
 
           @include colorModed() {
@@ -2326,7 +2340,7 @@ p.rune {
       margin-top: 6px;
       padding: 4px 8px;
       border-radius: 4px;
-      font-size: 13px;
+      font-size: 14px;
 
       @include colorModed() {
         color: m($button);
@@ -2462,7 +2476,6 @@ p.rune {
   // Two-column scorecard view
   .two-col-scorecard {
     @include type-monospace;
-    font-size: 13px;
     position: relative;
 
     @include colorModed() {
@@ -2548,9 +2561,15 @@ p.rune {
       min-height: 38px;
     }
 
-    &.two-col-turn-selected {
+    &:hover {
       @include colorModed() {
         background: m($primary-light);
+      }
+    }
+
+    &.two-col-turn-selected {
+      @include colorModed() {
+        background: m($primary-middle);
       }
     }
 
@@ -2760,7 +2779,7 @@ p.rune {
 
             .ant-card-head-title {
               padding: 3px 0px;
-              font-size: 13px;
+              font-size: 14px;
               font-weight: 600;
 
               @include colorModed() {
@@ -2838,7 +2857,7 @@ p.rune {
           display: inline-block; // Ensure proper spacing
           padding: 4px 8px;
           border-radius: 4px;
-          font-size: 13px;
+          font-size: 14px;
 
           @include colorModed() {
             color: m($button);
@@ -2892,7 +2911,7 @@ p.rune {
       margin-bottom: 12px;
 
       .turn-indicator {
-        font-size: 13px;
+        font-size: 14px;
         font-weight: 500;
 
         @include colorModed() {
@@ -3330,7 +3349,7 @@ p.rune {
 
         .analyzer-container {
           .suggestions {
-            font-size: 13px;
+            font-size: 14px;
             max-height: 182px;
             overflow-y: auto;
           }

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -1386,6 +1386,7 @@ export const Table = React.memo((props: Props) => {
           />
           <ScoreCard
             isExamining={isExamining}
+            isInMobileView={isInMobileView}
             events={examinableGameContext.turns}
             allEvents={gameContext.turns}
             allBoard={gameContext.board}

--- a/liwords-ui/src/leagues/leagues.scss
+++ b/liwords-ui/src/leagues/leagues.scss
@@ -321,7 +321,7 @@
     }
 
     p {
-      font-size: 13px;
+      font-size: 14px;
       line-height: 1.4;
       margin: 0 0 12px 0;
       color: #666;
@@ -360,7 +360,7 @@
     cursor: pointer;
     text-decoration: none;
     color: #666;
-    font-size: 13px;
+    font-size: 14px;
     margin-bottom: 12px;
     padding-left: 16px;
 
@@ -958,7 +958,7 @@
 
       .opponent-name-compact {
         font-weight: 500;
-        font-size: 13px;
+        font-size: 14px;
       }
 
       .turn-indicator-compact {
@@ -1017,6 +1017,6 @@
   color: #999;
 
   @include colorModed {
-    color: m($gray-dark);
+    color: m($gray-medium);
   }
 }

--- a/liwords-ui/src/lobby/accountForms.scss
+++ b/liwords-ui/src/lobby/accountForms.scss
@@ -216,7 +216,7 @@ div.account {
     }
     & {
       font-weight: bold;
-      font-size: 13px;
+      font-size: 14px;
       border: 0;
       outline: 0;
     }

--- a/liwords-ui/src/lobby/seek_form.scss
+++ b/liwords-ui/src/lobby/seek_form.scss
@@ -12,7 +12,7 @@
     }
   }
   button {
-    font-size: 13px;
+    font-size: 14px;
   }
   .ant-modal-body {
     padding-bottom: 0;
@@ -156,7 +156,7 @@
       margin-left: 12px;
       .help {
         display: block;
-        font-size: 13px;
+        font-size: 14px;
         @include colorModed() {
           color: m($primary-midDark);
         }
@@ -165,7 +165,7 @@
   }
   .ant-modal-footer .ant-btn {
     border: 0;
-    font-size: 13px;
+    font-size: 14px;
     text-transform: none;
   }
 

--- a/liwords-ui/src/lobby/upcoming_tournaments.scss
+++ b/liwords-ui/src/lobby/upcoming_tournaments.scss
@@ -55,7 +55,7 @@
 
   .tournament-name {
     font-weight: 600;
-    font-size: 13px;
+    font-size: 14px;
     display: flex;
     align-items: center;
     gap: 5px;
@@ -134,7 +134,7 @@
 
       &.closed {
         background-color: m($gray-subtle);
-        color: m($gray-dark);
+        color: m($gray-medium);
       }
 
       &.live {
@@ -220,7 +220,7 @@
 
   .tournament-name {
     font-weight: 600;
-    font-size: 13px;
+    font-size: 14px;
     display: flex;
     align-items: center;
     gap: 5px;
@@ -299,7 +299,7 @@
 
       &.closed {
         background-color: m($gray-subtle);
-        color: m($gray-dark);
+        color: m($gray-medium);
       }
 
       &.live {
@@ -352,7 +352,7 @@
 
   .league-name {
     font-weight: 600;
-    font-size: 13px;
+    font-size: 14px;
     display: flex;
     align-items: center;
     gap: 6px;
@@ -409,7 +409,7 @@
 
       &.completed {
         background-color: m($gray-subtle);
-        color: m($gray-dark);
+        color: m($gray-medium);
       }
     }
   }

--- a/liwords-ui/src/navigation/topbar.scss
+++ b/liwords-ui/src/navigation/topbar.scss
@@ -20,7 +20,7 @@ body {
     @include type-default;
     & {
       letter-spacing: 0.16em;
-      font-size: 13px;
+      font-size: 14px;
       font-weight: bold;
       text-transform: uppercase;
     }
@@ -56,7 +56,7 @@ body {
   padding-bottom: 0;
   justify-content: center;
   max-width: none;
-  font-size: 13px;
+  font-size: 14px;
   div {
     display: none;
     padding: 12px 24px;

--- a/liwords-ui/src/profile/profile.scss
+++ b/liwords-ui/src/profile/profile.scss
@@ -19,7 +19,7 @@
     margin: 48px 0 18px 9px;
     text-transform: uppercase;
     letter-spacing: 0.16em;
-    font-size: 13px;
+    font-size: 14px;
   }
   .bio {
     margin-bottom: 18px;
@@ -171,7 +171,7 @@
       }
     }
     .rating-date {
-      font-size: 13px;
+      font-size: 14px;
       margin: 0 0 12px 0;
     }
     .ant-card-head {

--- a/liwords-ui/src/puzzles/puzzle_preview.scss
+++ b/liwords-ui/src/puzzles/puzzle_preview.scss
@@ -84,7 +84,7 @@
         }
         @media (min-width: $screen-laptop-min) {
           max-width: 120px;
-          font-size: 13px;
+          font-size: 14px;
           line-height: 1.3em;
         }
         @media (min-width: $screen-desktop-min) {

--- a/liwords-ui/src/puzzles/puzzles.scss
+++ b/liwords-ui/src/puzzles/puzzles.scss
@@ -15,7 +15,7 @@
         color: m($secondary);
       }
       & {
-        font-size: 13px;
+        font-size: 14px;
         letter-spacing: 1.2px;
         text-transform: uppercase;
       }

--- a/liwords-ui/src/tournament/room.scss
+++ b/liwords-ui/src/tournament/room.scss
@@ -91,7 +91,7 @@
     @include colorModed() {
       background: m($background);
       color: m($gray-extreme);
-      border: 1px solid m($gray-dark);
+      border: 1px solid m($gray-medium);
     }
     .ant-select-arrow {
       @include colorModed() {

--- a/liwords-ui/src/tournament/tournament_wizard.scss
+++ b/liwords-ui/src/tournament/tournament_wizard.scss
@@ -79,7 +79,7 @@
       p {
         margin: 0;
         font-weight: normal;
-        font-size: 13px;
+        font-size: 14px;
         white-space: normal;
         opacity: 0.8;
       }
@@ -96,7 +96,7 @@
 
       .ant-typography {
         margin-bottom: 0;
-        font-size: 13px;
+        font-size: 14px;
       }
     }
   }

--- a/liwords-ui/src/tournament/tournaments_page.scss
+++ b/liwords-ui/src/tournament/tournaments_page.scss
@@ -72,7 +72,7 @@
 
     .tournament-name {
       font-weight: 600;
-      font-size: 13px;
+      font-size: 14px;
       display: flex;
       align-items: center;
       gap: 5px;
@@ -151,7 +151,7 @@
 
         &.closed {
           background-color: m($gray-subtle);
-          color: m($gray-dark);
+          color: m($gray-medium);
         }
 
         &.live {


### PR DESCRIPTION
## Summary

### Challenge display & button state
- **Challenge display (single challenge mode)**: Use `find()` instead of checking `evts[1]` — single challenge inserts a `CHALLENGE` event before `PHONY_TILES_RETURNED`/`CHALLENGE_BONUS`, causing the wrong event to be detected at index 1
- **No duplicate "Challenge!" on play line**: Previously prepended "Challenge!" to both the play and rack lines; now only the rack line shows it
- **Challenged-off score**: Shows blank instead of `0` in two-col view (the play was returned, no score change to display)
- **Challenge button disabled when not challengeable**: Button now only enables when the last event was an opponent tile placement — prevents spurious challenge at game start, after your own play, or after a challenge has already resolved

### DS polish — typography
- Added `type-overline` mixin (Mulish Bold 11px / 18px line-height / 1.76px letter-spacing / uppercase); wired to breadcrumb ("ALL CHATS") and presence-count ("1 PLAYER")
- Swept all `font-size: 13px` → `14px` across 16 files (35 instances)
- Analyzer `.suggestions` wired to `@include type-monospace` instead of bare `font-family`
- Pool/scorecard dropdown buttons and "Show list" use `.view-mode-btn` (Subheader/2, icon-first caret)
- Card header titles: 13px → 14px

### DS polish — color tokens
- `$gray-medium` corrected to `#707070` (DS Grayscale/Gray) from `#999999`
- `$gray-dark` token removed — 8 uses folded into `$gray-medium`
- Gray scale now maps exactly to the 4 DS palette colors
- Analyzer and scorecard selected state: `$primary-middle` (#c9f0ff)
- Analyzer and scorecard hover state: `$primary-light` (#e2f8ff)
- Chat input placeholder: `$gray-medium` (#707070)

### DS polish — gameroom UI
- Analyzer card: fixed top-alignment of suggestions list (was vertically centered in tall flex container)
- Renamed "Time penalty" → "Overtime" in scorecard and CommentsDrawer to prevent truncation
- Mobile: disabled scroll-to-selected-turn on scorecard (was jumping board out of view)
- Desktop 3-col: chat and notepad/analyzer now 50:50 flex split instead of hardcoded heights
- "Show list" / "Hide list": `<span>` → `<button>` with `.view-mode-btn` style

## Test plan
- [ ] Double challenge: challenged-off play shows word on play line, "Challenge! Invalid" on rack line — no duplicate "Challenge!"
- [ ] Single challenge: same as above
- [ ] Valid challenge (bonus): "Challenge! Valid" on rack line
- [ ] Challenge button disabled at game start (no plays yet)
- [ ] Challenge button disabled immediately after you play
- [ ] Challenge button enabled after opponent plays a word
- [ ] Challenge button disabled again after challenge resolves
- [ ] Analyzer suggestions top-aligned, hover/selected states use primary blue family
- [ ] Scorecard rows hover/selected states consistent with analyzer
- [ ] "1 PLAYER" and breadcrumbs use overline style
- [ ] 3-col desktop: chat and notepad/analyzer split 50:50

🤖 Generated with [Claude Code](https://claude.com/claude-code)