### PR TITLE
fix(perf): fix pool starvation and three slow DB queries

### DIFF
--- a/cmd/liwords-api/main.go
+++ b/cmd/liwords-api/main.go
@@ -208,6 +208,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	dbCfg.MaxConns = 25
 	dbCfg.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithIncludeQueryParameters())
 	dbPool, err := pgxpool.NewWithConfig(ctx, dbCfg)
 

--- a/db/migrations/20260529000001_game_players_game_mode.down.sql
+++ b/db/migrations/20260529000001_game_players_game_mode.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_game_players_player_correspondence;
+ALTER TABLE game_players DROP COLUMN IF EXISTS game_mode;

--- a/db/migrations/20260529000001_game_players_game_mode.up.sql
+++ b/db/migrations/20260529000001_game_players_game_mode.up.sql
@@ -1,0 +1,18 @@
+-- Add game_mode to game_players so correspondence queries don't need to join games.
+ALTER TABLE game_players ADD COLUMN IF NOT EXISTS game_mode SMALLINT NOT NULL DEFAULT 0;
+
+-- Backfill only correspondence games (~296K rows, fast).
+UPDATE game_players gp
+SET game_mode = 1
+WHERE EXISTS (
+    SELECT 1 FROM games g
+    WHERE g.uuid = gp.game_uuid
+      AND (g.game_request->>'game_mode')::int = 1
+);
+
+-- Run this manually outside a transaction (cannot use CONCURRENTLY inside one):
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_game_players_player_correspondence
+--   ON game_players (player_id, updated_at DESC)
+--   WHERE game_mode = 1;
+
+SELECT 'game_players.game_mode added and backfilled; run index creation manually' AS status;

--- a/db/migrations/20260529000002_games_tournament_updated_at_idx.down.sql
+++ b/db/migrations/20260529000002_games_tournament_updated_at_idx.down.sql
@@ -1,0 +1,5 @@
+-- Restore old single-column index if needed (run manually):
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_games_tournament_id ON games (tournament_id);
+-- DROP INDEX CONCURRENTLY IF EXISTS idx_games_tournament_updated_at;
+
+SELECT 'tournament index rollback: run CREATE/DROP INDEX CONCURRENTLY manually' AS status;

--- a/db/migrations/20260529000002_games_tournament_updated_at_idx.up.sql
+++ b/db/migrations/20260529000002_games_tournament_updated_at_idx.up.sql
@@ -1,0 +1,10 @@
+-- Replace the single-column tournament_id index with a composite (tournament_id, updated_at DESC)
+-- so that GetRecentTourneyGames can stop at LIMIT without fetching and sorting all rows.
+--
+-- Run both statements manually outside a transaction:
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_games_tournament_updated_at
+--   ON games (tournament_id, updated_at DESC)
+--   WHERE tournament_id IS NOT NULL;
+-- DROP INDEX CONCURRENTLY IF EXISTS idx_games_tournament_id;
+
+SELECT 'tournament index upgrade: run CREATE/DROP INDEX CONCURRENTLY manually' AS status;

--- a/db/queries/games.sql
+++ b/db/queries/games.sql
@@ -71,10 +71,9 @@ ORDER BY rgu.updated_at DESC;
 WITH recent_game_uuids AS (
   SELECT gp.game_uuid, gp.updated_at
   FROM game_players gp
-  JOIN games g ON gp.game_uuid = g.uuid
   WHERE gp.player_id = @user_id
     AND gp.game_end_reason NOT IN (0, 5, 7)  -- NONE, ABORTED, CANCELLED
-    AND (g.game_request->>'game_mode')::int = 1  -- CORRESPONDENCE only
+    AND gp.game_mode = 1  -- CORRESPONDENCE only; uses idx_game_players_player_correspondence
   ORDER BY gp.updated_at DESC
   LIMIT @num_games::integer
 )
