### PR TITLE
Revert chat/notepad flex split, restore original fixed heights

### DIFF
--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -440,46 +440,36 @@ p {
 @media (min-width: $screen-laptop-min) {
   .game-table {
     .chat-area {
-      display: flex;
-      flex-direction: column;
-      // header (60px) + game-table padding-top (12px) + game-container padding-bottom (24px)
-      height: calc(100vh - #{$header-height-desktop + 12px + 24px});
-
-      // Fixed-height cards don't participate in flex fill
-      .ant-card.left-menu,
-      .ant-card.disclaimer {
-        flex-shrink: 0;
-      }
-
-      // Chat and notepad/analyzer split the remaining space equally
-      .ant-card.chat,
-      .ant-card.notepad-card,
-      .ant-card.analyzer-card {
-        flex: 1;
-        min-height: 0;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
+      .ant-card.chat {
+        height: 355px;
         margin-bottom: 12px;
-
-        .ant-card-body {
-          flex: 1;
-          min-height: 0;
-          height: auto;
+      }
+      &.has-disclaimer {
+        .ant-card.chat {
+          height: 328px;
+        }
+        .ant-card.notepad-card,
+        .ant-card.analyzer-card {
+          .ant-card-body {
+            height: 90px;
+          }
         }
       }
-
-      // Analyzer: align content to top and let suggestions fill + scroll
-      .ant-card.analyzer-card {
-        .ant-card-body {
-          .analyzer-container {
-            align-items: flex-start;
-            justify-content: flex-start;
-
-            .suggestions {
-              max-height: 100%;
-              overflow-y: auto;
-            }
+    }
+  }
+  .competitor .game-table {
+    .chat-area {
+      .ant-card.chat {
+        height: 290px;
+      }
+      &.has-disclaimer {
+        .ant-card.chat {
+          height: 290px;
+        }
+        .ant-card.notepad-card,
+        .ant-card.analyzer-card {
+          .ant-card-body {
+            height: 90px;
           }
         }
       }
@@ -507,9 +497,88 @@ p {
 @media (min-width: $screen-laptop-min) {
   .chat-area {
     order: initial;
+    display: block;
     flex: 1;
     width: 25%;
     min-width: 25%;
     margin: 0;
+  }
+}
+
+@media (min-height: $screen-min-height-desktop-min) and (min-width: $screen-desktop-min) {
+  .game-table {
+    .chat-area {
+      .ant-card.chat {
+        height: 495px;
+      }
+      &.has-disclaimer {
+        .ant-card.chat {
+          height: 420px;
+        }
+        .ant-card.notepad-card,
+        .ant-card.analyzer-card {
+          .ant-card-body {
+            height: 90px;
+          }
+        }
+      }
+    }
+  }
+  .competitor .game-table {
+    .chat-area {
+      .ant-card.chat {
+        height: 430px;
+      }
+      &.has-disclaimer {
+        .ant-card.chat {
+          height: 430px;
+        }
+        .ant-card.notepad-card,
+        .ant-card.analyzer-card {
+          .ant-card-body {
+            height: 90px;
+          }
+        }
+      }
+    }
+  }
+}
+
+@media (min-height: $screen-min-height-desktop-max) and (min-width: $screen-desktop-min) {
+  .game-table {
+    .chat-area {
+      .ant-card.chat {
+        height: 564px;
+      }
+      &.has-disclaimer {
+        .ant-card.chat {
+          height: 564px;
+        }
+        .ant-card.notepad-card,
+        .ant-card.analyzer-card {
+          .ant-card-body {
+            height: 90px;
+          }
+        }
+      }
+    }
+  }
+  .competitor .game-table {
+    .chat-area {
+      .ant-card.chat {
+        height: 499px;
+      }
+      &.has-disclaimer {
+        .ant-card.chat {
+          height: 499px;
+        }
+        .ant-card.notepad-card,
+        .ant-card.analyzer-card {
+          .ant-card-body {
+            height: 90px;
+          }
+        }
+      }
+    }
   }
 }

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -213,14 +213,6 @@ p.streak-loss {
     }
   }
 
-  @media (min-width: $screen-laptop-min) {
-    .notepad-card,
-    .analyzer-card {
-      .ant-card-body {
-        height: auto;
-      }
-    }
-  }
 
   .analyzer-card {
     .ant-card-body {


### PR DESCRIPTION
## Summary

- Reverts the 50:50 flex split layout for chat/notepad introduced in #1830
- Restores original hardcoded heights (355px chat at laptop, stepping up at larger breakpoints)
- Removes the height: auto override on notepad/analyzer card bodies at laptop+

The flex approach caused layout issues and needs more work before it's ready.

## Test plan
- [ ] Game chat and notepad heights look correct at laptop, desktop, and large desktop breakpoints
- [ ] Competitor/tournament layout unaffected

Generated with Claude Code