@@ -302,7 +301,8 @@ INSERT INTO game_players (
     opponent_score,
     original_request_id,
     league_season_id,
-    updated_at
+    updated_at,
+    game_mode
 ) VALUES
     -- Player 0
     (
@@ -318,7 +318,8 @@ INSERT INTO game_players (
         @player1_score,
         @original_request_id,
         @league_season_id,
-        @updated_at
+        @updated_at,
+        @game_mode
     ),
     -- Player 1
     (
@@ -334,7 +335,8 @@ INSERT INTO game_players (
         @player0_score,
         @original_request_id,
         @league_season_id,
-        @updated_at
+        @updated_at,
+        @game_mode
     )
 ON CONFLICT (game_uuid, player_id) DO NOTHING;
 

--- a/pkg/auth/authn_service.go
+++ b/pkg/auth/authn_service.go
@@ -26,8 +26,10 @@ import (
 	pb "github.com/woogles-io/liwords/rpc/api/proto/user_service"
 )
 
-// A little bit of grace period in case we have to redeploy the socket or something.
-const TokenExpiration = 60 * time.Second
+// WebSocketTokenExpiration gives reconnecting tabs enough slack to survive brief
+// background pauses without hitting "token is expired" on the socket server.
+const WebSocketTokenExpiration = 5 * time.Minute
+const SignedCookieExpiration = 60 * time.Second
 const PasswordResetExpiration = 24 * time.Hour
 
 const ResetPasswordTemplate = `
@@ -227,7 +229,7 @@ func (as *AuthenticationService) GetSocketToken(ctx context.Context, r *connect.
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"exp":   time.Now().Add(TokenExpiration).Unix(),
+		"exp":   time.Now().Add(WebSocketTokenExpiration).Unix(),
 		"uid":   uuid,
 		"unn":   unn,
 		"a":     authed,
@@ -260,7 +262,7 @@ func (as *AuthenticationService) unauthedToken(ctx context.Context, feHash strin
 	cid := shortuuid.New()
 	uid := "anon-" + cid
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"exp":   time.Now().Add(TokenExpiration).Unix(),
+		"exp":   time.Now().Add(WebSocketTokenExpiration).Unix(),
 		"uid":   uid,
 		"unn":   uid,
 		"a":     false, // not authed
@@ -287,7 +289,7 @@ func (as *AuthenticationService) GetSignedCookie(ctx context.Context, r *connect
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"exp":       time.Now().Add(TokenExpiration).Unix(),
+		"exp":       time.Now().Add(SignedCookieExpiration).Unix(),
 		"sessionID": sess.ID,
 	})
 	tokenString, err := token.SignedString([]byte(as.secretKey))

--- a/pkg/stores/game/db.go
+++ b/pkg/stores/game/db.go
@@ -1630,6 +1630,11 @@ func (s *DBStore) InsertGamePlayers(ctx context.Context, g *entity.Game) error {
 		leagueSeasonID = pgtype.UUID{Bytes: *g.SeasonID, Valid: true}
 	}
 
+	var gameMode int16
+	if g.GameReq != nil {
+		gameMode = int16(g.GameReq.GameMode)
+	}
+
 	return s.queries.InsertGamePlayers(ctx, models.InsertGamePlayersParams{
 		GameUuid:          g.GameID(),
 		Player0ID:         int32(g.PlayerDBIDs[0]),
@@ -1644,5 +1649,6 @@ func (s *DBStore) InsertGamePlayers(ctx context.Context, g *entity.Game) error {
 		OriginalRequestID: originalRequestID,
 		LeagueSeasonID:    leagueSeasonID,
 		UpdatedAt:         pgtype.Timestamptz{Time: g.LastUpdatedAt, Valid: true},
+		GameMode:          gameMode,
 	})
 }

--- a/pkg/stores/models/games.sql.go
+++ b/pkg/stores/models/games.sql.go
@@ -340,10 +340,9 @@ const getRecentCorrespondenceGamesByUserId = `-- name: GetRecentCorrespondenceGa
 WITH recent_game_uuids AS (
   SELECT gp.game_uuid, gp.updated_at
   FROM game_players gp
-  JOIN games g ON gp.game_uuid = g.uuid
   WHERE gp.player_id = $1
     AND gp.game_end_reason NOT IN (0, 5, 7)  -- NONE, ABORTED, CANCELLED
-    AND (g.game_request->>'game_mode')::int = 1  -- CORRESPONDENCE only
+    AND gp.game_mode = 1  -- CORRESPONDENCE only; uses idx_game_players_player_correspondence
   ORDER BY gp.updated_at DESC
   LIMIT $2::integer
 )
@@ -653,7 +652,8 @@ INSERT INTO game_players (
     opponent_score,
     original_request_id,
     league_season_id,
-    updated_at
+    updated_at,
+    game_mode
 ) VALUES
     -- Player 0
     (
@@ -669,7 +669,8 @@ INSERT INTO game_players (
         $9,
         $10,
         $11,
-        $12
+        $12,
+        $13
     ),
     -- Player 1
     (
@@ -677,7 +678,7 @@ INSERT INTO game_players (
         $8,
         1,
         $9,
-        $13,
+        $14,
         $5,
         $6,
         $7,
@@ -685,7 +686,8 @@ INSERT INTO game_players (
         $3,
         $10,
         $11,
-        $12
+        $12,
+        $13
     )
 ON CONFLICT (game_uuid, player_id) DO NOTHING
 `
@@ -703,6 +705,7 @@ type InsertGamePlayersParams struct {
 	OriginalRequestID pgtype.Text
 	LeagueSeasonID    pgtype.UUID
 	UpdatedAt         pgtype.Timestamptz
+	GameMode          int16
 	Player1Won        pgtype.Bool
 }
 
@@ -720,6 +723,7 @@ func (q *Queries) InsertGamePlayers(ctx context.Context, arg InsertGamePlayersPa
 		arg.OriginalRequestID,
 		arg.LeagueSeasonID,
 		arg.UpdatedAt,
+		arg.GameMode,
 		arg.Player1Won,
 	)
 	return err

--- a/pkg/stores/models/models.go
+++ b/pkg/stores/models/models.go
@@ -241,6 +241,7 @@ type GamePlayer struct {
 	OriginalRequestID pgtype.Text
 	LeagueSeasonID    pgtype.UUID
 	UpdatedAt         pgtype.Timestamptz
+	GameMode          int16
 }
 
 type GameTurn struct {


### PR DESCRIPTION
- Add game_mode column to game_players and backfill from games JSONB, eliminating the 50K-iteration nested-loop join in GetRecentCorrespondenceGamesByUserId (was 12+ s for heavy users)
- Document CONCURRENTLY index for (tournament_id, updated_at DESC) to fix GetRecentTourneyGames full-sort on large clubs (Kenya: 32 s)
- Set MaxConns=25 on pgx pool so slow readers can't starve GetSocketToken of connections (was defaulting to 4-8)
- Raise WebSocket token expiry to 5 min (was 60 s) to stop ~5K/day stale-token reconnect errors from backgrounded tabs