### PR TITLE
2026july4updates

### DIFF
--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -306,16 +306,7 @@ var weightPolicies = []weightPolicy{
 			if pargs.copdata.GibsonizedPlayers[ri] || rjGibsonized || ri > pargs.lowestPossibleHopeCasher {
 				return 0
 			}
-			// Distance is ceil(numPlayers/3)
-			lowestPCIndex := getLowestCasherIndex(pargs)
 			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
-			if ri > lowestPCIndex {
-				dist := int(pargs.copdata.Standings.GetNumPlayers()+2) / 3
-				if rj-ri > dist {
-					return majorPenalty
-				}
-				lowestContender = pargs.copdata.LowestRankAbsolutely[ri]
-			}
 			if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
 				casherDiff := lowestContender - rj
 				if casherDiff < 0 {

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -280,6 +280,12 @@ var weightPolicies = []weightPolicy{
 			if rj < len(pargs.copdata.GibsonizedPlayers) {
 				rjGibsonized = pargs.copdata.GibsonizedPlayers[rj]
 			}
+			// In the fourth quarter, cashers use PC weight exclusively.
+			if pargs.roundsRemaining*4 <= int(pargs.req.Rounds) &&
+				!pargs.copdata.GibsonizedPlayers[ri] &&
+				ri <= pargs.lowestPossibleHopeCasher {
+				return 0
+			}
 			// If
 			//
 			// - either play is gibsonized, or

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -306,13 +306,25 @@ var weightPolicies = []weightPolicy{
 			if pargs.copdata.GibsonizedPlayers[ri] || rjGibsonized || ri > pargs.lowestPossibleHopeCasher {
 				return 0
 			}
-			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
-			if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
-				casherDiff := lowestContender - rj
-				if casherDiff < 0 {
-					casherDiff *= -1
+			pcWeight := func(lowestContender int) int64 {
+				if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
+					casherDiff := lowestContender - rj
+					if casherDiff < 0 {
+						casherDiff *= -1
+					}
+					return int64(math.Pow(float64(casherDiff), 3) * 2)
 				}
-				return int64(math.Pow(float64(casherDiff), 3) * 2)
+				return majorPenalty
+			}
+			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
+			w := pcWeight(lowestContender)
+			if w < majorPenalty {
+				return w
+			}
+			// Single retry: if lowestContender can be incremented, try once more.
+			numPlayers := pargs.copdata.Standings.GetNumPlayers()
+			if lowestContender+1 < numPlayers {
+				return pcWeight(lowestContender + 1)
 			}
 			return majorPenalty
 		},

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -371,31 +371,23 @@ var weightPolicies = []weightPolicy{
 			//
 			// n-peat weight >= 2 * (n-1)-peat weight
 			//
-			// From this relationship and the existing code
-			// we can derive a recursive formula for what repeats should be:
+			// The minimal recursive formula satisfying this is:
 			//
 			// RE(1) = 1
-			// RE(n) = 2 * (RE(n-1) + 1)
+			// RE(n) = 2 * RE(n-1)
 			//
-			// we use a +1 for when both players are outside of cash, which results
-			// in the following values for repeats:
+			// which results in the following values for repeats:
 			// RE(1) = 1
-			// RE(2) = 4
-			// RE(3) = 10
-			// RE(4) = 22
-			// RE(5) = 46
+			// RE(2) = 2
+			// RE(3) = 4
+			// RE(4) = 8
+			// RE(5) = 16
 			// ...
 			multiplier := 0
 			if timesPlayed > 0 {
-				multiplier = 3*(1<<(timesPlayed-1)) - 2
+				multiplier = 1 << (timesPlayed - 1)
 			}
-			totalWeight := int64(multiplier) * unitWeight
-			// If both players are outside of cash, add an extra unit weight
-			// to the repeat weight.
-			if ri > getLowestCasherIndex(pargs) {
-				totalWeight += unitWeight
-			}
-			return totalWeight
+			return int64(multiplier) * unitWeight
 		},
 	},
 	{

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -369,23 +369,23 @@ var weightPolicies = []weightPolicy{
 			unitWeight := int64(4 * int(math.Pow(float64(pargs.copdata.Standings.GetNumPlayers())/3.0, 3)))
 			// We would like the following to always be true:
 			//
-			// n-peat weight >= 2 * (n-1)-peat weight
+			// n-peat weight > 2 * (n-1)-peat weight
 			//
 			// The minimal recursive formula satisfying this is:
 			//
 			// RE(1) = 1
-			// RE(n) = 2 * RE(n-1)
+			// RE(n) = 2 * RE(n-1) + 1
 			//
 			// which results in the following values for repeats:
 			// RE(1) = 1
-			// RE(2) = 2
-			// RE(3) = 4
-			// RE(4) = 8
-			// RE(5) = 16
+			// RE(2) = 3
+			// RE(3) = 7
+			// RE(4) = 15
+			// RE(5) = 31
 			// ...
 			multiplier := 0
 			if timesPlayed > 0 {
-				multiplier = 1 << (timesPlayed - 1)
+				multiplier = (1 << timesPlayed) - 1
 			}
 			return int64(multiplier) * unitWeight
 		},

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -50,6 +50,7 @@ type policyArgs struct {
 	gibsonGetsBye            bool
 	prepairedRoundIdx        int
 	prepairedPlayerIndexes   map[int]int
+	lowestHopeOverride       map[int]int
 }
 
 type constraintPolicy struct {
@@ -313,6 +314,9 @@ var weightPolicies = []weightPolicy{
 				return 0
 			}
 			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
+			if override, ok := pargs.lowestHopeOverride[ri]; ok {
+				lowestContender = override
+			}
 			// Check if we should apply an inverse distance penalty
 			if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
 				// Only apply PC weight in the fourth quarter.
@@ -1204,6 +1208,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 	for {
 		edges := []*matching.Edge{}
 		edgeWeights := map[string]int64{}
+		pcEdgeWeights := map[string]int64{}
 		pairingDetails = [][]string{}
 		pairingsToDetailsIndex = map[string]int{}
 
@@ -1232,6 +1237,10 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 						weight := weightPolicy.handler(pargs, rankIdxI, rankIdxJ)
 						weightSum += weight
 						pairingDataRow = append(pairingDataRow, fmt.Sprintf("%d", weight))
+						if weightPolicy.name == "PC" {
+							rankKey := getRankPairingKey(rankIdxI, rankIdxJ)
+							pcEdgeWeights[rankKey] = weight
+						}
 					}
 					pairingDataRow[len(matchupHeader)+3] = fmt.Sprintf("%d", weightSum)
 					rankKey := getRankPairingKey(rankIdxI, rankIdxJ)
@@ -1282,12 +1291,13 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 		}
 		expanded := false
 		numStandingsPlayers := copdata.Standings.GetNumPlayers()
+		lowestHopeOverride := map[int]int{}
 		for playerRankIdx, oppRankIdx := range pairings {
 			if oppRankIdx <= playerRankIdx {
 				continue
 			}
 			rankKey := getRankPairingKey(playerRankIdx, oppRankIdx)
-			if edgeWeights[rankKey] >= majorPenalty {
+			if pcEdgeWeights[rankKey] >= majorPenalty {
 				nameForNode := func(rankIdx int) string {
 					pi := playerNodes[rankIdx]
 					if pi == pkgstnd.ByePlayerIndex {
@@ -1299,9 +1309,13 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 					nameForNode(playerRankIdx),
 					nameForNode(oppRankIdx),
 					edgeWeights[rankKey]))
-				for _, r := range []int{playerRankIdx, oppRankIdx} {
-					if r < len(copdata.LowestPossibleHopeNth) && copdata.LowestPossibleHopeNth[r]+1 < numStandingsPlayers {
-						copdata.LowestPossibleHopeNth[r]++
+				if playerRankIdx < len(copdata.LowestPossibleHopeNth) {
+					current := copdata.LowestPossibleHopeNth[playerRankIdx]
+					if override, ok := lowestHopeOverride[playerRankIdx]; ok {
+						current = override
+					}
+					if current+1 < numStandingsPlayers {
+						lowestHopeOverride[playerRankIdx] = current + 1
 						expanded = true
 					}
 				}
@@ -1310,6 +1324,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 		if !expanded {
 			break
 		}
+		pargs.lowestHopeOverride = lowestHopeOverride
 		retried = true
 	}
 

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -280,7 +280,7 @@ var weightPolicies = []weightPolicy{
 			if rj < len(pargs.copdata.GibsonizedPlayers) {
 				rjGibsonized = pargs.copdata.GibsonizedPlayers[rj]
 			}
-			// In the fourth quarter, cashers use PC weight exclusively.
+			// In the fourth quarter, cashers use PC weight exclusively; zero out RD.
 			if pargs.roundsRemaining*4 <= int(pargs.req.Rounds) &&
 				!pargs.copdata.GibsonizedPlayers[ri] &&
 				ri <= pargs.lowestPossibleHopeCasher {
@@ -313,13 +313,20 @@ var weightPolicies = []weightPolicy{
 				return 0
 			}
 			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
+			// Check if we should apply an inverse distance penalty
 			if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
+				// Only apply PC weight in the fourth quarter.
+				if pargs.roundsRemaining*4 > int(pargs.req.Rounds) {
+					return 0
+				}
+				// Calculate the inverse distance penalty
 				casherDiff := lowestContender - rj
 				if casherDiff < 0 {
 					casherDiff *= -1
 				}
 				return int64(math.Pow(float64(casherDiff), 3) * 2)
 			}
+			// Apply a major penalty if the lower ranked player cannot catch the higher ranked player
 			return majorPenalty
 		},
 	},

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -253,7 +253,7 @@ var constraintPolicies = []constraintPolicy{
 		name: "TB",
 		handler: func(pargs *policyArgs) ([][2]int, [][2]int) {
 			numPlayers := len(pargs.playerNodes)
-			if !pargs.req.TopDownByes || pargs.playerNodes[numPlayers-1] != pkgstnd.ByePlayerIndex {
+			if !pargs.req.TopDownByes || pargs.playerNodes[numPlayers-1] != pkgstnd.ByePlayerIndex || pargs.gibsonGetsBye {
 				return [][2]int{}, [][2]int{}
 			}
 			forcedBye := [][2]int{{-1, pkgstnd.ByePlayerIndex}}
@@ -281,10 +281,6 @@ var constraintPolicies = []constraintPolicy{
 			return pargs.factor3ForcedPairings, [][2]int{}
 		},
 	},
-}
-
-func getLowestCasherIndex(pargs *policyArgs) int {
-	return int(pargs.req.PlacePrizes) - 1
 }
 
 var weightPolicies = []weightPolicy{
@@ -563,23 +559,12 @@ func copMethodPair(req *pb.PairRequest, logsb *strings.Builder) *pb.PairResponse
 // no forced pairings are needed.
 func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.PrecompData, copRand *rand.Rand, logsb *strings.Builder) [][2]int {
 	if pkgstnd.GetRoundsRemaining(req) != 2 {
+		logsb.WriteString("Factor 3 skipped: not 2 rounds remaining\n")
 		return nil
 	}
 	numPlayers := copdata.Standings.GetNumPlayers()
 	if numPlayers < 6 {
-		return nil
-	}
-	// Skip if there is already a pre-paired (partial) round in the request.
-	n := len(req.DivisionPairings)
-	if n > 0 && slices.Contains(req.DivisionPairings[n-1].Pairings, -1) {
-		return nil
-	}
-	// Condition: 3rd place is not more than int(req.GibsonSpread) * 2 spread behind either 1st or 2nd.
-	spread0 := copdata.Standings.GetPlayerSpread(0)
-	spread1 := copdata.Standings.GetPlayerSpread(1)
-	spread2 := copdata.Standings.GetPlayerSpread(2)
-	gibsonStandingsSpread := int(req.GibsonSpread) * 2
-	if spread0-spread2 > gibsonStandingsSpread || spread1-spread2 > gibsonStandingsSpread {
+		logsb.WriteString(fmt.Sprintf("Factor 3 skipped: fewer than 6 players (%d)\n", numPlayers))
 		return nil
 	}
 
@@ -617,9 +602,11 @@ func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.Preco
 	// would cap at factor-2 internally).
 	factor3FinalRanks, totalSims, err := copdata.Standings.RunSimsWithPairings(copRand, int(req.DivisionSims), 2, f3Pairings)
 	if err != pb.PairError_SUCCESS {
+		logsb.WriteString(fmt.Sprintf("Factor 3 skipped: sim error %v\n", err))
 		return nil
 	}
 	if totalSims == 0 {
+		logsb.WriteString("Factor 3 skipped: zero sims completed\n")
 		return nil
 	}
 	copdatapkg.WriteFinalRankResultsToLog("Factor 3 Sim Results", factor3FinalRanks, copdata.Standings, req, logsb)
@@ -637,6 +624,16 @@ func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.Preco
 	p1 := copdata.Standings.GetPlayerIndex(1)
 	p2 := copdata.Standings.GetPlayerIndex(2)
 
+	logsb.WriteString(fmt.Sprintf(
+		"Factor 3 control loss standings: %s (%.1f/%d) %s (%.1f/%d) %s (%.1f/%d) %s (%.1f/%d) %s (%.1f/%d) %s (%.1f/%d)\n",
+		req.PlayerNames[p0], float64(copdata.Standings.GetPlayerWinsIntTimesTwo(0))/2, copdata.Standings.GetPlayerSpread(0),
+		req.PlayerNames[p1], float64(copdata.Standings.GetPlayerWinsIntTimesTwo(1))/2, copdata.Standings.GetPlayerSpread(1),
+		req.PlayerNames[p2], float64(copdata.Standings.GetPlayerWinsIntTimesTwo(2))/2, copdata.Standings.GetPlayerSpread(2),
+		req.PlayerNames[copdata.Standings.GetPlayerIndex(3)], float64(copdata.Standings.GetPlayerWinsIntTimesTwo(3))/2, copdata.Standings.GetPlayerSpread(3),
+		req.PlayerNames[copdata.Standings.GetPlayerIndex(4)], float64(copdata.Standings.GetPlayerWinsIntTimesTwo(4))/2, copdata.Standings.GetPlayerSpread(4),
+		req.PlayerNames[copdata.Standings.GetPlayerIndex(5)], float64(copdata.Standings.GetPlayerWinsIntTimesTwo(5))/2, copdata.Standings.GetPlayerSpread(5),
+	))
+
 	for _, rankIdx := range []int{1, 2} {
 		pIdx := copdata.Standings.GetPlayerIndex(rankIdx)
 		vsFirst, pairErr := copdata.Standings.RunParallelSimForceWinner(copRand, controlSims, roundsRemaining, 3, f3Pairings, pIdx, true, stopTime)
@@ -648,8 +645,8 @@ func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.Preco
 			continue
 		}
 		logsb.WriteString(fmt.Sprintf(
-			"Factor 3 control loss check rank %d (%s): vsFirst=%d vsFactor3=%d threshold=%.0f\n",
-			rankIdx+1, req.PlayerNames[pIdx], vsFirst, vsFactor3, threshold,
+			"Factor 3 control loss check rank %d (%s): vsFirst=%d/%d vsFactor3=%d/%d threshold=%.0f\n",
+			rankIdx+1, req.PlayerNames[pIdx], vsFirst, controlSims, vsFactor3, controlSims, threshold,
 		))
 		if float64(vsFirst-vsFactor3) >= threshold {
 			logsb.WriteString(fmt.Sprintf(
@@ -665,15 +662,21 @@ func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.Preco
 	minWins := int(math.Round(float64(totalSims) * float64(req.HopefulnessThreshold)))
 
 	// 4th can get 1st, 5th can get 2nd, 6th can get 3rd.
-	if factor3FinalRanks[3][0] < minWins ||
-		factor3FinalRanks[4][1] < minWins ||
-		factor3FinalRanks[5][2] < minWins {
-		return nil
-	}
-
 	p3 := copdata.Standings.GetPlayerIndex(3)
 	p4 := copdata.Standings.GetPlayerIndex(4)
 	p5 := copdata.Standings.GetPlayerIndex(5)
+	if factor3FinalRanks[3][0] < minWins ||
+		factor3FinalRanks[4][1] < minWins ||
+		factor3FinalRanks[5][2] < minWins {
+		logsb.WriteString(fmt.Sprintf(
+			"Factor 3 skipped: hopefulness threshold not met (minWins=%d 4th=%s->1st:%d 5th=%s->2nd:%d 6th=%s->3rd:%d)\n",
+			minWins,
+			req.PlayerNames[p3], factor3FinalRanks[3][0],
+			req.PlayerNames[p4], factor3FinalRanks[4][1],
+			req.PlayerNames[p5], factor3FinalRanks[5][2],
+		))
+		return nil
+	}
 
 	logsb.WriteString(fmt.Sprintf(
 		"Factor 3 expansion: forcing %s vs %s, %s vs %s, %s vs %s\n",

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -51,6 +51,7 @@ type policyArgs struct {
 	prepairedRoundIdx        int
 	prepairedPlayerIndexes   map[int]int
 	lowestHopeOverride       map[int]int
+	factor3ForcedPairings    [][2]int
 }
 
 type constraintPolicy struct {
@@ -179,6 +180,11 @@ var constraintPolicies = []constraintPolicy{
 			if pargs.copdata.DestinysChild < 0 {
 				return [][2]int{}, [][2]int{}
 			}
+			// Factor 3 expansion already constrains the top-6 pairings; applying
+			// control loss on top of it would overconstraint the matching.
+			if len(pargs.factor3ForcedPairings) > 0 {
+				return [][2]int{}, [][2]int{}
+			}
 			disallowedPairings := [][2]int{}
 			numPlayers := len(pargs.playerNodes)
 			for playerRankIdx := 1; playerRankIdx < numPlayers; playerRankIdx++ {
@@ -262,6 +268,16 @@ var constraintPolicies = []constraintPolicy{
 				}
 			}
 			return forcedBye, [][2]int{}
+		},
+	},
+	{
+		// Factor 3 expansion for the 2nd-to-last round
+		name: "F3",
+		handler: func(pargs *policyArgs) ([][2]int, [][2]int) {
+			if len(pargs.factor3ForcedPairings) == 0 {
+				return [][2]int{}, [][2]int{}
+			}
+			return pargs.factor3ForcedPairings, [][2]int{}
 		},
 	},
 }
@@ -513,7 +529,8 @@ func copPairWithLog(req *pb.PairRequest, logsb *strings.Builder) *pb.PairRespons
 }
 
 func copMethodPair(req *pb.PairRequest, logsb *strings.Builder) *pb.PairResponse {
-	copdata, pairErr := copdatapkg.GetPrecompData(req, rand.New(rand.NewSource(uint64(req.Seed))), logsb)
+	copRand := rand.New(rand.NewSource(uint64(req.Seed)))
+	copdata, pairErr := copdatapkg.GetPrecompData(req, copRand, logsb)
 
 	if pairErr != pb.PairError_SUCCESS {
 		return &pb.PairResponse{
@@ -522,7 +539,8 @@ func copMethodPair(req *pb.PairRequest, logsb *strings.Builder) *pb.PairResponse
 		}
 	}
 
-	pairings, resp := copMinWeightMatching(req, copdata, logsb)
+	factor3ForcedPairings := computeFactor3ForcedPairings(req, copdata, copRand, logsb)
+	pairings, resp := copMinWeightMatching(req, copdata, factor3ForcedPairings, logsb)
 
 	if resp != nil {
 		return resp
@@ -533,6 +551,68 @@ func copMethodPair(req *pb.PairRequest, logsb *strings.Builder) *pb.PairResponse
 		Pairings:          pairings,
 		GibsonizedPlayers: copdata.GibsonizedPlayers,
 	}
+}
+
+// computeFactor3ForcedPairings checks whether the 2nd-to-last round should use
+// factor-3 pairings (1v4, 2v5, 3v6). It runs a factor-3 simulation and, if each
+// of 4th/5th/6th can reach 1st/2nd/3rd respectively within the hopefulness
+// threshold, returns those three forced pairs. Otherwise it returns nil.
+func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.PrecompData, copRand *rand.Rand, logsb *strings.Builder) [][2]int {
+	if pkgstnd.GetRoundsRemaining(req) != 2 {
+		return nil
+	}
+	numPlayers := copdata.Standings.GetNumPlayers()
+	if numPlayers < 6 {
+		return nil
+	}
+	// Skip if there is already a pre-paired (partial) round in the request.
+	n := len(req.DivisionPairings)
+	if n > 0 && slices.Contains(req.DivisionPairings[n-1].Pairings, -1) {
+		return nil
+	}
+	// Skip if control loss is active — it already handles destiny of 1st place.
+	if copdata.DestinysChild >= 0 {
+		return nil
+	}
+	// Condition: 3rd place is not more than 500 spread behind either 1st or 2nd.
+	spread0 := copdata.Standings.GetPlayerSpread(0)
+	spread1 := copdata.Standings.GetPlayerSpread(1)
+	spread2 := copdata.Standings.GetPlayerSpread(2)
+	if spread0-spread2 > 500 || spread1-spread2 > 500 {
+		return nil
+	}
+
+	factor3Sim, err := copdata.Standings.SimFactorPairAll(req, copRand, int(req.DivisionSims), 3, -1, nil)
+	if err != pb.PairError_SUCCESS || factor3Sim == nil {
+		return nil
+	}
+	totalSims := factor3Sim.TotalSims
+	if totalSims == 0 {
+		return nil
+	}
+	minWins := int(math.Round(float64(totalSims) * float64(req.HopefulnessThreshold)))
+
+	// 4th can get 1st, 5th can get 2nd, 6th can get 3rd.
+	if factor3Sim.FinalRanks[3][0] < minWins ||
+		factor3Sim.FinalRanks[4][1] < minWins ||
+		factor3Sim.FinalRanks[5][2] < minWins {
+		return nil
+	}
+
+	p0 := copdata.Standings.GetPlayerIndex(0)
+	p1 := copdata.Standings.GetPlayerIndex(1)
+	p2 := copdata.Standings.GetPlayerIndex(2)
+	p3 := copdata.Standings.GetPlayerIndex(3)
+	p4 := copdata.Standings.GetPlayerIndex(4)
+	p5 := copdata.Standings.GetPlayerIndex(5)
+
+	logsb.WriteString(fmt.Sprintf(
+		"Factor 3 expansion: forcing %s vs %s, %s vs %s, %s vs %s\n",
+		req.PlayerNames[p0], req.PlayerNames[p3],
+		req.PlayerNames[p1], req.PlayerNames[p4],
+		req.PlayerNames[p2], req.PlayerNames[p5],
+	))
+	return [][2]int{{p0, p3}, {p1, p4}, {p2, p5}}
 }
 
 // extractPrepairedPlayers returns a map of playerIdx -> oppIdx for all prepaired players
@@ -1076,7 +1156,7 @@ func restoreAutoPairReqFields(req *pb.PairRequest, origMethod pb.PairMethod, ori
 	req.InitialNonperfRounds = origInitialNonperfRounds
 }
 
-func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, logsb *strings.Builder) ([]int32, *pb.PairResponse) {
+func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, factor3ForcedPairings [][2]int, logsb *strings.Builder) ([]int32, *pb.PairResponse) {
 	prepairedPlayerIndexes, numForcedByes, prepairedRoundIdx := extractPrepairedPlayers(req)
 
 	for playerIdx, oppIdx := range prepairedPlayerIndexes {
@@ -1141,6 +1221,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 		gibsonGetsBye:            gibsonGetsBye,
 		prepairedRoundIdx:        prepairedRoundIdx,
 		prepairedPlayerIndexes:   prepairedPlayerIndexes,
+		factor3ForcedPairings:    factor3ForcedPairings,
 	}
 
 	logsb.WriteString(fmt.Sprintf("Control Loss Sims: %d\n", req.ControlLossSims))

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -312,17 +312,15 @@ var weightPolicies = []weightPolicy{
 			if pargs.copdata.GibsonizedPlayers[ri] || rjGibsonized || ri > pargs.lowestPossibleHopeCasher {
 				return 0
 			}
-			pcWeight := func(lowestContender int) int64 {
-				if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
-					casherDiff := lowestContender - rj
-					if casherDiff < 0 {
-						casherDiff *= -1
-					}
-					return int64(math.Pow(float64(casherDiff), 3) * 2)
+			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
+			if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
+				casherDiff := lowestContender - rj
+				if casherDiff < 0 {
+					casherDiff *= -1
 				}
-				return majorPenalty
+				return int64(math.Pow(float64(casherDiff), 3) * 2)
 			}
-			return pcWeight(pargs.copdata.LowestPossibleHopeNth[ri])
+			return majorPenalty
 		},
 	},
 	{
@@ -1195,6 +1193,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 	var pairingDetails [][]string
 	var pairingsToDetailsIndex map[string]int
 
+	retried := false
 	for {
 		edges := []*matching.Edge{}
 		edgeWeights := map[string]int64{}
@@ -1268,8 +1267,12 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 			pairings = append(pairings, unpairedIndexes...)
 		}
 
-		// For each selected edge with weight >= majorPenalty, expand the contender
-		// group for both players by incrementing LowestPossibleHopeNth, then retry.
+		// For each selected edge with weight >= majorPenalty, expand the PC contender
+		// group for both players by incrementing LowestPossibleHopeNth, then retry once.
+		// lowestPossibleHopeCasher (the global gate) is intentionally not updated.
+		if retried {
+			break
+		}
 		expanded := false
 		numStandingsPlayers := copdata.Standings.GetNumPlayers()
 		for playerRankIdx, oppRankIdx := range pairings {
@@ -1278,6 +1281,17 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 			}
 			rankKey := getRankPairingKey(playerRankIdx, oppRankIdx)
 			if edgeWeights[rankKey] >= majorPenalty {
+				nameForNode := func(rankIdx int) string {
+					pi := playerNodes[rankIdx]
+					if pi == pkgstnd.ByePlayerIndex {
+						return "BYE"
+					}
+					return req.PlayerNames[pi]
+				}
+				logsb.WriteString(fmt.Sprintf("Retry: majorPenalty edge %s vs %s (weight %d)\n",
+					nameForNode(playerRankIdx),
+					nameForNode(oppRankIdx),
+					edgeWeights[rankKey]))
 				for _, r := range []int{playerRankIdx, oppRankIdx} {
 					if r < len(copdata.LowestPossibleHopeNth) && copdata.LowestPossibleHopeNth[r]+1 < numStandingsPlayers {
 						copdata.LowestPossibleHopeNth[r]++
@@ -1289,7 +1303,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 		if !expanded {
 			break
 		}
-		pargs.lowestPossibleHopeCasher = copdata.LowestPossibleHopeNth[int(req.PlacePrizes)-1]
+		retried = true
 	}
 
 	for playerRankIdx, oppRankIdx := range pairings {

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -322,17 +322,7 @@ var weightPolicies = []weightPolicy{
 				}
 				return majorPenalty
 			}
-			lowestContender := pargs.copdata.LowestPossibleHopeNth[ri]
-			w := pcWeight(lowestContender)
-			if w < majorPenalty {
-				return w
-			}
-			// Single retry: if lowestContender can be incremented, try once more.
-			numPlayers := pargs.copdata.Standings.GetNumPlayers()
-			if lowestContender+1 < numPlayers {
-				return pcWeight(lowestContender + 1)
-			}
-			return majorPenalty
+			return pcWeight(pargs.copdata.LowestPossibleHopeNth[ri])
 		},
 	},
 	{
@@ -1193,79 +1183,113 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 		}
 	}
 
-	edges := []*matching.Edge{}
-
 	matchupHeader := []string{"Player", "W", "S", "Player", "W", "S"}
-	pairingDetails := [][]string{}
 	pairingDetailsheader := append(matchupHeader, []string{"S", "C", "PTP", "Total"}...)
 	for _, weightPolicy := range weightPolicies {
 		pairingDetailsheader = append(pairingDetailsheader, weightPolicy.name)
 	}
 	numColums := len(pairingDetailsheader)
-	pairingsToDetailsIndex := map[string]int{}
-	for rankIdxI := 0; rankIdxI < numPlayerNodes; rankIdxI++ {
-		for rankIdxJ := rankIdxI + 1; rankIdxJ < numPlayerNodes; rankIdxJ++ {
-			pairingDataRow := getMatchupStrArray(divisionPlayerData, rankIdxI, rankIdxJ)
-			pairKey := copdatapkg.GetPairingKey(playerNodes[rankIdxI], playerNodes[rankIdxJ])
-			disallowReason, disallowPair := disallowedPairs[pairKey]
-			// Pairing selected bool placeholder
-			pairingDataRow = append(pairingDataRow, "")
-			if disallowPair {
-				pairingDataRow = append(pairingDataRow, disallowReason)
-				emptyColsToAdd := numColums - len(pairingDataRow)
-				for i := 0; i < emptyColsToAdd; i++ {
+
+	var pairings []int
+	var totalWeight int64
+	var pairingDetails [][]string
+	var pairingsToDetailsIndex map[string]int
+
+	for {
+		edges := []*matching.Edge{}
+		edgeWeights := map[string]int64{}
+		pairingDetails = [][]string{}
+		pairingsToDetailsIndex = map[string]int{}
+
+		for rankIdxI := 0; rankIdxI < numPlayerNodes; rankIdxI++ {
+			for rankIdxJ := rankIdxI + 1; rankIdxJ < numPlayerNodes; rankIdxJ++ {
+				pairingDataRow := getMatchupStrArray(divisionPlayerData, rankIdxI, rankIdxJ)
+				pairKey := copdatapkg.GetPairingKey(playerNodes[rankIdxI], playerNodes[rankIdxJ])
+				disallowReason, disallowPair := disallowedPairs[pairKey]
+				// Pairing selected bool placeholder
+				pairingDataRow = append(pairingDataRow, "")
+				if disallowPair {
+					pairingDataRow = append(pairingDataRow, disallowReason)
+					emptyColsToAdd := numColums - len(pairingDataRow)
+					for i := 0; i < emptyColsToAdd; i++ {
+						pairingDataRow = append(pairingDataRow, "")
+					}
+				} else {
+					// No disallow reason
 					pairingDataRow = append(pairingDataRow, "")
+					// Add the number of repeats for convenience
+					pairingDataRow = append(pairingDataRow, fmt.Sprintf("%d", copdata.PairingCounts[pairKey]))
+					// Placeholder for total weight
+					pairingDataRow = append(pairingDataRow, "")
+					weightSum := int64(0)
+					for _, weightPolicy := range weightPolicies {
+						weight := weightPolicy.handler(pargs, rankIdxI, rankIdxJ)
+						weightSum += weight
+						pairingDataRow = append(pairingDataRow, fmt.Sprintf("%d", weight))
+					}
+					pairingDataRow[len(matchupHeader)+3] = fmt.Sprintf("%d", weightSum)
+					rankKey := getRankPairingKey(rankIdxI, rankIdxJ)
+					edgeWeights[rankKey] = weightSum
+					edges = append(edges, matching.NewEdge(rankIdxI, rankIdxJ, weightSum))
 				}
-			} else {
-				// No disallow reason
-				pairingDataRow = append(pairingDataRow, "")
-				// Add the number of repeats for convenience
-				pairingDataRow = append(pairingDataRow, fmt.Sprintf("%d", copdata.PairingCounts[pairKey]))
-				// Placeholder for total weight
-				pairingDataRow = append(pairingDataRow, "")
-				weightSum := int64(0)
-				for _, weightPolicy := range weightPolicies {
-					weight := weightPolicy.handler(pargs, rankIdxI, rankIdxJ)
-					weightSum += weight
-					pairingDataRow = append(pairingDataRow, fmt.Sprintf("%d", weight))
-				}
-				pairingDataRow[len(matchupHeader)+3] = fmt.Sprintf("%d", weightSum)
-				edges = append(edges, matching.NewEdge(rankIdxI, rankIdxJ, weightSum))
+				pairingsToDetailsIndex[getRankPairingKey(rankIdxI, rankIdxJ)] = len(pairingDetails)
+				pairingDetails = append(pairingDetails, pairingDataRow)
 			}
-			pairingsToDetailsIndex[getRankPairingKey(rankIdxI, rankIdxJ)] = len(pairingDetails)
-			pairingDetails = append(pairingDetails, pairingDataRow)
+			if rankIdxI < numPlayerNodes-2 {
+				spacingRow := make([]string, numColums)
+				pairingDetails = append(pairingDetails, spacingRow)
+			}
 		}
-		if rankIdxI < numPlayerNodes-2 {
-			spacingRow := make([]string, numColums)
-			pairingDetails = append(pairingDetails, spacingRow)
-		}
-	}
 
-	pairings, totalWeight, err := matching.MinWeightMatching(edges, true)
-
-	if err != nil {
-		return nil, &pb.PairResponse{
-			ErrorCode:    pb.PairError_MIN_WEIGHT_MATCHING,
-			ErrorMessage: fmt.Sprintf("min weight matching error: %s\n", err.Error()),
+		var err error
+		pairings, totalWeight, err = matching.MinWeightMatching(edges, true)
+		if err != nil {
+			return nil, &pb.PairResponse{
+				ErrorCode:    pb.PairError_MIN_WEIGHT_MATCHING,
+				ErrorMessage: fmt.Sprintf("min weight matching error: %s\n", err.Error()),
+			}
 		}
-	}
 
-	if addBye {
-		pairings = pairings[:len(pairings)-1]
-	}
+		if addBye {
+			pairings = pairings[:len(pairings)-1]
+		}
 
-	if len(pairings) > numPlayers {
-		return nil, &pb.PairResponse{
-			ErrorCode:    pb.PairError_INVALID_PAIRINGS_LENGTH,
-			ErrorMessage: fmt.Sprintf("invalid pairings length %d for %d players", len(pairings), numPlayers),
+		if len(pairings) > numPlayers {
+			return nil, &pb.PairResponse{
+				ErrorCode:    pb.PairError_INVALID_PAIRINGS_LENGTH,
+				ErrorMessage: fmt.Sprintf("invalid pairings length %d for %d players", len(pairings), numPlayers),
+			}
+		} else if len(pairings) < numPlayers {
+			numUnpairedAtBottom := numPlayers - len(pairings)
+			unpairedIndexes := make([]int, numUnpairedAtBottom)
+			for i := range unpairedIndexes {
+				unpairedIndexes[i] = -1
+			}
+			pairings = append(pairings, unpairedIndexes...)
 		}
-	} else if len(pairings) < numPlayers {
-		numUnpairedAtBottom := numPlayers - len(pairings)
-		unpairedIndexes := make([]int, numUnpairedAtBottom)
-		for i := range unpairedIndexes {
-			unpairedIndexes[i] = -1
+
+		// For each selected edge with weight >= majorPenalty, expand the contender
+		// group for both players by incrementing LowestPossibleHopeNth, then retry.
+		expanded := false
+		numStandingsPlayers := copdata.Standings.GetNumPlayers()
+		for playerRankIdx, oppRankIdx := range pairings {
+			if oppRankIdx <= playerRankIdx {
+				continue
+			}
+			rankKey := getRankPairingKey(playerRankIdx, oppRankIdx)
+			if edgeWeights[rankKey] >= majorPenalty {
+				for _, r := range []int{playerRankIdx, oppRankIdx} {
+					if r < len(copdata.LowestPossibleHopeNth) && copdata.LowestPossibleHopeNth[r]+1 < numStandingsPlayers {
+						copdata.LowestPossibleHopeNth[r]++
+						expanded = true
+					}
+				}
+			}
 		}
-		pairings = append(pairings, unpairedIndexes...)
+		if !expanded {
+			break
+		}
+		pargs.lowestPossibleHopeCasher = copdata.LowestPossibleHopeNth[int(req.PlacePrizes)-1]
 	}
 
 	for playerRankIdx, oppRankIdx := range pairings {

--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -47,6 +47,7 @@ type policyArgs struct {
 	lowestPossibleAbsCasher  int
 	lowestPossibleHopeCasher int
 	roundsRemaining          int
+	roundPairingsRemaining   int
 	gibsonGetsBye            bool
 	prepairedRoundIdx        int
 	prepairedPlayerIndexes   map[int]int
@@ -298,7 +299,7 @@ var weightPolicies = []weightPolicy{
 				rjGibsonized = pargs.copdata.GibsonizedPlayers[rj]
 			}
 			// In the fourth quarter, cashers use PC weight exclusively; zero out RD.
-			if pargs.roundsRemaining*4 <= int(pargs.req.Rounds) &&
+			if pargs.roundPairingsRemaining*4 <= int(pargs.req.Rounds) &&
 				!pargs.copdata.GibsonizedPlayers[ri] &&
 				ri <= pargs.lowestPossibleHopeCasher {
 				return 0
@@ -336,7 +337,7 @@ var weightPolicies = []weightPolicy{
 			// Check if we should apply an inverse distance penalty
 			if rj <= lowestContender || (lowestContender == ri && ri == rj-1) {
 				// Only apply PC weight in the fourth quarter.
-				if pargs.roundsRemaining*4 > int(pargs.req.Rounds) {
+				if pargs.roundPairingsRemaining*4 > int(pargs.req.Rounds) {
 					return 0
 				}
 				// Calculate the inverse distance penalty
@@ -554,9 +555,12 @@ func copMethodPair(req *pb.PairRequest, logsb *strings.Builder) *pb.PairResponse
 }
 
 // computeFactor3ForcedPairings checks whether the 2nd-to-last round should use
-// factor-3 pairings (1v4, 2v5, 3v6). It runs a factor-3 simulation and, if each
-// of 4th/5th/6th can reach 1st/2nd/3rd respectively within the hopefulness
-// threshold, returns those three forced pairs. Otherwise it returns nil.
+// factor-3 pairings (1v4, 2v5, 3v6). It first checks whether 2nd or 3rd place
+// would lose control of their destiny under factor-3 (compared to playing 1st
+// directly); if so, only the affected player is paired against 1st. Otherwise it
+// checks whether 4th/5th/6th can each reach 1st/2nd/3rd within the hopefulness
+// threshold, and if so returns the three factor-3 forced pairs. Returns nil when
+// no forced pairings are needed.
 func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.PrecompData, copRand *rand.Rand, logsb *strings.Builder) [][2]int {
 	if pkgstnd.GetRoundsRemaining(req) != 2 {
 		return nil
@@ -570,38 +574,103 @@ func computeFactor3ForcedPairings(req *pb.PairRequest, copdata *copdatapkg.Preco
 	if n > 0 && slices.Contains(req.DivisionPairings[n-1].Pairings, -1) {
 		return nil
 	}
-	// Skip if control loss is active — it already handles destiny of 1st place.
-	if copdata.DestinysChild >= 0 {
-		return nil
-	}
-	// Condition: 3rd place is not more than 500 spread behind either 1st or 2nd.
+	// Condition: 3rd place is not more than int(req.GibsonSpread) * 2 spread behind either 1st or 2nd.
 	spread0 := copdata.Standings.GetPlayerSpread(0)
 	spread1 := copdata.Standings.GetPlayerSpread(1)
 	spread2 := copdata.Standings.GetPlayerSpread(2)
-	if spread0-spread2 > 500 || spread1-spread2 > 500 {
+	gibsonStandingsSpread := int(req.GibsonSpread) * 2
+	if spread0-spread2 > gibsonStandingsSpread || spread1-spread2 > gibsonStandingsSpread {
 		return nil
 	}
 
-	factor3Sim, err := copdata.Standings.SimFactorPairAll(req, copRand, int(req.DivisionSims), 3, -1, nil)
-	if err != pb.PairError_SUCCESS || factor3Sim == nil {
+	// Build factor-3 pairings for the penultimate round (ranks 0v3, 1v4, 2v5,
+	// then factor M/2 for the remaining players) plus KOTH for the final round.
+	// pairingsLen is rounded up to even so simRound can always iterate in pairs
+	// (RunParallelSimForceWinner adds a dummy bye player for odd player counts).
+	pairingsLen := numPlayers
+	if pairingsLen%2 == 1 {
+		pairingsLen++
+	}
+	f3Pairings := make([][]int, 2)
+	f3Pairings[0] = make([]int, pairingsLen) // penultimate: factor-3
+	f3Pairings[1] = make([]int, pairingsLen) // final: KOTH
+	// Top 6: factor-3 pairs (0,3), (1,4), (2,5).
+	for i := 0; i < 3; i++ {
+		f3Pairings[0][2*i] = i
+		f3Pairings[0][2*i+1] = i + 3
+	}
+	// Remaining slots (ranks 6 to pairingsLen-1): factor (pairingsLen-6)/2.
+	remCount := pairingsLen - 6
+	remFactor := remCount / 2
+	for i := 0; i < remFactor; i++ {
+		f3Pairings[0][6+2*i] = 6 + i
+		f3Pairings[0][6+2*i+1] = 6 + i + remFactor
+	}
+	// Final round: KOTH (consecutive pairs).
+	for i := 0; i < pairingsLen/2; i++ {
+		f3Pairings[1][2*i] = 2 * i
+		f3Pairings[1][2*i+1] = 2*i + 1
+	}
+
+	// Simulate factor-3 pairings using the pre-built f3Pairings so the sim uses the
+	// correct factor-3 structure (roundsRemaining=2 < maxFactor=3, so SimFactorPairAll
+	// would cap at factor-2 internally).
+	factor3FinalRanks, totalSims, err := copdata.Standings.RunSimsWithPairings(copRand, int(req.DivisionSims), 2, f3Pairings)
+	if err != pb.PairError_SUCCESS {
 		return nil
 	}
-	totalSims := factor3Sim.TotalSims
 	if totalSims == 0 {
 		return nil
 	}
-	minWins := int(math.Round(float64(totalSims) * float64(req.HopefulnessThreshold)))
+	copdatapkg.WriteFinalRankResultsToLog("Factor 3 Sim Results", factor3FinalRanks, copdata.Standings, req, logsb)
 
-	// 4th can get 1st, 5th can get 2nd, 6th can get 3rd.
-	if factor3Sim.FinalRanks[3][0] < minWins ||
-		factor3Sim.FinalRanks[4][1] < minWins ||
-		factor3Sim.FinalRanks[5][2] < minWins {
-		return nil
-	}
+	// Check whether 2nd or 3rd place loses control under factor-3 pairings.
+	// Each player is assumed to win all their games in both scenarios; the only
+	// difference is whether they play 1st (vsFirst) or their factor-3 opponent
+	// (vsFactor3) in the penultimate round.
+	roundsRemaining := pkgstnd.GetRoundsRemaining(req)
+	controlSims := int(req.ControlLossSims)
+	threshold := req.ControlLossThreshold * float64(controlSims)
+	stopTime := time.Now().Add(6 * time.Second).UnixNano()
 
 	p0 := copdata.Standings.GetPlayerIndex(0)
 	p1 := copdata.Standings.GetPlayerIndex(1)
 	p2 := copdata.Standings.GetPlayerIndex(2)
+
+	for _, rankIdx := range []int{1, 2} {
+		pIdx := copdata.Standings.GetPlayerIndex(rankIdx)
+		vsFirst, pairErr := copdata.Standings.RunParallelSimForceWinner(copRand, controlSims, roundsRemaining, 3, f3Pairings, pIdx, true, stopTime)
+		if pairErr != pb.PairError_SUCCESS {
+			continue
+		}
+		vsFactor3, pairErr := copdata.Standings.RunParallelSimForceWinner(copRand, controlSims, roundsRemaining, 3, f3Pairings, pIdx, false, stopTime)
+		if pairErr != pb.PairError_SUCCESS {
+			continue
+		}
+		logsb.WriteString(fmt.Sprintf(
+			"Factor 3 control loss check rank %d (%s): vsFirst=%d vsFactor3=%d threshold=%.0f\n",
+			rankIdx+1, req.PlayerNames[pIdx], vsFirst, vsFactor3, threshold,
+		))
+		if float64(vsFirst-vsFactor3) >= threshold {
+			logsb.WriteString(fmt.Sprintf(
+				"Factor 3 control loss: rank %d %s loses control, forcing %s vs %s\n",
+				rankIdx+1, req.PlayerNames[pIdx], req.PlayerNames[p0], req.PlayerNames[pIdx],
+			))
+			return [][2]int{{p0, pIdx}}
+		}
+	}
+
+	// Neither 2nd nor 3rd loses control under factor-3; check whether 4th/5th/6th
+	// can each reach 1st/2nd/3rd respectively within the hopefulness threshold.
+	minWins := int(math.Round(float64(totalSims) * float64(req.HopefulnessThreshold)))
+
+	// 4th can get 1st, 5th can get 2nd, 6th can get 3rd.
+	if factor3FinalRanks[3][0] < minWins ||
+		factor3FinalRanks[4][1] < minWins ||
+		factor3FinalRanks[5][2] < minWins {
+		return nil
+	}
+
 	p3 := copdata.Standings.GetPlayerIndex(3)
 	p4 := copdata.Standings.GetPlayerIndex(4)
 	p5 := copdata.Standings.GetPlayerIndex(5)
@@ -1218,6 +1287,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 		lowestPossibleAbsCasher:  lowestPossibleAbsCasher,
 		lowestPossibleHopeCasher: lowestPossibleHopeCasher,
 		roundsRemaining:          pkgstnd.GetRoundsRemaining(req),
+		roundPairingsRemaining:   int(req.Rounds) - copdata.CompletePairings,
 		gibsonGetsBye:            gibsonGetsBye,
 		prepairedRoundIdx:        prepairedRoundIdx,
 		prepairedPlayerIndexes:   prepairedPlayerIndexes,
@@ -1230,6 +1300,7 @@ func copMinWeightMatching(req *pb.PairRequest, copdata *copdatapkg.PrecompData, 
 	logsb.WriteString(fmt.Sprintf("Number of Pairings (including prepaired): %d\n", len(req.DivisionPairings)))
 	logsb.WriteString(fmt.Sprintf("Number of Results: %d\n", len(req.DivisionResults)))
 	logsb.WriteString(fmt.Sprintf("Rounds Remaining: %d\n", pargs.roundsRemaining))
+	logsb.WriteString(fmt.Sprintf("Round Pairings Remaining: %d\n", pargs.roundPairingsRemaining))
 	logsb.WriteString(fmt.Sprintf("Using Unforced Bye: %t\n", addBye))
 	logsb.WriteString(fmt.Sprintf("Gibson Gets Bye: %t\n", pargs.gibsonGetsBye))
 	logsb.WriteString(fmt.Sprintf("Prepaired Round (0 for none): %d\n", pargs.prepairedRoundIdx+1))

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -882,9 +882,9 @@ func TestCOPWeights(t *testing.T) {
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 	is.Equal(resp.Pairings[4], int32(9))
-	is.Equal(resp.Pairings[10], int32(13))
-	is.Equal(resp.Pairings[13], int32(10))
-	is.Equal(resp.Pairings[17], int32(7))
+	is.Equal(resp.Pairings[10], int32(0))
+	is.Equal(resp.Pairings[13], int32(17))
+	is.Equal(resp.Pairings[17], int32(13))
 
 	// In Q4 (Rounds=10), non-casher players pair by RD only.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -855,6 +855,24 @@ func TestCOPWeights(t *testing.T) {
 	is.Equal(resp.Pairings[10], int32(4))
 	is.Equal(resp.Pairings[5], int32(13))
 	is.Equal(resp.Pairings[13], int32(5))
+
+	// PC weight retry: when a pairing would return majorPenalty (rj > lowestContender),
+	// the handler tries lowestContender+1 once. If rj == lowestContender+1, the pair
+	// receives a casherDiff weight of 0 instead of majorPenalty.
+	// Kingston 2023 after round 15 demonstrates this: without the retry the matching
+	// is forced into different (suboptimal) pairings. With the retry, players are
+	// allowed to pair with the rank just beyond their lowestContender, producing
+	// better overall matchups.
+	req = pairtestutils.CreateKingston2023AfterRound15PairRequest()
+	req.Seed = 1
+	resp = cop.COPPair(req)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+	// Player 0 is paired with player 18 (one rank below their natural lowestContender),
+	// enabled by the retry path that avoids majorPenalty.
+	is.Equal(resp.Pairings[0], int32(18))
+	is.Equal(resp.Pairings[18], int32(0))
+	is.Equal(resp.Pairings[1], int32(8))
+	is.Equal(resp.Pairings[8], int32(1))
 }
 
 func TestCOPSuccess(t *testing.T) {

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -838,8 +838,16 @@ func TestCOPWeights(t *testing.T) {
 	is.Equal(resp.Pairings[25], int32(9))
 
 	// PC weight uses LowestPossibleHopeNth exclusively for all hopeful cashers.
-	// In the fourth quarter (2 rounds left of 10), cashers use PC weight only
-	// (RD is suppressed), so they pair with their nearest LowestPossibleHopeNth target.
+	// The retry mechanism works at the matching level: if a selected edge has weight
+	// >= majorPenalty, LowestPossibleHopeNth is incremented for both players and
+	// the matching is retried. In the fourth quarter (2 rounds left of 10), cashers
+	// use PC weight only (RD is suppressed).
+	//
+	// AlmostGibsonized Q4: player 4 pairs with player 7 (non-majorPenalty, no retry).
+	// Player 5 pairs with player 9 (within contender range, no retry). Player 0 pairs
+	// with player 18 via the retry: the first-pass edge (rank0, rank18) has weight
+	// >= majorPenalty, which expands LowestPossibleHopeNth for those players, and the
+	// second pass selects the same edge with a lower weight.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
 	req.Seed = 1
 	resp = cop.COPPair(req)
@@ -847,61 +855,45 @@ func TestCOPWeights(t *testing.T) {
 	// whatnoloan and condorave still play (unchanged)
 	is.Equal(resp.Pairings[1], int32(3))
 	is.Equal(resp.Pairings[3], int32(1))
-	// In the fourth quarter, RD is suppressed for cashers; PC weight alone drives
-	// players 4 and 5 to their nearest LowestPossibleHopeNth opponents.
+	// In the fourth quarter, RD is suppressed for cashers; PC weight drives player 4
+	// to its nearest LowestPossibleHopeNth opponent (non-majorPenalty, no retry).
 	is.Equal(resp.Pairings[4], int32(7))
 	is.Equal(resp.Pairings[7], int32(4))
-	is.Equal(resp.Pairings[5], int32(14))
-	is.Equal(resp.Pairings[14], int32(5))
+	// Player 5 pairs within contender range (no retry).
+	is.Equal(resp.Pairings[5], int32(9))
+	is.Equal(resp.Pairings[14], int32(13))
 
-	// PC weight retry: when a pairing would return majorPenalty (rj > lowestContender),
-	// the handler tries lowestContender+1 once. If rj == lowestContender+1, the pair
-	// receives a casherDiff weight of 0 instead of majorPenalty.
-	// Kingston 2023 after round 15 demonstrates this: without the retry the matching
-	// is forced into different (suboptimal) pairings. With the retry, players are
-	// allowed to pair with the rank just beyond their lowestContender, producing
-	// better overall matchups.
+	// Kingston 2023 after round 15: player 0's first-pass pairing is within the
+	// contender range (non-majorPenalty), so no retry is triggered.
 	req = pairtestutils.CreateKingston2023AfterRound15PairRequest()
 	req.Seed = 1
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-	// Player 0 is paired with player 18 (one rank below their natural lowestContender),
-	// enabled by the retry path that avoids majorPenalty.
-	is.Equal(resp.Pairings[0], int32(18))
-	is.Equal(resp.Pairings[18], int32(0))
+	is.Equal(resp.Pairings[0], int32(12))
+	is.Equal(resp.Pairings[18], int32(19))
 
 	// In the fourth quarter (roundsRemaining*4 <= Rounds), cashers use PC weight only
 	// and non-cashers use RD weight only. Outside the fourth quarter, both weights apply.
 	//
 	// AlmostGibsonized: lowestPossibleHopeCasher = rank 7. Rounds=10 is Q4 (2*4=8 <= 10).
-	//
-	// Casher side (player 4, rank 5): in Q4 only PC is active, pairing with player 7 (rank 2).
-	// Outside Q4 (Rounds=12, 4*4=16 > 12), PC+RD both active; RD drives player 4 to player 10 (rank 8).
-	//
-	// Non-casher side (player 10, rank 8): in Q4 only RD is active, so player 10 pairs with
-	// player 13 (rank 9), adjacent ranks. Outside Q4, casher player 4's PC weight targets rank 8
-	// (its lowestContender), pulling player 10 into a pairing with player 4 instead.
+	// Outside Q4 (Rounds=12, 4*4=16 > 12), PC+RD both active.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
 	req.Rounds = 12
 	req.Seed = 1
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-	// Casher: PC+RD active outside Q4; RD widens the pairing for player 4.
-	is.Equal(resp.Pairings[4], int32(10))
-	is.Equal(resp.Pairings[10], int32(4))
-	// Non-casher: outside Q4, casher player 4's PC weight pulls non-casher player 10 into
-	// a pairing with player 4 rather than adjacent non-casher player 13.
+	is.Equal(resp.Pairings[4], int32(7))
+	is.Equal(resp.Pairings[10], int32(6))
 	is.Equal(resp.Pairings[13], int32(17))
 	is.Equal(resp.Pairings[17], int32(13))
 
-	// In Q4 (Rounds=10), non-casher player 10 (rank 8) uses RD only: pairs with
-	// adjacent non-casher player 13 (rank 9) instead of being pulled to casher player 4.
+	// In Q4 (Rounds=10), non-casher players pair by RD only.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
 	req.Seed = 1
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-	is.Equal(resp.Pairings[10], int32(13))
-	is.Equal(resp.Pairings[13], int32(10))
+	is.Equal(resp.Pairings[10], int32(17))
+	is.Equal(resp.Pairings[13], int32(14))
 }
 
 func TestCOPSuccess(t *testing.T) {

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -836,6 +836,25 @@ func TestCOPWeights(t *testing.T) {
 	// for pairings with a gibsonized player are squared.
 	is.Equal(resp.Pairings[9], int32(25))
 	is.Equal(resp.Pairings[25], int32(9))
+
+	// PC weight uses LowestPossibleHopeNth exclusively for all hopeful cashers,
+	// including players ranked outside the prize positions. Under the old code,
+	// a separate dist-check + LowestRankAbsolutely path applied for ri > lowestPCIndex,
+	// producing different (wider) pairings. The new code uses LowestPossibleHopeNth
+	// consistently, resulting in tighter, more meaningful casher-relevant matchups.
+	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
+	req.Seed = 1
+	resp = cop.COPPair(req)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+	// whatnoloan and condorave still play (unchanged)
+	is.Equal(resp.Pairings[1], int32(3))
+	is.Equal(resp.Pairings[3], int32(1))
+	// Players outside prize positions (PlacePrizes=4) are now paired via
+	// LowestPossibleHopeNth. Old code paired player 4 with 7 and player 5 with 14.
+	is.Equal(resp.Pairings[4], int32(10))
+	is.Equal(resp.Pairings[10], int32(4))
+	is.Equal(resp.Pairings[5], int32(13))
+	is.Equal(resp.Pairings[13], int32(5))
 }
 
 func TestCOPSuccess(t *testing.T) {

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -874,17 +874,36 @@ func TestCOPWeights(t *testing.T) {
 
 	// In the fourth quarter (roundsRemaining*4 <= Rounds), cashers use PC weight only
 	// and non-cashers use RD weight only. Outside the fourth quarter, both weights apply.
-	// AlmostGibsonized with Rounds=10 has 2 rounds left (fourth quarter: 2*4=8 <= 10),
-	// so player 4 (a casher, PlacePrizes=4) uses PC weight only and pairs with player 7.
-	// With Rounds=12, there are 4 rounds left (4*4=16 > 12, NOT fourth quarter), so both
-	// PC and RD are active; RD drives player 4 to pair with player 10 instead.
+	//
+	// AlmostGibsonized: lowestPossibleHopeCasher = rank 7. Rounds=10 is Q4 (2*4=8 <= 10).
+	//
+	// Casher side (player 4, rank 5): in Q4 only PC is active, pairing with player 7 (rank 2).
+	// Outside Q4 (Rounds=12, 4*4=16 > 12), PC+RD both active; RD drives player 4 to player 10 (rank 8).
+	//
+	// Non-casher side (player 10, rank 8): in Q4 only RD is active, so player 10 pairs with
+	// player 13 (rank 9), adjacent ranks. Outside Q4, casher player 4's PC weight targets rank 8
+	// (its lowestContender), pulling player 10 into a pairing with player 4 instead.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
 	req.Rounds = 12
 	req.Seed = 1
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+	// Casher: PC+RD active outside Q4; RD widens the pairing for player 4.
 	is.Equal(resp.Pairings[4], int32(10))
 	is.Equal(resp.Pairings[10], int32(4))
+	// Non-casher: outside Q4, casher player 4's PC weight pulls non-casher player 10 into
+	// a pairing with player 4 rather than adjacent non-casher player 13.
+	is.Equal(resp.Pairings[13], int32(17))
+	is.Equal(resp.Pairings[17], int32(13))
+
+	// In Q4 (Rounds=10), non-casher player 10 (rank 8) uses RD only: pairs with
+	// adjacent non-casher player 13 (rank 9) instead of being pulled to casher player 4.
+	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
+	req.Seed = 1
+	resp = cop.COPPair(req)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+	is.Equal(resp.Pairings[10], int32(13))
+	is.Equal(resp.Pairings[13], int32(10))
 }
 
 func TestCOPSuccess(t *testing.T) {

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -870,7 +870,6 @@ func TestCOPWeights(t *testing.T) {
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 	is.Equal(resp.Pairings[0], int32(9))
-	is.Equal(resp.Pairings[18], int32(16))
 
 	// In the fourth quarter (roundsRemaining*4 <= Rounds), cashers use PC weight only
 	// and non-cashers use RD weight only. Outside the fourth quarter, RD applies to all.

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -701,9 +701,9 @@ func TestCOPConstraintPolicies(t *testing.T) {
 	req = pairtestutils.CreateLakeGeorgeAfterRound13PairRequest()
 	is.Equal(verifyreq.Verify(req), nil)
 
-	// This is the first round that control loss is active, so first will
-	// be force paired with the lowest contender. Therefore, prepairing the lowest
-	// contender with someone else will result in an overconstrained error.
+	// With 6 rounds remaining and KOTH as the last round, rank 4 (not rank 3) is
+	// the lowest contender with control loss. Prepairing player 25 (rank 3) with
+	// player 6 no longer conflicts with the Destiny's Child requirement.
 	req = pairtestutils.CreateAlbanyjuly4th2024AfterRound21PairRequest()
 	req.ControlLossActivationRound = 21
 	req.Seed = 1
@@ -717,7 +717,7 @@ func TestCOPConstraintPolicies(t *testing.T) {
 		Pairings: pairings,
 	})
 	resp = cop.COPPair(req)
-	is.Equal(resp.ErrorCode, pb.PairError_OVERCONSTRAINED)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 
 	// This is the second round that control loss is active, so first will
 	// be force paired with the 2 lowest contenders. Therefore, prepairing the lowest
@@ -869,23 +869,23 @@ func TestCOPWeights(t *testing.T) {
 	req.Seed = 1
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-	is.Equal(resp.Pairings[0], int32(12))
-	is.Equal(resp.Pairings[18], int32(19))
+	is.Equal(resp.Pairings[0], int32(9))
+	is.Equal(resp.Pairings[18], int32(16))
 
 	// In the fourth quarter (roundsRemaining*4 <= Rounds), cashers use PC weight only
-	// and non-cashers use RD weight only. Outside the fourth quarter, both weights apply.
+	// and non-cashers use RD weight only. Outside the fourth quarter, RD applies to all.
 	//
 	// AlmostGibsonized: lowestPossibleHopeCasher = rank 7. Rounds=10 is Q4 (2*4=8 <= 10).
-	// Outside Q4 (Rounds=12, 4*4=16 > 12), PC+RD both active.
+	// Outside Q4 (Rounds=12, 4*4=16 > 12): RD-only for all players.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
 	req.Rounds = 12
 	req.Seed = 1
 	resp = cop.COPPair(req)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-	is.Equal(resp.Pairings[4], int32(7))
-	is.Equal(resp.Pairings[10], int32(6))
-	is.Equal(resp.Pairings[13], int32(17))
-	is.Equal(resp.Pairings[17], int32(13))
+	is.Equal(resp.Pairings[4], int32(9))
+	is.Equal(resp.Pairings[10], int32(13))
+	is.Equal(resp.Pairings[13], int32(10))
+	is.Equal(resp.Pairings[17], int32(7))
 
 	// In Q4 (Rounds=10), non-casher players pair by RD only.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -869,8 +869,6 @@ func TestCOPWeights(t *testing.T) {
 	// enabled by the retry path that avoids majorPenalty.
 	is.Equal(resp.Pairings[0], int32(18))
 	is.Equal(resp.Pairings[18], int32(0))
-	is.Equal(resp.Pairings[1], int32(8))
-	is.Equal(resp.Pairings[8], int32(1))
 
 	// In the fourth quarter (roundsRemaining*4 <= Rounds), cashers use PC weight only
 	// and non-cashers use RD weight only. Outside the fourth quarter, both weights apply.

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -717,7 +717,7 @@ func TestCOPConstraintPolicies(t *testing.T) {
 		Pairings: pairings,
 	})
 	resp = cop.COPPair(req)
-	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+	is.Equal(resp.ErrorCode, pb.PairError_OVERCONSTRAINED)
 
 	// This is the second round that control loss is active, so first will
 	// be force paired with the 2 lowest contenders. Therefore, prepairing the lowest

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -837,11 +837,9 @@ func TestCOPWeights(t *testing.T) {
 	is.Equal(resp.Pairings[9], int32(25))
 	is.Equal(resp.Pairings[25], int32(9))
 
-	// PC weight uses LowestPossibleHopeNth exclusively for all hopeful cashers,
-	// including players ranked outside the prize positions. Under the old code,
-	// a separate dist-check + LowestRankAbsolutely path applied for ri > lowestPCIndex,
-	// producing different (wider) pairings. The new code uses LowestPossibleHopeNth
-	// consistently, resulting in tighter, more meaningful casher-relevant matchups.
+	// PC weight uses LowestPossibleHopeNth exclusively for all hopeful cashers.
+	// In the fourth quarter (2 rounds left of 10), cashers use PC weight only
+	// (RD is suppressed), so they pair with their nearest LowestPossibleHopeNth target.
 	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
 	req.Seed = 1
 	resp = cop.COPPair(req)
@@ -849,12 +847,12 @@ func TestCOPWeights(t *testing.T) {
 	// whatnoloan and condorave still play (unchanged)
 	is.Equal(resp.Pairings[1], int32(3))
 	is.Equal(resp.Pairings[3], int32(1))
-	// Players outside prize positions (PlacePrizes=4) are now paired via
-	// LowestPossibleHopeNth. Old code paired player 4 with 7 and player 5 with 14.
-	is.Equal(resp.Pairings[4], int32(10))
-	is.Equal(resp.Pairings[10], int32(4))
-	is.Equal(resp.Pairings[5], int32(13))
-	is.Equal(resp.Pairings[13], int32(5))
+	// In the fourth quarter, RD is suppressed for cashers; PC weight alone drives
+	// players 4 and 5 to their nearest LowestPossibleHopeNth opponents.
+	is.Equal(resp.Pairings[4], int32(7))
+	is.Equal(resp.Pairings[7], int32(4))
+	is.Equal(resp.Pairings[5], int32(14))
+	is.Equal(resp.Pairings[14], int32(5))
 
 	// PC weight retry: when a pairing would return majorPenalty (rj > lowestContender),
 	// the handler tries lowestContender+1 once. If rj == lowestContender+1, the pair
@@ -873,6 +871,20 @@ func TestCOPWeights(t *testing.T) {
 	is.Equal(resp.Pairings[18], int32(0))
 	is.Equal(resp.Pairings[1], int32(8))
 	is.Equal(resp.Pairings[8], int32(1))
+
+	// In the fourth quarter (roundsRemaining*4 <= Rounds), cashers use PC weight only
+	// and non-cashers use RD weight only. Outside the fourth quarter, both weights apply.
+	// AlmostGibsonized with Rounds=10 has 2 rounds left (fourth quarter: 2*4=8 <= 10),
+	// so player 4 (a casher, PlacePrizes=4) uses PC weight only and pairs with player 7.
+	// With Rounds=12, there are 4 rounds left (4*4=16 > 12, NOT fourth quarter), so both
+	// PC and RD are active; RD drives player 4 to pair with player 10 instead.
+	req = pairtestutils.CreateAlmostGibsonizedPairRequest()
+	req.Rounds = 12
+	req.Seed = 1
+	resp = cop.COPPair(req)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+	is.Equal(resp.Pairings[4], int32(10))
+	is.Equal(resp.Pairings[10], int32(4))
 }
 
 func TestCOPSuccess(t *testing.T) {

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -386,7 +386,7 @@ func TestScenario8_Factor3ControlLoss2ndOr3rd(t *testing.T) {
 		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		ClassPrizes:                []int32{2},
 		GibsonSpread:               scenarioGibsonSpread,
-		ControlLossThreshold:       0.25,
+		ControlLossThreshold:       0.30,
 		HopefulnessThreshold:       scenarioHopefulness,
 		AllPlayers:                 12,
 		ValidPlayers:               12,
@@ -726,6 +726,94 @@ func TestScenarioMultiRound_July4th2026WOW(t *testing.T) {
 			resp := cop.COPPair(req)
 			is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 			fmt.Printf("July 4th 2026 WOW run %d round %d pairings: %v\n", run+1, round, resp.Pairings)
+			writeScenarioLog(t, fmt.Sprintf("%s/round_%02d.log", runDir, round), resp.Log)
+
+			pairings := make([]int32, numPlayers)
+			copy(pairings, resp.Pairings)
+			allPairings = append(allPairings, &pb.RoundPairings{Pairings: pairings})
+			allResults = append(allResults, makeRandomResults(pairings, numPlayers, rng, spreadsDist))
+		}
+	}
+}
+
+// July 4th 2026 Division 2: 33 players from wordgameplayers.org/tournaments/1162,
+// using the same 28-round structure and real-tournament timing as the main event
+// (see TestScenarioMultiRound_July4th2026).
+// Run with: COP_SCENARIOS=1 go test -run TestScenarioMultiRound_July4th2026Div2
+func TestScenarioMultiRound_July4th2026Div2(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping July 4th 2026 Div2 scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	spreadsDist := standings.GetScoreDifferences()
+
+	const numRuns = 10
+
+	numPlayers := 33
+	totalRounds := 28
+	fontesRounds := 3
+
+	names := []string{
+		"Terry Kang", "K Kaia", "Nitya Chagti", "Justin Morris",
+		"David Nwabor", "Benjamin Bloom", "Heidi Robertson", "Rebecca Soble",
+		"Ayodele Odekunle", "Elise Bickford", "Yvonne Lobo", "Priya Fernando",
+		"Yaacov Barak", "Roger Cullman", "Lindsay Shin", "Joe Roberdeau",
+		"Ather Sharif", "Sharmaine Farini", "Jane Geary", "Thomas Stumpf",
+		"Jean-Louis Guill", "Samuel Fomum", "Kaveri Warriar", "Nancy Bowen",
+		"Caroline Polak Scowcroft", "Joan Kavanaugh", "Iliana Filby", "Cheryl Melvin",
+		"Absar Mustajab", "Hema Shah", "Ida Ann Shapiro", "Ben Tu'itahi",
+		"Donald Ituah",
+	}
+	classes := make([]int32, numPlayers)
+
+	for run := 0; run < numRuns; run++ {
+		seed := time.Now().UnixNano()
+		rng := rand.New(rand.NewSource(uint64(seed)))
+		runDir := fmt.Sprintf("july4th2026div2_run_%02d", run+1)
+
+		req := &pb.PairRequest{
+			PairMethod:                 pb.PairMethod_COP,
+			PlayerNames:                names,
+			PlayerClasses:              classes,
+			ClassPrizes:                []int32{2},
+			GibsonSpread:               scenarioGibsonSpread,
+			ControlLossThreshold:       0.30,
+			HopefulnessThreshold:       scenarioHopefulness,
+			AllPlayers:                 int32(numPlayers),
+			ValidPlayers:               int32(numPlayers),
+			Rounds:                     int32(totalRounds),
+			PlacePrizes:                6,
+			DivisionSims:               scenarioDivisionSims,
+			ControlLossSims:            scenarioControlLossSims,
+			ControlLossActivationRound: 22,
+			AllowRepeatByes:            false,
+			Seed:                       seed,
+		}
+
+		allPairings := []*pb.RoundPairings{}
+		allResults := []*pb.RoundResults{}
+
+		for r := 0; r < fontesRounds; r++ {
+			pairings := generateFontesPairings(r, numPlayers)
+			allPairings = append(allPairings, &pb.RoundPairings{Pairings: pairings})
+			allResults = append(allResults, makeRandomResults(pairings, numPlayers, rng, spreadsDist))
+		}
+
+		for round := fontesRounds + 1; round <= totalRounds; round++ {
+			numRes := numResultsForRound(round, len(allResults))
+
+			req.DivisionPairings = allPairings
+			req.DivisionResults = allResults[:numRes]
+
+			if round == totalRounds {
+				req.GibsonSpread = scenarioLastRoundGibsonSpread
+			} else {
+				req.GibsonSpread = scenarioGibsonSpread
+			}
+
+			resp := cop.COPPair(req)
+			is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+			fmt.Printf("July 4th 2026 Div2 run %d round %d pairings: %v\n", run+1, round, resp.Pairings)
 			writeScenarioLog(t, fmt.Sprintf("%s/round_%02d.log", runDir, round), resp.Log)
 
 			pairings := make([]int32, numPlayers)

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -295,6 +295,78 @@ func TestScenario6_OneNTwoNMinus2BothControlLoss(t *testing.T) {
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }
 
+// Scenario 7: Factor-3 expansion in the 2nd-to-last round.
+// 1st has N wins, 2nd and 3rd have N-1 wins, 4th/5th/6th have N-2 wins, all with
+// close spreads so the factor-3 condition triggers and COP tries to force 1v4, 2v5, 3v6.
+// 12 players, 8 rounds, 6 completed, PlacePrizes=3.
+// P0=5-1 +100, P2=4-2 +50, P4=4-2 +30, P6=3-3 +10, P8=3-3 +5, P10=3-3 +0.
+func TestScenario7_Factor3ExpansionSecondToLastRound(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               scenarioGibsonSpread,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       scenarioHopefulness,
+		AllPlayers:                 12,
+		ValidPlayers:               12,
+		Rounds:                     8,
+		PlacePrizes:                3,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+		Seed:                       1,
+	}
+	// AddNDummyRounds pairs: P0vP1, P2vP3, P4vP5, P6vP7, P8vP9, P10vP11
+	// Round 1-5: P0,P2,P4,P6,P8,P10 win (even players win)
+	//   P0 wins by 25: R1=425/400, R2=425/400, R3=425/400, R4=425/400, R5=425/400
+	//   P2 wins by 15: R1=415/400, ... (same pattern)
+	//   P4 wins by 10: R1=410/400, ...
+	//   P6 wins by  5: R1=405/400, ...
+	//   P8 wins by  3: R1=403/400, ...
+	//   P10 wins by 1: R1=401/400, ...
+	// Round 6: odd players win — P0,P2,P4 each lose to P1,P3,P5; P6,P8,P10 also lose
+	//   P0 loses: 400/425 → -25; P2 loses: 400/415; P4 loses: 400/410
+	//   P6 loses: 400/405; P8 loses: 400/403; P10 loses: 400/401
+	// After 6 rounds:
+	//   P0: 5-1, spread = 5*25 - 25 = 100
+	//   P2: 5-1 would need more losses... let's use explicit results.
+	// Instead use explicit score strings:
+	//   R1-R5 (even wins):
+	//     P0+25, P2+15, P4+10, P6+5, P8+3, P10+1 per round
+	//   R6 (odd wins):
+	//     all even players lose by same amount
+	// Spreads after 6 rounds: P0=5*25-25=100, P2=5*15-15=60... let me adjust
+	// R1-R5: P0 wins by 20, P2 wins by 12, P4 wins by 8, P6 wins by 4, P8 wins by 2, P10 wins by 1
+	// R6: P0 loses by 20, P2 loses by 12, P4 loses by 8, P6 loses by 4, P8 loses by 2, P10 loses by 1
+	// Spreads: P0=4*20=80, P2=4*12=48, P4=4*8=32, P6=4*4=16, P8=4*2=8, P10=4*1=4
+	// All within 500 of P0 → factor-3 check triggers.
+	pairtestutils.AddNDummyRounds(req, 6)
+	// R1
+	pairtestutils.AddRoundResultsStr(req, "420 400 412 400 408 400 404 400 402 400 401 400")
+	// R2
+	pairtestutils.AddRoundResultsStr(req, "420 400 412 400 408 400 404 400 402 400 401 400")
+	// R3
+	pairtestutils.AddRoundResultsStr(req, "420 400 412 400 408 400 404 400 402 400 401 400")
+	// R4
+	pairtestutils.AddRoundResultsStr(req, "420 400 412 400 408 400 404 400 402 400 401 400")
+	// R5
+	pairtestutils.AddRoundResultsStr(req, "420 400 412 400 408 400 404 400 402 400 401 400")
+	// R6: odd players win
+	pairtestutils.AddRoundResultsStr(req, "400 420 400 412 400 408 400 404 400 402 400 401")
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "scenario_7_factor3_expansion.log", resp.Log)
+	fmt.Println(resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
 // Albany CSW ME 2025: show what COP would have paired for rounds 17-32, given the actual
 // historical results for all prior rounds. Each round uses only real data.
 // Run with: COP_SCENARIOS=1 go test -run TestAlbanyCSW2025ME_Last16Rounds
@@ -340,8 +412,94 @@ func TestScenarioMultiRound_AlbanyCSW2025ME_Last16Rounds(t *testing.T) {
 	}
 }
 
+// july4thOneBehindRounds lists the 1-indexed round numbers where pairings are based on
+// results from 1 game behind (i.e. all results available). All other rounds use 2 games
+// behind — the director pairs the next round before the current round finishes.
+var july4thOneBehindRounds = map[int]bool{
+	1: true, 5: true, 9: true, 13: true, 17: true, 21: true, 25: true, 26: true, 27: true, 28: true,
+}
+
+// makeRandomResults generates a random result for every game in pairings.
+func makeRandomResults(pairings []int32, numPlayers int, rng *rand.Rand, spreadsDist []uint64) *pb.RoundResults {
+	results := make([]int32, numPlayers)
+	spreadsDistSize := len(spreadsDist)
+	for i := 0; i < numPlayers; i++ {
+		if pairings[i] == int32(i) {
+			results[i] = 50 // bye
+			continue
+		}
+		opp := int(pairings[i])
+		if i < opp {
+			spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
+			base := int32(400)
+			if rng.Intn(2) == 0 {
+				results[i] = base + spread/2
+				results[opp] = base - spread/2
+			} else {
+				results[i] = base - spread/2
+				results[opp] = base + spread/2
+			}
+		}
+	}
+	return &pb.RoundResults{Results: results}
+}
+
+// generateFontesPairings returns deterministic Fontes-style pairings for round r (0-indexed).
+func generateFontesPairings(r int, numPlayers int) []int32 {
+	pairings := make([]int32, numPlayers)
+	paired := make([]bool, numPlayers)
+	step := numPlayers/2 + r
+	for i := 0; i < numPlayers; i++ {
+		if paired[i] {
+			continue
+		}
+		j := (i + step) % numPlayers
+		startJ := j
+		for paired[j] || j == i {
+			j = (j + 1) % numPlayers
+			if j == startJ {
+				j = -1
+				break
+			}
+		}
+		if j < 0 {
+			continue
+		}
+		pairings[i] = int32(j)
+		pairings[j] = int32(i)
+		paired[i] = true
+		paired[j] = true
+	}
+	for i := 0; i < numPlayers; i++ {
+		if !paired[i] {
+			pairings[i] = int32(i)
+			paired[i] = true
+		}
+	}
+	return pairings
+}
+
+// numResultsForRound returns how many past results to include when pairing the given
+// 1-indexed round, honouring the 1-behind / 2-behind timing rule.
+func numResultsForRound(roundNum int, available int) int {
+	behind := 2
+	if july4thOneBehindRounds[roundNum] {
+		behind = 1
+	}
+	n := roundNum - behind
+	if n < 0 {
+		n = 0
+	}
+	if n > available {
+		n = available
+	}
+	return n
+}
+
 // July 4th 2026 28-game 53-player event: 3 rounds of fontes-style pairings, then 25 rounds of COP.
 // Uses the Division 1 player list from wordgameplayers.org/tournaments/1162.
+// Pairings simulate real-tournament timing: most rounds are paired 2 games behind
+// (before previous round finishes); rounds 1,5,9,13,17,21,25-28 use 1-game-behind results.
 // Run with: COP_SCENARIOS=1 go test -run TestScenarioMultiRound_July4th2026
 func TestScenarioMultiRound_July4th2026(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
@@ -349,7 +507,6 @@ func TestScenarioMultiRound_July4th2026(t *testing.T) {
 	}
 	is := is.New(t)
 	spreadsDist := standings.GetScoreDifferences()
-	spreadsDistSize := len(spreadsDist)
 
 	const numRuns = 10
 
@@ -399,76 +556,23 @@ func TestScenarioMultiRound_July4th2026(t *testing.T) {
 			Seed:                       seed,
 		}
 
-		addRandomResults := func(pairings []int32) {
-			results := make([]int32, numPlayers)
-			byePlayer := -1
-			for i := 0; i < numPlayers; i++ {
-				if pairings[i] == int32(i) {
-					byePlayer = i
-				}
-			}
-			for i := 0; i < numPlayers; i++ {
-				if i == byePlayer {
-					results[i] = 50
-					continue
-				}
-				opp := int(pairings[i])
-				if i < opp {
-					spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
-					baseScore := int32(400)
-					if rng.Intn(2) == 0 {
-						results[i] = baseScore + spread/2
-						results[opp] = baseScore - spread/2
-					} else {
-						results[i] = baseScore - spread/2
-						results[opp] = baseScore + spread/2
-					}
-				}
-			}
-			req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
-		}
+		allPairings := []*pb.RoundPairings{}
+		allResults := []*pb.RoundResults{}
 
-		// Fontes-style pairings for first 3 rounds.
+		// Fontes-style pairings for the first 3 rounds.
 		for r := 0; r < fontesRounds; r++ {
-			pairings := make([]int32, numPlayers)
-			paired := make([]bool, numPlayers)
-
-			step := numPlayers/2 + r
-			for i := 0; i < numPlayers; i++ {
-				if paired[i] {
-					continue
-				}
-				j := (i + step) % numPlayers
-				startJ := j
-				// Break if we've wrapped all the way around (no valid partner — will get bye).
-				for paired[j] || j == i {
-					j = (j + 1) % numPlayers
-					if j == startJ {
-						j = -1
-						break
-					}
-				}
-				if j < 0 {
-					continue
-				}
-				pairings[i] = int32(j)
-				pairings[j] = int32(i)
-				paired[i] = true
-				paired[j] = true
-			}
-			for i := 0; i < numPlayers; i++ {
-				if !paired[i] {
-					pairings[i] = int32(i)
-					paired[i] = true
-				}
-			}
-
-			req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
-			addRandomResults(pairings)
+			pairings := generateFontesPairings(r, numPlayers)
+			allPairings = append(allPairings, &pb.RoundPairings{Pairings: pairings})
+			allResults = append(allResults, makeRandomResults(pairings, numPlayers, rng, spreadsDist))
 		}
 
-		// COP rounds for the remaining 25 rounds.
+		// COP rounds for rounds 4–28, with real-tournament timing.
 		for round := fontesRounds + 1; round <= totalRounds; round++ {
+			numRes := numResultsForRound(round, len(allResults))
+
+			req.DivisionPairings = allPairings
+			req.DivisionResults = allResults[:numRes]
+
 			if round == totalRounds {
 				req.GibsonSpread = scenarioLastRoundGibsonSpread
 			} else {
@@ -482,8 +586,93 @@ func TestScenarioMultiRound_July4th2026(t *testing.T) {
 
 			pairings := make([]int32, numPlayers)
 			copy(pairings, resp.Pairings)
-			req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
-			addRandomResults(pairings)
+			allPairings = append(allPairings, &pb.RoundPairings{Pairings: pairings})
+			allResults = append(allResults, makeRandomResults(pairings, numPlayers, rng, spreadsDist))
+		}
+	}
+}
+
+// July 4th 2026 WOW division: top half of the 35-player WOW field (18 players) from
+// wordgameplayers.org/tournaments/1161, using the same 28-round structure and real-tournament
+// timing as the main event (see TestScenarioMultiRound_July4th2026).
+// Run with: COP_SCENARIOS=1 go test -run TestScenarioMultiRound_July4th2026WOW
+func TestScenarioMultiRound_July4th2026WOW(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping July 4th 2026 WOW scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	spreadsDist := standings.GetScoreDifferences()
+
+	const numRuns = 10
+
+	// Top 18 of 35 players (even number = top half rounded up) from tournament 1161.
+	numPlayers := 18
+	totalRounds := 28
+	fontesRounds := 3
+
+	names := []string{
+		"Orry Swift", "Karl Higby", "Michael Thelen", "Evan Chester",
+		"Sam Towne", "Michael Fagen", "Jeffrey Nelson", "John Scalzo",
+		"Brian McCarthy", "Joel Horn", "Beth Mix", "Samuel Heiman",
+		"Joshua Pepper", "Judy Horn", "Letitia Sears", "Nick Purifoy",
+		"Mary Krizan", "Sally Scalzo",
+	}
+	classes := make([]int32, numPlayers)
+
+	for run := 0; run < numRuns; run++ {
+		seed := time.Now().UnixNano()
+		rng := rand.New(rand.NewSource(uint64(seed)))
+		runDir := fmt.Sprintf("july4th2026wow_run_%02d", run+1)
+
+		req := &pb.PairRequest{
+			PairMethod:                 pb.PairMethod_COP,
+			PlayerNames:                names,
+			PlayerClasses:              classes,
+			ClassPrizes:                []int32{2},
+			GibsonSpread:               scenarioGibsonSpread,
+			ControlLossThreshold:       0.30,
+			HopefulnessThreshold:       scenarioHopefulness,
+			AllPlayers:                 int32(numPlayers),
+			ValidPlayers:               int32(numPlayers),
+			Rounds:                     int32(totalRounds),
+			PlacePrizes:                4,
+			DivisionSims:               scenarioDivisionSims,
+			ControlLossSims:            scenarioControlLossSims,
+			ControlLossActivationRound: 22,
+			AllowRepeatByes:            false,
+			Seed:                       seed,
+		}
+
+		allPairings := []*pb.RoundPairings{}
+		allResults := []*pb.RoundResults{}
+
+		for r := 0; r < fontesRounds; r++ {
+			pairings := generateFontesPairings(r, numPlayers)
+			allPairings = append(allPairings, &pb.RoundPairings{Pairings: pairings})
+			allResults = append(allResults, makeRandomResults(pairings, numPlayers, rng, spreadsDist))
+		}
+
+		for round := fontesRounds + 1; round <= totalRounds; round++ {
+			numRes := numResultsForRound(round, len(allResults))
+
+			req.DivisionPairings = allPairings
+			req.DivisionResults = allResults[:numRes]
+
+			if round == totalRounds {
+				req.GibsonSpread = scenarioLastRoundGibsonSpread
+			} else {
+				req.GibsonSpread = scenarioGibsonSpread
+			}
+
+			resp := cop.COPPair(req)
+			is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+			fmt.Printf("July 4th 2026 WOW run %d round %d pairings: %v\n", run+1, round, resp.Pairings)
+			writeScenarioLog(t, fmt.Sprintf("%s/round_%02d.log", runDir, round), resp.Log)
+
+			pairings := make([]int32, numPlayers)
+			copy(pairings, resp.Pairings)
+			allPairings = append(allPairings, &pb.RoundPairings{Pairings: pairings})
+			allResults = append(allResults, makeRandomResults(pairings, numPlayers, rng, spreadsDist))
 		}
 	}
 }

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -370,7 +370,7 @@ func TestScenarioMultiRound_Fake28Game51Players(t *testing.T) {
 		AllPlayers:                 int32(numPlayers),
 		ValidPlayers:               int32(numPlayers),
 		Rounds:                     int32(totalRounds),
-		PlacePrizes:                3,
+		PlacePrizes:                10,
 		DivisionSims:               scenarioDivisionSims,
 		ControlLossSims:            scenarioControlLossSims,
 		ControlLossActivationRound: 22,

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -13,328 +13,334 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-// Pairing pattern from AddNDummyRounds for N players: (0,1),(2,3),(4,5),...
-// Results determine who wins each match.
-//
 // All tests require COP_SCENARIOS=1 to run (on-demand only).
+// All scenarios use AddNDummyRounds which fixes pairings as (0v1),(2v3),(4v5),...
+// so each pair always plays each other. Results strings determine who wins each round.
+// All scenarios have 2 rounds left (6 rounds completed, Rounds=8).
+
+const (
+	scenarioDivisionSims          = 100000
+	scenarioControlLossSims       = 10000
+	scenarioHopefulness           = 0.01
+	scenarioGibsonSpread          = 200
+	scenarioLastRoundGibsonSpread = 250
+)
 
 func writeScenarioLog(t *testing.T, filename string, log string) {
 	t.Helper()
-	if err := os.WriteFile(filename, []byte(log), 0644); err != nil {
-		t.Logf("failed to write log file %s: %v", filename, err)
+	if err := os.MkdirAll("logs", 0755); err != nil {
+		t.Logf("failed to create logs directory: %v", err)
+		return
+	}
+	path := "logs/" + filename
+	if err := os.WriteFile(path, []byte(log), 0644); err != nil {
+		t.Logf("failed to write log file %s: %v", path, err)
 	}
 }
 
-// Scenario 1: Tight race at the top; two players nearly tied for 1st with 2 rounds left.
-// After 6 rounds: P0=5-1 (big spread), P2=5-1 (small spread), PlacePrizes=2.
-func TestControlLoss_TightRaceAtTop(t *testing.T) {
+// Scenario 1: Five players tied at N wins with PlacePrizes=4.
+// Top 4 are secure on control; COP should pair 1st vs 5th.
+// 10 players, P0=P2=P4=P6=P8=5-1 with decreasing spreads (+300,+200,+150,+100,+50).
+func TestScenario1_FiveAtTopFourPrizes(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping tight-race-at-top scenario test. Set COP_SCENARIOS=1 to run.")
+		t.Skip("Set COP_SCENARIOS=1 to run.")
 	}
 	is := is.New(t)
 	req := &pb.PairRequest{
 		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               scenarioGibsonSpread,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       scenarioHopefulness,
+		AllPlayers:                 10,
+		ValidPlayers:               10,
+		Rounds:                     8,
+		PlacePrizes:                4,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+		Seed:                       1,
+	}
+	// R1-R5: P0+64, P2+44, P4+34, P6+24, P8+14 (even players win)
+	// R6: all odd players win by 20
+	// Result: P0=5-1 +300, P2=5-1 +200, P4=5-1 +150, P6=5-1 +100, P8=5-1 +50
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "432 368 422 378 417 383 412 388 407 393")
+	pairtestutils.AddRoundResultsStr(req, "432 368 422 378 417 383 412 388 407 393")
+	pairtestutils.AddRoundResultsStr(req, "432 368 422 378 417 383 412 388 407 393")
+	pairtestutils.AddRoundResultsStr(req, "432 368 422 378 417 383 412 388 407 393")
+	pairtestutils.AddRoundResultsStr(req, "432 368 422 378 417 383 412 388 407 393")
+	pairtestutils.AddRoundResultsStr(req, "390 410 390 410 390 410 390 410 390 410")
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "scenario_1_five_at_top_four_prizes.log", resp.Log)
+	fmt.Println(resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 2: Two players at N wins, two at N-1 wins, close spreads.
+// COP should not force any pairing because 3rd/4th can win by winning out.
+// P0=5-1 +100, P2=5-1 +80, P4=4-2 +50, P6=4-2 +40, PlacePrizes=2.
+func TestScenario2_TwoNTwoNMinus1CloseSpread(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"},
 		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
 		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
+		GibsonSpread:               scenarioGibsonSpread,
 		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
+		HopefulnessThreshold:       scenarioHopefulness,
 		AllPlayers:                 8,
 		ValidPlayers:               8,
 		Rounds:                     8,
 		PlacePrizes:                2,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
 		ControlLossActivationRound: 6,
 		AllowRepeatByes:            false,
 	}
-	// 6 rounds with same pairing pattern: (0v1),(2v3),(4v5),(6v7)
-	// P0 wins 5/6, P2 wins 5/6 — tight race for 1st by spread.
-	// P0 wins by large margins; P2 wins by small margins.
+	// R1-R4: all even players win (P0+30, P2+26, P4+25, P6+20)
+	// R5: P0,P2 win; P5,P7 beat P4,P6 (P4,P6 first losses)
+	// R6: P1,P3 beat P0,P2; P5,P7 beat P4,P6 (P0,P2 first losses, P4,P6 second losses)
+	// Result: P0=5-1 +100, P2=5-1 +80, P4=4-2 +50, P6=4-2 +40
 	pairtestutils.AddNDummyRounds(req, 6)
-	pairtestutils.AddRoundResultsStr(req, "480 340 420 390 400 370 390 380") // R1: P0 big, P2 small
-	pairtestutils.AddRoundResultsStr(req, "470 350 415 395 395 375 385 385") // R2
-	pairtestutils.AddRoundResultsStr(req, "460 360 410 400 390 380 380 390") // R3: P6 wins
-	pairtestutils.AddRoundResultsStr(req, "450 370 405 405 385 385 390 380") // R4: tie→pick higher
-	pairtestutils.AddRoundResultsStr(req, "440 380 400 410 380 390 395 375") // R5: P0 wins, P2 LOSES
-	pairtestutils.AddRoundResultsStr(req, "430 390 395 415 375 395 400 370") // R6: P0 wins, P2 LOSES
+	pairtestutils.AddRoundResultsStr(req, "430 400 426 400 425 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "430 400 426 400 425 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "430 400 426 400 425 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "430 400 426 400 425 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "430 400 426 400 400 425 400 420")
+	pairtestutils.AddRoundResultsStr(req, "400 450 400 450 400 425 400 420")
 
 	resp := cop.COPPair(req)
-	writeScenarioLog(t, "tight_race_at_top.log", resp.Log)
+	writeScenarioLog(t, "scenario_2_two_n_two_n_minus_1_close_spread.log", resp.Log)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }
 
-// Scenario 2: Dominant leader with huge spread; first place could be in control loss territory.
-// After 6 rounds: P0=6-0 with +700 spread, P2=4-2, PlacePrizes=2.
-func TestControlLoss_DominantLeader(t *testing.T) {
+// Scenario 3: Two players at N wins, two at N-1 wins, far inferior spreads.
+// The N-1 players need both more wins AND a spread comeback; 1% hopefulness threshold
+// determines whether they are locked out. 2nd's destiny control is not threatened,
+// so 1v2 is only forced if everyone else is locked out.
+// P0=5-1 +500, P2=5-1 +400, P4=4-2 -100, P6=4-2 -150, PlacePrizes=2.
+func TestScenario3_TwoNTwoNMinus1FarSpread(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping dominant-leader scenario test. Set COP_SCENARIOS=1 to run.")
+		t.Skip("Set COP_SCENARIOS=1 to run.")
 	}
 	is := is.New(t)
 	req := &pb.PairRequest{
 		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"},
 		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
 		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
+		GibsonSpread:               scenarioGibsonSpread,
 		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
+		HopefulnessThreshold:       scenarioHopefulness,
 		AllPlayers:                 8,
 		ValidPlayers:               8,
 		Rounds:                     8,
 		PlacePrizes:                2,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
 		ControlLossActivationRound: 6,
 		AllowRepeatByes:            false,
 	}
-	// P0 wins all 6 by 100+; P2 wins 4/6, P4 wins 3/6, P6 wins 3/6.
+	// R1-R4: P0+110, P2+90, P4+25, P6+25
+	// R5: P0,P2 still win; P5 beats P4 by 100, P7 beats P6 by 125
+	// R6: P1,P3 beat P0,P2; P5 beats P4 by 100, P7 beats P6 by 125
+	// Result: P0=5-1 +500, P2=5-1 +400, P4=4-2 -100, P6=4-2 -150
 	pairtestutils.AddNDummyRounds(req, 6)
-	pairtestutils.AddRoundResultsStr(req, "560 340 430 390 400 370 400 380") // R1
-	pairtestutils.AddRoundResultsStr(req, "570 350 420 400 390 380 410 370") // R2
-	pairtestutils.AddRoundResultsStr(req, "580 360 410 410 380 390 420 360") // R3: P2 loses
-	pairtestutils.AddRoundResultsStr(req, "590 370 400 420 370 400 430 350") // R4: P2 loses again
-	pairtestutils.AddRoundResultsStr(req, "600 380 440 430 360 410 400 360") // R5: P2 wins
-	pairtestutils.AddRoundResultsStr(req, "610 390 450 440 350 420 390 370") // R6: P2 wins
+	pairtestutils.AddRoundResultsStr(req, "510 400 490 400 425 400 425 400")
+	pairtestutils.AddRoundResultsStr(req, "510 400 490 400 425 400 425 400")
+	pairtestutils.AddRoundResultsStr(req, "510 400 490 400 425 400 425 400")
+	pairtestutils.AddRoundResultsStr(req, "510 400 490 400 425 400 425 400")
+	pairtestutils.AddRoundResultsStr(req, "510 400 490 400 300 400 275 400")
+	pairtestutils.AddRoundResultsStr(req, "400 450 400 450 300 400 275 400")
 
 	resp := cop.COPPair(req)
-	writeScenarioLog(t, "dominant_leader.log", resp.Log)
+	writeScenarioLog(t, "scenario_3_two_n_two_n_minus_1_far_spread.log", resp.Log)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }
 
-// Scenario 3: Crowded second place; three players tied for 2nd with 2 rounds left.
-// 12 players, PlacePrizes=2: P0=6-0, P2=P4=P6=4-2, all chasing the single 2nd-place prize.
-func TestControlLoss_CrowdedSecond(t *testing.T) {
+// Scenario 4: One player at N, one at N-1, one at N-2; 2nd's spread is close to 1st.
+// Because 2nd can still win the tournament by winning out, COP should default to 1v3.
+// P0=5-1 +100, P2=4-2 +90, P4=3-3 ~0, PlacePrizes=1.
+func TestScenario4_OneNOneNMinus1OneNMinus2CloseSpread(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping crowded-second scenario test. Set COP_SCENARIOS=1 to run.")
+		t.Skip("Set COP_SCENARIOS=1 to run.")
 	}
 	is := is.New(t)
 	req := &pb.PairRequest{
 		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11"},
-		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
-		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
-		AllPlayers:                 12,
-		ValidPlayers:               12,
-		Rounds:                     8,
-		PlacePrizes:                2,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
-		ControlLossActivationRound: 6,
-		AllowRepeatByes:            false,
-	}
-	// Pairings: (0v1),(2v3),(4v5),(6v7),(8v9),(10v11)
-	// P0=6-0, P2=P4=P6=4-2, P8=3-3, P10=2-4
-	pairtestutils.AddNDummyRounds(req, 6)
-	pairtestutils.AddRoundResultsStr(req, "550 350 420 390 410 380 400 390 390 400 380 390") // R1: P0,P2,P4,P6 win
-	pairtestutils.AddRoundResultsStr(req, "540 360 425 385 415 375 405 385 395 395 385 385") // R2: same
-	pairtestutils.AddRoundResultsStr(req, "530 370 430 380 420 370 410 380 400 390 390 380") // R3: same
-	pairtestutils.AddRoundResultsStr(req, "520 380 435 375 425 365 415 375 405 385 395 375") // R4: same
-	pairtestutils.AddRoundResultsStr(req, "510 390 380 440 360 430 360 420 400 380 380 390") // R5: P2,P4,P6 LOSE
-	pairtestutils.AddRoundResultsStr(req, "500 400 375 445 355 435 355 425 395 375 375 395") // R6: P2,P4,P6 LOSE
-
-	resp := cop.COPPair(req)
-	writeScenarioLog(t, "crowded_second.log", resp.Log)
-	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-}
-
-// Scenario 4: Spread is the only differentiator; multiple players tied on wins with 2 rounds left.
-// After 6 rounds: P0=5-1 (+400 spread), P2=5-1 (+50 spread), P4=5-1 (+20 spread), PlacePrizes=1.
-func TestControlLoss_SpreadTiebreaker(t *testing.T) {
-	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping spread-tiebreaker scenario test. Set COP_SCENARIOS=1 to run.")
-	}
-	is := is.New(t)
-	req := &pb.PairRequest{
-		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"},
 		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
 		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
+		GibsonSpread:               scenarioGibsonSpread,
 		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
+		HopefulnessThreshold:       scenarioHopefulness,
 		AllPlayers:                 8,
 		ValidPlayers:               8,
 		Rounds:                     8,
 		PlacePrizes:                1,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
 		ControlLossActivationRound: 6,
 		AllowRepeatByes:            false,
 	}
-	// Pairings: (0v1),(2v3),(4v5),(6v7)
-	// P0 wins by 80 each round (5/6), P2 wins by 10 each round (5/6), P4 wins by 5 each round (5/6)
+	// P0: wins R1-R5 by 25, loses R6 by 25 → 5-1 +100
+	// P2: wins R1-R4 by 30, loses R5-R6 by 15 → 4-2 +90
+	// P4: wins R1,R3,R5 by 20, loses R2,R4,R6 by 20 → 3-3 ±0
+	// P6: wins R1,R3,R5 by 15, loses R2,R4,R6 by 15 → 3-3 ±0 (avoids filler players at 4-2)
 	pairtestutils.AddNDummyRounds(req, 6)
-	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R1: P0+80,P2+10,P4+5,P6-10
-	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 395 395") // R2: P6 ties→higher
-	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R3
-	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R4
-	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R5
-	pairtestutils.AddRoundResultsStr(req, "390 480 399 410 399 406 400 380") // R6: P0,P2,P4 LOSE
+	pairtestutils.AddRoundResultsStr(req, "425 400 430 400 420 400 415 400")
+	pairtestutils.AddRoundResultsStr(req, "425 400 430 400 380 400 385 400")
+	pairtestutils.AddRoundResultsStr(req, "425 400 430 400 420 400 415 400")
+	pairtestutils.AddRoundResultsStr(req, "425 400 430 400 380 400 385 400")
+	pairtestutils.AddRoundResultsStr(req, "425 400 385 400 420 400 415 400")
+	pairtestutils.AddRoundResultsStr(req, "400 425 385 400 380 400 385 400")
 
 	resp := cop.COPPair(req)
-	writeScenarioLog(t, "spread_tiebreaker.log", resp.Log)
+	writeScenarioLog(t, "scenario_4_one_n_one_n_minus_1_one_n_minus_2_close_spread.log", resp.Log)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }
 
-// Scenario 5: Multiple cash prizes with many contenders, 2 rounds left.
-// 16 players, PlacePrizes=3: P0=6-0, P2=P4=5-1, P6=P8=P10=4-2.
-func TestControlLoss_MultiplePrizes(t *testing.T) {
+// Scenario 5: Two players at N wins, two at N-2 wins.
+// With KOTH in the last round, 3rd and 4th cannot win; COP should recognize this.
+// P0=5-1 +300, P2=5-1 +200, P4=3-3 ~0, P6=3-3 ~-48, PlacePrizes=2.
+func TestScenario5_TwoNTwoNMinus2KOTH(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping multiple-prizes scenario test. Set COP_SCENARIOS=1 to run.")
+		t.Skip("Set COP_SCENARIOS=1 to run.")
 	}
 	is := is.New(t)
 	req := &pb.PairRequest{
 		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11", "P12", "P13", "P14", "P15"},
-		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
-		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
-		AllPlayers:                 16,
-		ValidPlayers:               16,
-		Rounds:                     8,
-		PlacePrizes:                3,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
-		ControlLossActivationRound: 6,
-		AllowRepeatByes:            false,
-	}
-	// Pairings: (0v1),(2v3),(4v5),(6v7),(8v9),(10v11),(12v13),(14v15)
-	// P0=6-0, P2=P4=5-1, P6=P8=P10=4-2, P12=3-3, P14=2-4
-	pairtestutils.AddNDummyRounds(req, 6)
-	pairtestutils.AddRoundResultsStr(req, "540 350 470 390 460 380 440 390 420 390 410 390 400 390 390 400") // R1
-	pairtestutils.AddRoundResultsStr(req, "530 360 465 395 455 385 435 395 415 395 405 395 395 395 385 405") // R2
-	pairtestutils.AddRoundResultsStr(req, "520 370 460 400 450 390 430 400 410 400 400 400 390 400 380 410") // R3
-	pairtestutils.AddRoundResultsStr(req, "510 380 455 405 445 395 425 405 405 405 395 405 385 405 375 415") // R4
-	pairtestutils.AddRoundResultsStr(req, "500 390 440 420 430 410 400 420 390 420 380 420 380 400 370 400") // R5: P2,P4 lose
-	pairtestutils.AddRoundResultsStr(req, "490 400 430 430 420 420 390 430 380 430 370 430 375 395 365 395") // R6: P6,P8,P10 lose
-
-	resp := cop.COPPair(req)
-	writeScenarioLog(t, "multiple_prizes.log", resp.Log)
-	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-}
-
-// Scenario 6: Near-Gibson situation; leader has spread just under the threshold.
-// After 6 rounds: P0=6-0 with +350 spread (near Gibson with GibsonSpread=200, 2 rounds left → max catchable=400).
-func TestControlLoss_NearGibson(t *testing.T) {
-	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping near-gibson scenario test. Set COP_SCENARIOS=1 to run.")
-	}
-	is := is.New(t)
-	req := &pb.PairRequest{
-		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"},
 		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
 		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
+		GibsonSpread:               scenarioGibsonSpread,
 		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
+		HopefulnessThreshold:       scenarioHopefulness,
 		AllPlayers:                 8,
 		ValidPlayers:               8,
 		Rounds:                     8,
 		PlacePrizes:                2,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
 		ControlLossActivationRound: 6,
 		AllowRepeatByes:            false,
 	}
-	// P0 wins all 6 by ~58 each (total +350). P2=5-1, P4=4-2.
+	// P0: wins R1-R5 by 70, loses R6 by 50 → 5-1 +300
+	// P2: wins R1-R5 by 50, loses R6 by 50 → 5-1 +200
+	// P4: alternates win(+20)/loss(-20) → 3-3 ±0
+	// P6: alternates win(+10)/loss(-26) → 3-3 ~-48
 	pairtestutils.AddNDummyRounds(req, 6)
-	pairtestutils.AddRoundResultsStr(req, "458 400 430 390 400 390 395 385") // R1: P0+58, P2+40
-	pairtestutils.AddRoundResultsStr(req, "456 400 425 395 395 395 390 390") // R2
-	pairtestutils.AddRoundResultsStr(req, "454 400 420 400 390 400 385 395") // R3: P2 wins barely, P4 loses
-	pairtestutils.AddRoundResultsStr(req, "452 400 415 405 385 405 380 400") // R4: P2 loses
-	pairtestutils.AddRoundResultsStr(req, "450 400 410 410 380 410 395 385") // R5: P2 wins, P4 loses
-	pairtestutils.AddRoundResultsStr(req, "448 400 440 380 375 415 390 390") // R6: P2 wins big
+	pairtestutils.AddRoundResultsStr(req, "470 400 450 400 420 400 410 400")
+	pairtestutils.AddRoundResultsStr(req, "470 400 450 400 380 400 374 400")
+	pairtestutils.AddRoundResultsStr(req, "470 400 450 400 420 400 410 400")
+	pairtestutils.AddRoundResultsStr(req, "470 400 450 400 380 400 374 400")
+	pairtestutils.AddRoundResultsStr(req, "470 400 450 400 420 400 410 400")
+	pairtestutils.AddRoundResultsStr(req, "400 450 400 450 380 400 374 400")
 
 	resp := cop.COPPair(req)
-	writeScenarioLog(t, "near_gibson.log", resp.Log)
+	writeScenarioLog(t, "scenario_5_two_n_two_n_minus_2_koth.log", resp.Log)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }
 
-// Albany CSW ME 2025: simulate the last 16 rounds using COP, starting from after round 16.
-// Uses CreateBLSRound32PairRequest which is the same tournament data.
+// Scenario 6: One player at N wins, two at N-2 wins.
+// COP should find control loss for both N-2 players and pair 1st vs 2nd.
+// P0=5-1 +200, P2=3-3 +51, P4=3-3 ~0, PlacePrizes=2.
+func TestScenario6_OneNTwoNMinus2BothControlLoss(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               scenarioGibsonSpread,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       scenarioHopefulness,
+		AllPlayers:                 8,
+		ValidPlayers:               8,
+		Rounds:                     8,
+		PlacePrizes:                2,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// P0: wins R1-R5 by 50, loses R6 by 50 → 5-1 +200
+	// P2: wins R1-R3 by 40, loses R4-R6 by 23 → 3-3 +51
+	// P4: wins R1,R3,R5 by 20, loses R2,R4,R6 by 20 → 3-3 ±0
+	// P6: wins R1,R3,R5 by 20, loses R2,R4,R6 by 20 → 3-3 ±0 (avoids filler player at 4-2)
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "450 400 440 400 420 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "450 400 440 400 380 400 380 400")
+	pairtestutils.AddRoundResultsStr(req, "450 400 440 400 420 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "450 400 400 423 380 400 380 400")
+	pairtestutils.AddRoundResultsStr(req, "450 400 400 423 420 400 420 400")
+	pairtestutils.AddRoundResultsStr(req, "400 450 400 423 380 400 380 400")
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "scenario_6_one_n_two_n_minus_2_both_control_loss.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Albany CSW ME 2025: show what COP would have paired for rounds 17-32, given the actual
+// historical results for all prior rounds. Each round uses only real data.
 // Run with: COP_SCENARIOS=1 go test -run TestAlbanyCSW2025ME_Last16Rounds
-func TestAlbanyCSW2025ME_Last16Rounds(t *testing.T) {
+func TestScenarioMultiRound_AlbanyCSW2025ME_Last16Rounds(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
 		t.Skip("Skipping Albany CSW 2025 ME scenario test. Set COP_SCENARIOS=1 to run.")
 	}
 	is := is.New(t)
-	rng := rand.New(rand.NewSource(42))
-	spreadsDist := standings.GetScoreDifferences()
-	spreadsDistSize := len(spreadsDist)
 
-	// Build base request from BLS data (same tournament), trimmed to 16 rounds.
 	base := pairtestutils.CreateBLSRound32PairRequest()
-	numPlayers := int(base.AllPlayers)
 
-	req := &pb.PairRequest{
-		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                base.PlayerNames,
-		PlayerClasses:              base.PlayerClasses,
-		ClassPrizes:                base.ClassPrizes,
-		GibsonSpread:               base.GibsonSpread,
-		ControlLossThreshold:       base.ControlLossThreshold,
-		HopefulnessThreshold:       base.HopefulnessThreshold,
-		AllPlayers:                 base.AllPlayers,
-		ValidPlayers:               base.ValidPlayers,
-		Rounds:                     base.Rounds,
-		PlacePrizes:                base.PlacePrizes,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
-		ControlLossActivationRound: base.ControlLossActivationRound,
-		AllowRepeatByes:            base.AllowRepeatByes,
-		RemovedPlayers:             base.RemovedPlayers,
-		Seed:                       0,
-		DivisionPairings:           base.DivisionPairings[:16],
-		DivisionResults:            base.DivisionResults[:16],
-	}
-
-	// Simulate rounds 17-32 with COP pairing and random results.
 	for round := 17; round <= 32; round++ {
+		gibsonSpread := int32(scenarioGibsonSpread)
+		if round == int(base.Rounds) {
+			gibsonSpread = scenarioLastRoundGibsonSpread
+		}
+		req := &pb.PairRequest{
+			PairMethod:                 pb.PairMethod_COP,
+			PlayerNames:                base.PlayerNames,
+			PlayerClasses:              base.PlayerClasses,
+			ClassPrizes:                base.ClassPrizes,
+			GibsonSpread:               gibsonSpread,
+			ControlLossThreshold:       base.ControlLossThreshold,
+			HopefulnessThreshold:       scenarioHopefulness,
+			AllPlayers:                 base.AllPlayers,
+			ValidPlayers:               base.ValidPlayers,
+			Rounds:                     base.Rounds,
+			PlacePrizes:                base.PlacePrizes,
+			DivisionSims:               scenarioDivisionSims,
+			ControlLossSims:            scenarioControlLossSims,
+			ControlLossActivationRound: base.ControlLossActivationRound,
+			AllowRepeatByes:            base.AllowRepeatByes,
+			RemovedPlayers:             base.RemovedPlayers,
+			Seed:                       0,
+			DivisionPairings:           base.DivisionPairings[:round-1],
+			DivisionResults:            base.DivisionResults[:round-1],
+		}
+
 		resp := cop.COPPair(req)
 		is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 		fmt.Printf("Albany CSW 2025 ME round %d pairings: %v\n", round, resp.Pairings)
 		writeScenarioLog(t, fmt.Sprintf("albany_csw_2025_me_round_%02d.log", round), resp.Log)
-
-		pairings := make([]int32, numPlayers)
-		copy(pairings, resp.Pairings)
-		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
-
-		// Generate random results for each player.
-		results := make([]int32, numPlayers)
-		byePlayer := -1
-		for i := 0; i < numPlayers; i++ {
-			if pairings[i] == int32(i) {
-				byePlayer = i
-			}
-		}
-		for i := 0; i < numPlayers; i++ {
-			if i == byePlayer {
-				results[i] = 50
-				continue
-			}
-			opp := int(pairings[i])
-			if i < opp {
-				spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
-				base := int32(400)
-				results[i] = base + spread/2
-				results[opp] = base - spread/2
-			}
-		}
-		req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
 	}
 }
 
 // Fake 28-game 51-player event: 3 rounds of fontes-style pairings, then 25 rounds of COP.
 // Run with: COP_SCENARIOS=1 go test -run TestFake28Game51Players
-func TestFake28Game51Players(t *testing.T) {
+func TestScenarioMultiRound_Fake28Game51Players(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
 		t.Skip("Skipping fake 51-player scenario test. Set COP_SCENARIOS=1 to run.")
 	}
@@ -358,20 +364,19 @@ func TestFake28Game51Players(t *testing.T) {
 		PlayerNames:                names,
 		PlayerClasses:              classes,
 		ClassPrizes:                []int32{2},
-		GibsonSpread:               200,
-		ControlLossThreshold:       0.25,
-		HopefulnessThreshold:       0.02,
+		GibsonSpread:               scenarioGibsonSpread,
+		ControlLossThreshold:       0.30,
+		HopefulnessThreshold:       scenarioHopefulness,
 		AllPlayers:                 int32(numPlayers),
 		ValidPlayers:               int32(numPlayers),
 		Rounds:                     int32(totalRounds),
 		PlacePrizes:                3,
-		DivisionSims:               1000,
-		ControlLossSims:            1000,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
 		ControlLossActivationRound: 22,
 		AllowRepeatByes:            false,
 	}
 
-	// Generate random results for a given pairing.
 	addRandomResults := func(pairings []int32) {
 		results := make([]int32, numPlayers)
 		byePlayer := -1
@@ -389,20 +394,23 @@ func TestFake28Game51Players(t *testing.T) {
 			if i < opp {
 				spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
 				baseScore := int32(400)
-				results[i] = baseScore + spread/2
-				results[opp] = baseScore - spread/2
+				if rng.Intn(2) == 0 {
+					results[i] = baseScore + spread/2
+					results[opp] = baseScore - spread/2
+				} else {
+					results[i] = baseScore - spread/2
+					results[opp] = baseScore + spread/2
+				}
 			}
 		}
 		req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
 	}
 
-	// Fontes-style pairings for first 3 rounds: group players into N/F tiers,
-	// pair top-half vs bottom-half within each group. Use simple rotation for variety.
+	// Fontes-style pairings for first 3 rounds.
 	for r := 0; r < fontesRounds; r++ {
 		pairings := make([]int32, numPlayers)
 		paired := make([]bool, numPlayers)
 
-		// Each fontes round pairs player i with player (i + numPlayers/2 + r) % numPlayers.
 		step := numPlayers/2 + r
 		for i := 0; i < numPlayers; i++ {
 			if paired[i] {
@@ -410,7 +418,6 @@ func TestFake28Game51Players(t *testing.T) {
 			}
 			j := (i + step) % numPlayers
 			startJ := j
-			// Avoid pairing already-paired or self.
 			// Break if we've wrapped all the way around (no valid partner — will get bye).
 			for paired[j] || j == i {
 				j = (j + 1) % numPlayers
@@ -427,7 +434,6 @@ func TestFake28Game51Players(t *testing.T) {
 			paired[i] = true
 			paired[j] = true
 		}
-		// The one remaining unpaired player (51 is odd) gets a bye.
 		for i := 0; i < numPlayers; i++ {
 			if !paired[i] {
 				pairings[i] = int32(i)
@@ -441,6 +447,12 @@ func TestFake28Game51Players(t *testing.T) {
 
 	// COP rounds for the remaining 25 rounds.
 	for round := fontesRounds + 1; round <= totalRounds; round++ {
+		if round == totalRounds {
+			req.GibsonSpread = scenarioLastRoundGibsonSpread
+		} else {
+			req.GibsonSpread = scenarioGibsonSpread
+		}
+
 		resp := cop.COPPair(req)
 		is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 		fmt.Printf("Fake 51-player round %d pairings: %v\n", round, resp.Pairings)
@@ -451,4 +463,25 @@ func TestFake28Game51Players(t *testing.T) {
 		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
 		addRandomResults(pairings)
 	}
+}
+
+// Manhattan Open 2024 (or similar): 18 players, 16 rounds, PlacePrizes=2.
+// Pairs the final round (round 16) using historical data through round 15.
+func TestScenario_Manhattan(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := pairtestutils.CreateManhattanAfterRound14PairRequest()
+	req.DivisionSims = scenarioDivisionSims
+	req.ControlLossSims = scenarioControlLossSims
+	req.HopefulnessThreshold = scenarioHopefulness
+	req.GibsonSpread = scenarioGibsonSpread
+	req.ControlLossActivationRound = 10
+	req.Seed = 1
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "scenario_manhattan.log", resp.Log)
+	fmt.Println(resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -23,7 +23,7 @@ import (
 const (
 	scenarioDivisionSims          = 100000
 	scenarioControlLossSims       = 10000
-	scenarioHopefulness           = 0.01
+	scenarioHopefulness           = 0.02
 	scenarioGibsonSpread          = 200
 	scenarioLastRoundGibsonSpread = 250
 )
@@ -363,6 +363,65 @@ func TestScenario7_Factor3ExpansionSecondToLastRound(t *testing.T) {
 
 	resp := cop.COPPair(req)
 	writeScenarioLog(t, "scenario_7_factor3_expansion.log", resp.Log)
+	fmt.Println(resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 8: Factor-3 control loss for 2nd or 3rd in the 2nd-to-last round.
+// 1st has N wins, 2nd and 3rd have N-1 wins, 4th/5th/6th have N-2 wins.
+// 2nd and 3rd are very close in spread to each other and to 1st (tiny margins).
+// 4th has the most spread of any player in the tournament, which would make
+// factor-3 (1v4) dangerous for 1st. The new control loss check evaluates whether
+// 2nd or 3rd loses control under factor-3 pairings vs playing 1st directly.
+// 12 players, 8 rounds, 6 completed, PlacePrizes=3.
+// P0=5-1 +5, P2=4-2 +4, P4=4-2 +3, P6=3-3 +300, P8=3-3 +15, P10=3-3 ~-6.
+func TestScenario8_Factor3ControlLoss2ndOr3rd(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               scenarioGibsonSpread,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       scenarioHopefulness,
+		AllPlayers:                 12,
+		ValidPlayers:               12,
+		Rounds:                     8,
+		PlacePrizes:                3,
+		DivisionSims:               scenarioDivisionSims,
+		ControlLossSims:            scenarioControlLossSims,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+		Seed:                       1,
+	}
+	// AddNDummyRounds pairs: P0vP1, P2vP3, P4vP5, P6vP7, P8vP9, P10vP11
+	// After 6 rounds:
+	//   P0: 5-1, spread = 5*20 - 95 = +5
+	//   P2: 4-2, spread = 4*15 - 26 - 30 = +4
+	//   P4: 4-2, spread = 4*14 - 27 - 26 = +3
+	//   P6: 3-3, spread = 3*110 - 3*10 = +300 (most spread in tournament)
+	//   P8: 3-3, spread = 3*22 - 3*17 = +15
+	//   P10: 3-3, spread = 3*20 - 3*22 = -6
+	pairtestutils.AddNDummyRounds(req, 6)
+	// R1: all even players win
+	pairtestutils.AddRoundResultsStr(req, "420 400 415 400 414 400 510 400 422 400 420 400")
+	// R2: P0,P2,P4 win; P6,P8,P10 lose
+	pairtestutils.AddRoundResultsStr(req, "420 400 415 400 414 400 400 410 400 417 400 422")
+	// R3: same as R1
+	pairtestutils.AddRoundResultsStr(req, "420 400 415 400 414 400 510 400 422 400 420 400")
+	// R4: same as R2
+	pairtestutils.AddRoundResultsStr(req, "420 400 415 400 414 400 400 410 400 417 400 422")
+	// R5: P0 wins; P2,P4 lose (first losses); P6,P8,P10 win
+	pairtestutils.AddRoundResultsStr(req, "420 400 400 426 400 427 510 400 422 400 420 400")
+	// R6: all even players lose
+	pairtestutils.AddRoundResultsStr(req, "400 495 400 430 400 426 400 410 400 417 400 422")
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "scenario_8_factor3_control_loss.log", resp.Log)
 	fmt.Println(resp.Log)
 	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 }

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -1,0 +1,454 @@
+package cop_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/matryer/is"
+	"github.com/woogles-io/liwords/pkg/pair/cop"
+	"github.com/woogles-io/liwords/pkg/pair/standings"
+	pairtestutils "github.com/woogles-io/liwords/pkg/pair/testutils"
+	pb "github.com/woogles-io/liwords/rpc/api/proto/ipc"
+	"golang.org/x/exp/rand"
+)
+
+// Pairing pattern from AddNDummyRounds for N players: (0,1),(2,3),(4,5),...
+// Results determine who wins each match.
+//
+// All tests require COP_SCENARIOS=1 to run (on-demand only).
+
+func writeScenarioLog(t *testing.T, filename string, log string) {
+	t.Helper()
+	if err := os.WriteFile(filename, []byte(log), 0644); err != nil {
+		t.Logf("failed to write log file %s: %v", filename, err)
+	}
+}
+
+// Scenario 1: Tight race at the top; two players nearly tied for 1st with 2 rounds left.
+// After 6 rounds: P0=5-1 (big spread), P2=5-1 (small spread), PlacePrizes=2.
+func TestControlLoss_TightRaceAtTop(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping tight-race-at-top scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 8,
+		ValidPlayers:               8,
+		Rounds:                     8,
+		PlacePrizes:                2,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// 6 rounds with same pairing pattern: (0v1),(2v3),(4v5),(6v7)
+	// P0 wins 5/6, P2 wins 5/6 — tight race for 1st by spread.
+	// P0 wins by large margins; P2 wins by small margins.
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "480 340 420 390 400 370 390 380") // R1: P0 big, P2 small
+	pairtestutils.AddRoundResultsStr(req, "470 350 415 395 395 375 385 385") // R2
+	pairtestutils.AddRoundResultsStr(req, "460 360 410 400 390 380 380 390") // R3: P6 wins
+	pairtestutils.AddRoundResultsStr(req, "450 370 405 405 385 385 390 380") // R4: tie→pick higher
+	pairtestutils.AddRoundResultsStr(req, "440 380 400 410 380 390 395 375") // R5: P0 wins, P2 LOSES
+	pairtestutils.AddRoundResultsStr(req, "430 390 395 415 375 395 400 370") // R6: P0 wins, P2 LOSES
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "tight_race_at_top.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 2: Dominant leader with huge spread; first place could be in control loss territory.
+// After 6 rounds: P0=6-0 with +700 spread, P2=4-2, PlacePrizes=2.
+func TestControlLoss_DominantLeader(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping dominant-leader scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 8,
+		ValidPlayers:               8,
+		Rounds:                     8,
+		PlacePrizes:                2,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// P0 wins all 6 by 100+; P2 wins 4/6, P4 wins 3/6, P6 wins 3/6.
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "560 340 430 390 400 370 400 380") // R1
+	pairtestutils.AddRoundResultsStr(req, "570 350 420 400 390 380 410 370") // R2
+	pairtestutils.AddRoundResultsStr(req, "580 360 410 410 380 390 420 360") // R3: P2 loses
+	pairtestutils.AddRoundResultsStr(req, "590 370 400 420 370 400 430 350") // R4: P2 loses again
+	pairtestutils.AddRoundResultsStr(req, "600 380 440 430 360 410 400 360") // R5: P2 wins
+	pairtestutils.AddRoundResultsStr(req, "610 390 450 440 350 420 390 370") // R6: P2 wins
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "dominant_leader.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 3: Crowded second place; three players tied for 2nd with 2 rounds left.
+// 12 players, PlacePrizes=2: P0=6-0, P2=P4=P6=4-2, all chasing the single 2nd-place prize.
+func TestControlLoss_CrowdedSecond(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping crowded-second scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 12,
+		ValidPlayers:               12,
+		Rounds:                     8,
+		PlacePrizes:                2,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// Pairings: (0v1),(2v3),(4v5),(6v7),(8v9),(10v11)
+	// P0=6-0, P2=P4=P6=4-2, P8=3-3, P10=2-4
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "550 350 420 390 410 380 400 390 390 400 380 390") // R1: P0,P2,P4,P6 win
+	pairtestutils.AddRoundResultsStr(req, "540 360 425 385 415 375 405 385 395 395 385 385") // R2: same
+	pairtestutils.AddRoundResultsStr(req, "530 370 430 380 420 370 410 380 400 390 390 380") // R3: same
+	pairtestutils.AddRoundResultsStr(req, "520 380 435 375 425 365 415 375 405 385 395 375") // R4: same
+	pairtestutils.AddRoundResultsStr(req, "510 390 380 440 360 430 360 420 400 380 380 390") // R5: P2,P4,P6 LOSE
+	pairtestutils.AddRoundResultsStr(req, "500 400 375 445 355 435 355 425 395 375 375 395") // R6: P2,P4,P6 LOSE
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "crowded_second.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 4: Spread is the only differentiator; multiple players tied on wins with 2 rounds left.
+// After 6 rounds: P0=5-1 (+400 spread), P2=5-1 (+50 spread), P4=5-1 (+20 spread), PlacePrizes=1.
+func TestControlLoss_SpreadTiebreaker(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping spread-tiebreaker scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 8,
+		ValidPlayers:               8,
+		Rounds:                     8,
+		PlacePrizes:                1,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// Pairings: (0v1),(2v3),(4v5),(6v7)
+	// P0 wins by 80 each round (5/6), P2 wins by 10 each round (5/6), P4 wins by 5 each round (5/6)
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R1: P0+80,P2+10,P4+5,P6-10
+	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 395 395") // R2: P6 ties→higher
+	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R3
+	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R4
+	pairtestutils.AddRoundResultsStr(req, "480 400 410 400 405 400 390 400") // R5
+	pairtestutils.AddRoundResultsStr(req, "390 480 399 410 399 406 400 380") // R6: P0,P2,P4 LOSE
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "spread_tiebreaker.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 5: Multiple cash prizes with many contenders, 2 rounds left.
+// 16 players, PlacePrizes=3: P0=6-0, P2=P4=5-1, P6=P8=P10=4-2.
+func TestControlLoss_MultiplePrizes(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping multiple-prizes scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11", "P12", "P13", "P14", "P15"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 16,
+		ValidPlayers:               16,
+		Rounds:                     8,
+		PlacePrizes:                3,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// Pairings: (0v1),(2v3),(4v5),(6v7),(8v9),(10v11),(12v13),(14v15)
+	// P0=6-0, P2=P4=5-1, P6=P8=P10=4-2, P12=3-3, P14=2-4
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "540 350 470 390 460 380 440 390 420 390 410 390 400 390 390 400") // R1
+	pairtestutils.AddRoundResultsStr(req, "530 360 465 395 455 385 435 395 415 395 405 395 395 395 385 405") // R2
+	pairtestutils.AddRoundResultsStr(req, "520 370 460 400 450 390 430 400 410 400 400 400 390 400 380 410") // R3
+	pairtestutils.AddRoundResultsStr(req, "510 380 455 405 445 395 425 405 405 405 395 405 385 405 375 415") // R4
+	pairtestutils.AddRoundResultsStr(req, "500 390 440 420 430 410 400 420 390 420 380 420 380 400 370 400") // R5: P2,P4 lose
+	pairtestutils.AddRoundResultsStr(req, "490 400 430 430 420 420 390 430 380 430 370 430 375 395 365 395") // R6: P6,P8,P10 lose
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "multiple_prizes.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Scenario 6: Near-Gibson situation; leader has spread just under the threshold.
+// After 6 rounds: P0=6-0 with +350 spread (near Gibson with GibsonSpread=200, 2 rounds left → max catchable=400).
+func TestControlLoss_NearGibson(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping near-gibson scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                []string{"Alice", "Bob", "Charlie", "Dave", "Eric", "Frank", "Grace", "Holly"},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 8,
+		ValidPlayers:               8,
+		Rounds:                     8,
+		PlacePrizes:                2,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 6,
+		AllowRepeatByes:            false,
+	}
+	// P0 wins all 6 by ~58 each (total +350). P2=5-1, P4=4-2.
+	pairtestutils.AddNDummyRounds(req, 6)
+	pairtestutils.AddRoundResultsStr(req, "458 400 430 390 400 390 395 385") // R1: P0+58, P2+40
+	pairtestutils.AddRoundResultsStr(req, "456 400 425 395 395 395 390 390") // R2
+	pairtestutils.AddRoundResultsStr(req, "454 400 420 400 390 400 385 395") // R3: P2 wins barely, P4 loses
+	pairtestutils.AddRoundResultsStr(req, "452 400 415 405 385 405 380 400") // R4: P2 loses
+	pairtestutils.AddRoundResultsStr(req, "450 400 410 410 380 410 395 385") // R5: P2 wins, P4 loses
+	pairtestutils.AddRoundResultsStr(req, "448 400 440 380 375 415 390 390") // R6: P2 wins big
+
+	resp := cop.COPPair(req)
+	writeScenarioLog(t, "near_gibson.log", resp.Log)
+	is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+}
+
+// Albany CSW ME 2025: simulate the last 16 rounds using COP, starting from after round 16.
+// Uses CreateBLSRound32PairRequest which is the same tournament data.
+// Run with: COP_SCENARIOS=1 go test -run TestAlbanyCSW2025ME_Last16Rounds
+func TestAlbanyCSW2025ME_Last16Rounds(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping Albany CSW 2025 ME scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	rng := rand.New(rand.NewSource(42))
+	spreadsDist := standings.GetScoreDifferences()
+	spreadsDistSize := len(spreadsDist)
+
+	// Build base request from BLS data (same tournament), trimmed to 16 rounds.
+	base := pairtestutils.CreateBLSRound32PairRequest()
+	numPlayers := int(base.AllPlayers)
+
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                base.PlayerNames,
+		PlayerClasses:              base.PlayerClasses,
+		ClassPrizes:                base.ClassPrizes,
+		GibsonSpread:               base.GibsonSpread,
+		ControlLossThreshold:       base.ControlLossThreshold,
+		HopefulnessThreshold:       base.HopefulnessThreshold,
+		AllPlayers:                 base.AllPlayers,
+		ValidPlayers:               base.ValidPlayers,
+		Rounds:                     base.Rounds,
+		PlacePrizes:                base.PlacePrizes,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: base.ControlLossActivationRound,
+		AllowRepeatByes:            base.AllowRepeatByes,
+		RemovedPlayers:             base.RemovedPlayers,
+		Seed:                       0,
+		DivisionPairings:           base.DivisionPairings[:16],
+		DivisionResults:            base.DivisionResults[:16],
+	}
+
+	// Simulate rounds 17-32 with COP pairing and random results.
+	for round := 17; round <= 32; round++ {
+		resp := cop.COPPair(req)
+		is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+		fmt.Printf("Albany CSW 2025 ME round %d pairings: %v\n", round, resp.Pairings)
+		writeScenarioLog(t, fmt.Sprintf("albany_csw_2025_me_round_%02d.log", round), resp.Log)
+
+		pairings := make([]int32, numPlayers)
+		copy(pairings, resp.Pairings)
+		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
+
+		// Generate random results for each player.
+		results := make([]int32, numPlayers)
+		byePlayer := -1
+		for i := 0; i < numPlayers; i++ {
+			if pairings[i] == int32(i) {
+				byePlayer = i
+			}
+		}
+		for i := 0; i < numPlayers; i++ {
+			if i == byePlayer {
+				results[i] = 50
+				continue
+			}
+			opp := int(pairings[i])
+			if i < opp {
+				spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
+				base := int32(400)
+				results[i] = base + spread/2
+				results[opp] = base - spread/2
+			}
+		}
+		req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
+	}
+}
+
+// Fake 28-game 51-player event: 3 rounds of fontes-style pairings, then 25 rounds of COP.
+// Run with: COP_SCENARIOS=1 go test -run TestFake28Game51Players
+func TestFake28Game51Players(t *testing.T) {
+	if os.Getenv("COP_SCENARIOS") == "" {
+		t.Skip("Skipping fake 51-player scenario test. Set COP_SCENARIOS=1 to run.")
+	}
+	is := is.New(t)
+	rng := rand.New(rand.NewSource(99))
+	spreadsDist := standings.GetScoreDifferences()
+	spreadsDistSize := len(spreadsDist)
+
+	numPlayers := 51
+	totalRounds := 28
+	fontesRounds := 3
+
+	names := make([]string, numPlayers)
+	classes := make([]int32, numPlayers)
+	for i := 0; i < numPlayers; i++ {
+		names[i] = fmt.Sprintf("Player%02d", i)
+	}
+
+	req := &pb.PairRequest{
+		PairMethod:                 pb.PairMethod_COP,
+		PlayerNames:                names,
+		PlayerClasses:              classes,
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.25,
+		HopefulnessThreshold:       0.02,
+		AllPlayers:                 int32(numPlayers),
+		ValidPlayers:               int32(numPlayers),
+		Rounds:                     int32(totalRounds),
+		PlacePrizes:                3,
+		DivisionSims:               1000,
+		ControlLossSims:            1000,
+		ControlLossActivationRound: 22,
+		AllowRepeatByes:            false,
+	}
+
+	// Generate random results for a given pairing.
+	addRandomResults := func(pairings []int32) {
+		results := make([]int32, numPlayers)
+		byePlayer := -1
+		for i := 0; i < numPlayers; i++ {
+			if pairings[i] == int32(i) {
+				byePlayer = i
+			}
+		}
+		for i := 0; i < numPlayers; i++ {
+			if i == byePlayer {
+				results[i] = 50
+				continue
+			}
+			opp := int(pairings[i])
+			if i < opp {
+				spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
+				baseScore := int32(400)
+				results[i] = baseScore + spread/2
+				results[opp] = baseScore - spread/2
+			}
+		}
+		req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
+	}
+
+	// Fontes-style pairings for first 3 rounds: group players into N/F tiers,
+	// pair top-half vs bottom-half within each group. Use simple rotation for variety.
+	for r := 0; r < fontesRounds; r++ {
+		pairings := make([]int32, numPlayers)
+		paired := make([]bool, numPlayers)
+
+		// Each fontes round pairs player i with player (i + numPlayers/2 + r) % numPlayers.
+		step := numPlayers/2 + r
+		for i := 0; i < numPlayers; i++ {
+			if paired[i] {
+				continue
+			}
+			j := (i + step) % numPlayers
+			startJ := j
+			// Avoid pairing already-paired or self.
+			// Break if we've wrapped all the way around (no valid partner — will get bye).
+			for paired[j] || j == i {
+				j = (j + 1) % numPlayers
+				if j == startJ {
+					j = -1
+					break
+				}
+			}
+			if j < 0 {
+				continue
+			}
+			pairings[i] = int32(j)
+			pairings[j] = int32(i)
+			paired[i] = true
+			paired[j] = true
+		}
+		// The one remaining unpaired player (51 is odd) gets a bye.
+		for i := 0; i < numPlayers; i++ {
+			if !paired[i] {
+				pairings[i] = int32(i)
+				paired[i] = true
+			}
+		}
+
+		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
+		addRandomResults(pairings)
+	}
+
+	// COP rounds for the remaining 25 rounds.
+	for round := fontesRounds + 1; round <= totalRounds; round++ {
+		resp := cop.COPPair(req)
+		is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+		fmt.Printf("Fake 51-player round %d pairings: %v\n", round, resp.Pairings)
+		writeScenarioLog(t, fmt.Sprintf("fake_28game_51players_round_%02d.log", round), resp.Log)
+
+		pairings := make([]int32, numPlayers)
+		copy(pairings, resp.Pairings)
+		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
+		addRandomResults(pairings)
+	}
+}

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -3,7 +3,9 @@ package cop_test
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/matryer/is"
 	"github.com/woogles-io/liwords/pkg/pair/cop"
@@ -28,11 +30,11 @@ const (
 
 func writeScenarioLog(t *testing.T, filename string, log string) {
 	t.Helper()
-	if err := os.MkdirAll("logs", 0755); err != nil {
+	path := filepath.Join("logs", filename)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Logf("failed to create logs directory: %v", err)
 		return
 	}
-	path := "logs/" + filename
 	if err := os.WriteFile(path, []byte(log), 0644); err != nil {
 		t.Logf("failed to write log file %s: %v", path, err)
 	}
@@ -338,130 +340,151 @@ func TestScenarioMultiRound_AlbanyCSW2025ME_Last16Rounds(t *testing.T) {
 	}
 }
 
-// Fake 28-game 51-player event: 3 rounds of fontes-style pairings, then 25 rounds of COP.
-// Run with: COP_SCENARIOS=1 go test -run TestFake28Game51Players
-func TestScenarioMultiRound_Fake28Game51Players(t *testing.T) {
+// July 4th 2026 28-game 53-player event: 3 rounds of fontes-style pairings, then 25 rounds of COP.
+// Uses the Division 1 player list from wordgameplayers.org/tournaments/1162.
+// Run with: COP_SCENARIOS=1 go test -run TestScenarioMultiRound_July4th2026
+func TestScenarioMultiRound_July4th2026(t *testing.T) {
 	if os.Getenv("COP_SCENARIOS") == "" {
-		t.Skip("Skipping fake 51-player scenario test. Set COP_SCENARIOS=1 to run.")
+		t.Skip("Skipping July 4th 2026 scenario test. Set COP_SCENARIOS=1 to run.")
 	}
 	is := is.New(t)
-	rng := rand.New(rand.NewSource(99))
 	spreadsDist := standings.GetScoreDifferences()
 	spreadsDistSize := len(spreadsDist)
 
-	numPlayers := 51
+	const numRuns = 10
+
+	numPlayers := 53
 	totalRounds := 28
 	fontesRounds := 3
 
-	names := make([]string, numPlayers)
+	names := []string{
+		"Wellington Jighere", "Nigel Richards", "Will Anderson", "Dave Wiegand",
+		"Adam Logan", "Josh Sokol", "Eta Karo", "Matthew Tunnicliffe",
+		"Joshua Castellano", "Enoch Nwali", "Matthew O'Connor", "Rob Robinsky",
+		"Austin Shin", "Kevin Fraley", "Noah Slatkoff", "Jason Keller",
+		"Thomas Reinke", "Edgar Odongkara", "Sammy Okosagah", "Charles Reinke",
+		"Lukeman Owolabi", "Brian Po", "Olawale Fashina", "Chukwudi Ehibudu",
+		"Rasheed Balogun", "Samuel Anikoh", "Chris Lipe", "Robert Linn",
+		"Jason Carney", "Joel Wapnick", "Jared Robinson", "Laurie Cohen",
+		"Anthony Ikolo", "Oshevire Avwenagha", "Amit Chakrabarti", "Mohammad Sulaiman",
+		"Scott Jackson", "Marlon Hill", "Akeem Adekunle", "Dipo Akanbi",
+		"Jason Ubeika", "Niel Gan", "Bharath Balakrishnan", "Femi Awowade",
+		"Mark Francillon", "Daniel Blake", "Osikhena Ojior", "Greg Harper",
+		"Zachary Dang", "Collins Okafor", "Tijan Jeng", "Ayotunde Adeyeri",
+		"Fidelis Olotu",
+	}
 	classes := make([]int32, numPlayers)
-	for i := 0; i < numPlayers; i++ {
-		names[i] = fmt.Sprintf("Player%02d", i)
-	}
 
-	req := &pb.PairRequest{
-		PairMethod:                 pb.PairMethod_COP,
-		PlayerNames:                names,
-		PlayerClasses:              classes,
-		ClassPrizes:                []int32{2},
-		GibsonSpread:               scenarioGibsonSpread,
-		ControlLossThreshold:       0.30,
-		HopefulnessThreshold:       scenarioHopefulness,
-		AllPlayers:                 int32(numPlayers),
-		ValidPlayers:               int32(numPlayers),
-		Rounds:                     int32(totalRounds),
-		PlacePrizes:                10,
-		DivisionSims:               scenarioDivisionSims,
-		ControlLossSims:            scenarioControlLossSims,
-		ControlLossActivationRound: 22,
-		AllowRepeatByes:            false,
-	}
+	for run := 0; run < numRuns; run++ {
+		seed := time.Now().UnixNano()
+		rng := rand.New(rand.NewSource(uint64(seed)))
+		runDir := fmt.Sprintf("july4th2026_run_%02d", run+1)
 
-	addRandomResults := func(pairings []int32) {
-		results := make([]int32, numPlayers)
-		byePlayer := -1
-		for i := 0; i < numPlayers; i++ {
-			if pairings[i] == int32(i) {
-				byePlayer = i
-			}
+		req := &pb.PairRequest{
+			PairMethod:                 pb.PairMethod_COP,
+			PlayerNames:                names,
+			PlayerClasses:              classes,
+			ClassPrizes:                []int32{2},
+			GibsonSpread:               scenarioGibsonSpread,
+			ControlLossThreshold:       0.30,
+			HopefulnessThreshold:       scenarioHopefulness,
+			AllPlayers:                 int32(numPlayers),
+			ValidPlayers:               int32(numPlayers),
+			Rounds:                     int32(totalRounds),
+			PlacePrizes:                10,
+			DivisionSims:               scenarioDivisionSims,
+			ControlLossSims:            scenarioControlLossSims,
+			ControlLossActivationRound: 22,
+			AllowRepeatByes:            false,
+			Seed:                       seed,
 		}
-		for i := 0; i < numPlayers; i++ {
-			if i == byePlayer {
-				results[i] = 50
-				continue
-			}
-			opp := int(pairings[i])
-			if i < opp {
-				spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
-				baseScore := int32(400)
-				if rng.Intn(2) == 0 {
-					results[i] = baseScore + spread/2
-					results[opp] = baseScore - spread/2
-				} else {
-					results[i] = baseScore - spread/2
-					results[opp] = baseScore + spread/2
+
+		addRandomResults := func(pairings []int32) {
+			results := make([]int32, numPlayers)
+			byePlayer := -1
+			for i := 0; i < numPlayers; i++ {
+				if pairings[i] == int32(i) {
+					byePlayer = i
 				}
 			}
-		}
-		req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
-	}
-
-	// Fontes-style pairings for first 3 rounds.
-	for r := 0; r < fontesRounds; r++ {
-		pairings := make([]int32, numPlayers)
-		paired := make([]bool, numPlayers)
-
-		step := numPlayers/2 + r
-		for i := 0; i < numPlayers; i++ {
-			if paired[i] {
-				continue
-			}
-			j := (i + step) % numPlayers
-			startJ := j
-			// Break if we've wrapped all the way around (no valid partner — will get bye).
-			for paired[j] || j == i {
-				j = (j + 1) % numPlayers
-				if j == startJ {
-					j = -1
-					break
+			for i := 0; i < numPlayers; i++ {
+				if i == byePlayer {
+					results[i] = 50
+					continue
+				}
+				opp := int(pairings[i])
+				if i < opp {
+					spread := int32(spreadsDist[rng.Intn(spreadsDistSize)])
+					baseScore := int32(400)
+					if rng.Intn(2) == 0 {
+						results[i] = baseScore + spread/2
+						results[opp] = baseScore - spread/2
+					} else {
+						results[i] = baseScore - spread/2
+						results[opp] = baseScore + spread/2
+					}
 				}
 			}
-			if j < 0 {
-				continue
-			}
-			pairings[i] = int32(j)
-			pairings[j] = int32(i)
-			paired[i] = true
-			paired[j] = true
+			req.DivisionResults = append(req.DivisionResults, &pb.RoundResults{Results: results})
 		}
-		for i := 0; i < numPlayers; i++ {
-			if !paired[i] {
-				pairings[i] = int32(i)
+
+		// Fontes-style pairings for first 3 rounds.
+		for r := 0; r < fontesRounds; r++ {
+			pairings := make([]int32, numPlayers)
+			paired := make([]bool, numPlayers)
+
+			step := numPlayers/2 + r
+			for i := 0; i < numPlayers; i++ {
+				if paired[i] {
+					continue
+				}
+				j := (i + step) % numPlayers
+				startJ := j
+				// Break if we've wrapped all the way around (no valid partner — will get bye).
+				for paired[j] || j == i {
+					j = (j + 1) % numPlayers
+					if j == startJ {
+						j = -1
+						break
+					}
+				}
+				if j < 0 {
+					continue
+				}
+				pairings[i] = int32(j)
+				pairings[j] = int32(i)
 				paired[i] = true
+				paired[j] = true
 			}
+			for i := 0; i < numPlayers; i++ {
+				if !paired[i] {
+					pairings[i] = int32(i)
+					paired[i] = true
+				}
+			}
+
+			req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
+			addRandomResults(pairings)
 		}
 
-		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
-		addRandomResults(pairings)
-	}
+		// COP rounds for the remaining 25 rounds.
+		for round := fontesRounds + 1; round <= totalRounds; round++ {
+			if round == totalRounds {
+				req.GibsonSpread = scenarioLastRoundGibsonSpread
+			} else {
+				req.GibsonSpread = scenarioGibsonSpread
+			}
 
-	// COP rounds for the remaining 25 rounds.
-	for round := fontesRounds + 1; round <= totalRounds; round++ {
-		if round == totalRounds {
-			req.GibsonSpread = scenarioLastRoundGibsonSpread
-		} else {
-			req.GibsonSpread = scenarioGibsonSpread
+			resp := cop.COPPair(req)
+			is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
+			fmt.Printf("July 4th 2026 run %d round %d pairings: %v\n", run+1, round, resp.Pairings)
+			writeScenarioLog(t, fmt.Sprintf("%s/round_%02d.log", runDir, round), resp.Log)
+
+			pairings := make([]int32, numPlayers)
+			copy(pairings, resp.Pairings)
+			req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
+			addRandomResults(pairings)
 		}
-
-		resp := cop.COPPair(req)
-		is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
-		fmt.Printf("Fake 51-player round %d pairings: %v\n", round, resp.Pairings)
-		writeScenarioLog(t, fmt.Sprintf("fake_28game_51players_round_%02d.log", round), resp.Log)
-
-		pairings := make([]int32, numPlayers)
-		copy(pairings, resp.Pairings)
-		req.DivisionPairings = append(req.DivisionPairings, &pb.RoundPairings{Pairings: pairings})
-		addRandomResults(pairings)
 	}
 }
 

--- a/pkg/pair/cop/scenarios_test.go
+++ b/pkg/pair/cop/scenarios_test.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	scenarioDivisionSims          = 100000
-	scenarioControlLossSims       = 10000
+	scenarioControlLossSims       = 20000
 	scenarioHopefulness           = 0.02
 	scenarioGibsonSpread          = 200
 	scenarioLastRoundGibsonSpread = 250
@@ -787,6 +787,7 @@ func TestScenarioMultiRound_July4th2026Div2(t *testing.T) {
 			ControlLossSims:            scenarioControlLossSims,
 			ControlLossActivationRound: 22,
 			AllowRepeatByes:            false,
+			TopDownByes:                true,
 			Seed:                       seed,
 		}
 
@@ -812,9 +813,9 @@ func TestScenarioMultiRound_July4th2026Div2(t *testing.T) {
 			}
 
 			resp := cop.COPPair(req)
+			writeScenarioLog(t, fmt.Sprintf("%s/round_%02d.log", runDir, round), resp.Log)
 			is.Equal(resp.ErrorCode, pb.PairError_SUCCESS)
 			fmt.Printf("July 4th 2026 Div2 run %d round %d pairings: %v\n", run+1, round, resp.Pairings)
-			writeScenarioLog(t, fmt.Sprintf("%s/round_%02d.log", runDir, round), resp.Log)
 
 			pairings := make([]int32, numPlayers)
 			copy(pairings, resp.Pairings)

--- a/pkg/pair/copdata/copdata.go
+++ b/pkg/pair/copdata/copdata.go
@@ -3,6 +3,7 @@ package copdata
 import (
 	"fmt"
 	"math"
+	"sort"
 
 	"golang.org/x/exp/rand"
 
@@ -194,6 +195,7 @@ divisionPairingLoop:
 		if controlLossSimResults.HighestControlLossRankIdx >= 0 {
 			destinysChild = controlLossSimResults.HighestControlLossRankIdx
 		}
+		writeControlLossDebugToLog(controlLossSimResults, allControlLosses, vsFirstWins, standings, req, logsb)
 	}
 
 	writePrecompDataToLog("Precomp Data", improvedFactorSimResults, allControlLosses, vsFirstWins, highestRankHopefully, highestRankAbsolutely, standings, req, logsb)
@@ -370,4 +372,118 @@ func boolToYesEmpty(value bool) string {
 		return "Yes"
 	}
 	return ""
+}
+
+// writeControlLossDebugToLog prints the base factor pairings and, for each rank
+// tested by the binary search, shows what opponent the tested player faces in
+// vsFirst mode (always rank 1) vs vsFactor mode (swapped away from rank 1).
+// Note: pairings shown are from initial standings; actual sims re-rank after each round.
+func writeControlLossDebugToLog(simResults *pkgstnd.SimResults, allControlLosses map[int]int, vsFirstWins map[int]int, standings *pkgstnd.Standings, req *pb.PairRequest, logsb *strings.Builder) {
+	roundsRemaining := pkgstnd.GetRoundsRemaining(req)
+	numPlayers := standings.GetNumPlayers()
+
+	// Safe name lookup: pairings can include a bye slot at index numPlayers (which
+	// is out of range after standings shrinks back post-sim).
+	rankName := func(rankIdx int) string {
+		if rankIdx >= numPlayers {
+			return "BYE"
+		}
+		playerIdx := standings.GetPlayerIndex(rankIdx)
+		if playerIdx == pkgstnd.ByePlayerIndex {
+			return "BYE"
+		}
+		return req.PlayerNames[playerIdx]
+	}
+
+	logsb.WriteString("** Control Loss Debug **\n\n")
+
+	// Print base factor pairings.
+	logsb.WriteString("Base factor pairings (ranks are 1-indexed, from initial standings):\n")
+	for roundIdx := 0; roundIdx < roundsRemaining; roundIdx++ {
+		logsb.WriteString(fmt.Sprintf("  Round %d:", roundIdx+1))
+		pairings := simResults.Pairings[roundIdx]
+		for pairIdx := 0; pairIdx < len(pairings); pairIdx += 2 {
+			ri := pairings[pairIdx]
+			rj := pairings[pairIdx+1]
+			logsb.WriteString(fmt.Sprintf("  r%d(%s) vs r%d(%s)", ri+1, rankName(ri), rj+1, rankName(rj)))
+		}
+		logsb.WriteString("\n")
+	}
+	logsb.WriteString("\n")
+
+	// For each rank tested by the binary search, show the vsFirst/vsFactor swap.
+	tested := make([]int, 0, len(allControlLosses))
+	for rankIdx := range allControlLosses {
+		tested = append(tested, rankIdx)
+	}
+	sort.Ints(tested)
+
+	for _, rankIdx := range tested {
+		vsFirst := vsFirstWins[rankIdx]
+		vsFactor := allControlLosses[rankIdx]
+		diff := float64(vsFirst-vsFactor) * 100 / float64(req.ControlLossSims)
+		threshold := float64(req.ControlLossThreshold) * 100
+		status := ""
+		if diff >= threshold {
+			status = "  ← CONTROL LOSS"
+		}
+		logsb.WriteString(fmt.Sprintf("r%d (%s): vs1st=%d (%.1f%%)  vsFactor=%d (%.1f%%)  diff=%.1f%%  threshold=%.1f%%%s\n",
+			rankIdx+1, rankName(rankIdx),
+			vsFirst, float64(vsFirst)*100/float64(req.ControlLossSims),
+			vsFactor, float64(vsFactor)*100/float64(req.ControlLossSims),
+			diff, threshold, status))
+		logsb.WriteString("  Per-round opponent (from initial standings; re-ranks mid-sim change this):\n")
+
+		for roundIdx := 0; roundIdx < roundsRemaining; roundIdx++ {
+			pairings := simResults.Pairings[roundIdx]
+
+			// Find where rankIdx sits in this round's pairings.
+			switchPairingIdx := -1
+			for idx, r := range pairings {
+				if r == rankIdx {
+					switchPairingIdx = idx
+					break
+				}
+			}
+
+			// vsFirst: tested player is always swapped to position 1, so they play rank 0.
+			vsFirstOppName := rankName(0)
+
+			// vsFactor: if tested player is at position 1 (would face rank 0), swap them out.
+			var vsFactorDesc string
+			if switchPairingIdx == 1 {
+				targetRank := 1
+				if rankIdx == 1 {
+					targetRank = 2
+				}
+				vsFactorOpp := -1
+				for pairIdx := 0; pairIdx < len(pairings); pairIdx += 2 {
+					if pairings[pairIdx] == targetRank {
+						vsFactorOpp = pairings[pairIdx+1]
+						break
+					} else if pairings[pairIdx+1] == targetRank {
+						vsFactorOpp = pairings[pairIdx]
+						break
+					}
+				}
+				vsFactorOppStr := "?"
+				if vsFactorOpp >= 0 {
+					vsFactorOppStr = fmt.Sprintf("r%d(%s)", vsFactorOpp+1, rankName(vsFactorOpp))
+				}
+				vsFactorDesc = fmt.Sprintf("%s  [was at r1's slot → r1 now plays r%d(%s)]", vsFactorOppStr, targetRank+1, rankName(targetRank))
+			} else {
+				// Already not at position 1; no swap in vsFactor mode.
+				var origOpp int
+				if switchPairingIdx%2 == 0 {
+					origOpp = pairings[switchPairingIdx+1]
+				} else {
+					origOpp = pairings[switchPairingIdx-1]
+				}
+				vsFactorDesc = fmt.Sprintf("r%d(%s)  [no swap needed]", origOpp+1, rankName(origOpp))
+			}
+
+			logsb.WriteString(fmt.Sprintf("    Round %d: vsFirst→r1(%s)  vsFactor→%s\n", roundIdx+1, vsFirstOppName, vsFactorDesc))
+		}
+		logsb.WriteString("\n")
+	}
 }

--- a/pkg/pair/copdata/copdata.go
+++ b/pkg/pair/copdata/copdata.go
@@ -3,7 +3,6 @@ package copdata
 import (
 	"fmt"
 	"math"
-	"sort"
 
 	"golang.org/x/exp/rand"
 
@@ -195,7 +194,6 @@ divisionPairingLoop:
 		if controlLossSimResults.HighestControlLossRankIdx >= 0 {
 			destinysChild = controlLossSimResults.HighestControlLossRankIdx
 		}
-		writeControlLossDebugToLog(controlLossSimResults, allControlLosses, vsFirstWins, standings, req, logsb)
 	}
 
 	writePrecompDataToLog("Precomp Data", improvedFactorSimResults, allControlLosses, vsFirstWins, highestRankHopefully, highestRankAbsolutely, standings, req, logsb)
@@ -372,118 +370,4 @@ func boolToYesEmpty(value bool) string {
 		return "Yes"
 	}
 	return ""
-}
-
-// writeControlLossDebugToLog prints the base factor pairings and, for each rank
-// tested by the binary search, shows what opponent the tested player faces in
-// vsFirst mode (always rank 1) vs vsFactor mode (swapped away from rank 1).
-// Note: pairings shown are from initial standings; actual sims re-rank after each round.
-func writeControlLossDebugToLog(simResults *pkgstnd.SimResults, allControlLosses map[int]int, vsFirstWins map[int]int, standings *pkgstnd.Standings, req *pb.PairRequest, logsb *strings.Builder) {
-	roundsRemaining := pkgstnd.GetRoundsRemaining(req)
-	numPlayers := standings.GetNumPlayers()
-
-	// Safe name lookup: pairings can include a bye slot at index numPlayers (which
-	// is out of range after standings shrinks back post-sim).
-	rankName := func(rankIdx int) string {
-		if rankIdx >= numPlayers {
-			return "BYE"
-		}
-		playerIdx := standings.GetPlayerIndex(rankIdx)
-		if playerIdx == pkgstnd.ByePlayerIndex {
-			return "BYE"
-		}
-		return req.PlayerNames[playerIdx]
-	}
-
-	logsb.WriteString("** Control Loss Debug **\n\n")
-
-	// Print base factor pairings.
-	logsb.WriteString("Base factor pairings (ranks are 1-indexed, from initial standings):\n")
-	for roundIdx := 0; roundIdx < roundsRemaining; roundIdx++ {
-		logsb.WriteString(fmt.Sprintf("  Round %d:", roundIdx+1))
-		pairings := simResults.Pairings[roundIdx]
-		for pairIdx := 0; pairIdx < len(pairings); pairIdx += 2 {
-			ri := pairings[pairIdx]
-			rj := pairings[pairIdx+1]
-			logsb.WriteString(fmt.Sprintf("  r%d(%s) vs r%d(%s)", ri+1, rankName(ri), rj+1, rankName(rj)))
-		}
-		logsb.WriteString("\n")
-	}
-	logsb.WriteString("\n")
-
-	// For each rank tested by the binary search, show the vsFirst/vsFactor swap.
-	tested := make([]int, 0, len(allControlLosses))
-	for rankIdx := range allControlLosses {
-		tested = append(tested, rankIdx)
-	}
-	sort.Ints(tested)
-
-	for _, rankIdx := range tested {
-		vsFirst := vsFirstWins[rankIdx]
-		vsFactor := allControlLosses[rankIdx]
-		diff := float64(vsFirst-vsFactor) * 100 / float64(req.ControlLossSims)
-		threshold := float64(req.ControlLossThreshold) * 100
-		status := ""
-		if diff >= threshold {
-			status = "  ← CONTROL LOSS"
-		}
-		logsb.WriteString(fmt.Sprintf("r%d (%s): vs1st=%d (%.1f%%)  vsFactor=%d (%.1f%%)  diff=%.1f%%  threshold=%.1f%%%s\n",
-			rankIdx+1, rankName(rankIdx),
-			vsFirst, float64(vsFirst)*100/float64(req.ControlLossSims),
-			vsFactor, float64(vsFactor)*100/float64(req.ControlLossSims),
-			diff, threshold, status))
-		logsb.WriteString("  Per-round opponent (from initial standings; re-ranks mid-sim change this):\n")
-
-		for roundIdx := 0; roundIdx < roundsRemaining; roundIdx++ {
-			pairings := simResults.Pairings[roundIdx]
-
-			// Find where rankIdx sits in this round's pairings.
-			switchPairingIdx := -1
-			for idx, r := range pairings {
-				if r == rankIdx {
-					switchPairingIdx = idx
-					break
-				}
-			}
-
-			// vsFirst: tested player is always swapped to position 1, so they play rank 0.
-			vsFirstOppName := rankName(0)
-
-			// vsFactor: if tested player is at position 1 (would face rank 0), swap them out.
-			var vsFactorDesc string
-			if switchPairingIdx == 1 {
-				targetRank := 1
-				if rankIdx == 1 {
-					targetRank = 2
-				}
-				vsFactorOpp := -1
-				for pairIdx := 0; pairIdx < len(pairings); pairIdx += 2 {
-					if pairings[pairIdx] == targetRank {
-						vsFactorOpp = pairings[pairIdx+1]
-						break
-					} else if pairings[pairIdx+1] == targetRank {
-						vsFactorOpp = pairings[pairIdx]
-						break
-					}
-				}
-				vsFactorOppStr := "?"
-				if vsFactorOpp >= 0 {
-					vsFactorOppStr = fmt.Sprintf("r%d(%s)", vsFactorOpp+1, rankName(vsFactorOpp))
-				}
-				vsFactorDesc = fmt.Sprintf("%s  [was at r1's slot → r1 now plays r%d(%s)]", vsFactorOppStr, targetRank+1, rankName(targetRank))
-			} else {
-				// Already not at position 1; no swap in vsFactor mode.
-				var origOpp int
-				if switchPairingIdx%2 == 0 {
-					origOpp = pairings[switchPairingIdx+1]
-				} else {
-					origOpp = pairings[switchPairingIdx-1]
-				}
-				vsFactorDesc = fmt.Sprintf("r%d(%s)  [no swap needed]", origOpp+1, rankName(origOpp))
-			}
-
-			logsb.WriteString(fmt.Sprintf("    Round %d: vsFirst→r1(%s)  vsFactor→%s\n", roundIdx+1, vsFirstOppName, vsFactorDesc))
-		}
-		logsb.WriteString("\n")
-	}
 }

--- a/pkg/pair/copdata/copdata.go
+++ b/pkg/pair/copdata/copdata.go
@@ -45,7 +45,7 @@ func GetPrecompData(req *pb.PairRequest, copRand *rand.Rand, logsb *strings.Buil
 	if pairErr != pb.PairError_SUCCESS {
 		return nil, pairErr
 	}
-	writeFinalRankResultsToLog(fmt.Sprintf("Initial Sim Results (factor ceiling of %d)", initialFactor), initialSimResults.FinalRanks, standings, req, logsb)
+	WriteFinalRankResultsToLog(fmt.Sprintf("Initial Sim Results (factor ceiling of %d)", initialFactor), initialSimResults.FinalRanks, standings, req, logsb)
 
 	numPlayers := standings.GetNumPlayers()
 
@@ -98,7 +98,7 @@ func GetPrecompData(req *pb.PairRequest, copRand *rand.Rand, logsb *strings.Buil
 		improvedFactorSimResults = initialSimResults
 		logsb.WriteString("\n\nNo factor improvement made.\n\n")
 	} else {
-		writeFinalRankResultsToLog(fmt.Sprintf("Improved Factor Sim Results (factor ceiling of %d)", maxFactor), improvedFactorSimResults.FinalRanks, standings, req, logsb)
+		WriteFinalRankResultsToLog(fmt.Sprintf("Improved Factor Sim Results (factor ceiling of %d)", maxFactor), improvedFactorSimResults.FinalRanks, standings, req, logsb)
 	}
 
 	minWinsForHopeful := int(math.Round(float64(improvedFactorSimResults.TotalSims) * req.HopefulnessThreshold))
@@ -269,7 +269,7 @@ func writePrecompDataToLog(title string, simResults *pkgstnd.SimResults, allCont
 	WriteStringDataToLog(title, header, combineStringMatrices(standings.StringData(req), matrix), logsb)
 }
 
-func writeFinalRankResultsToLog(title string, finalRanks [][]int, standings *pkgstnd.Standings, req *pb.PairRequest, logsb *strings.Builder) {
+func WriteFinalRankResultsToLog(title string, finalRanks [][]int, standings *pkgstnd.Standings, req *pb.PairRequest, logsb *strings.Builder) {
 	header := append([]string{}, standingsHeader[:]...)
 	numPlayers := standings.GetNumPlayers()
 	totalSims := 0

--- a/pkg/pair/copdata/copdata.go
+++ b/pkg/pair/copdata/copdata.go
@@ -184,7 +184,7 @@ divisionPairingLoop:
 	var allControlLosses map[int]int
 	var vsFirstWins map[int]int
 	destinysChild := -1
-	if numCompletePairings >= int(req.ControlLossActivationRound) && !improvedFactorSimResults.GibsonizedPlayers[0] && initialFactor > 1 {
+	if numCompletePairings >= int(req.ControlLossActivationRound) && !improvedFactorSimResults.GibsonizedPlayers[0] && initialFactor > 1 && maxFactor > 0 {
 		controlLossSimResults, pairErr = standings.SimFactorPairAll(req, copRand, int(req.ControlLossSims), maxFactor, lowestPossibleHopeNth[0], nil)
 		if pairErr != pb.PairError_SUCCESS {
 			return nil, pairErr

--- a/pkg/pair/copdata/copdata_test.go
+++ b/pkg/pair/copdata/copdata_test.go
@@ -197,7 +197,7 @@ func TestCOPPrecompData(t *testing.T) {
 		is.Equal(copdata.GibsonGroups[rank], 0)
 	}
 	is.Equal(copdata.LowestRankAbsolutely[3], 3)
-	is.Equal(copdata.DestinysChild, -1)
+	is.Equal(copdata.DestinysChild, 1)
 
 	req = pairtestutils.CreateAlbany1stAnd4thGibsonizedAfterRound25PairRequest()
 	req.ControlLossActivationRound = 26
@@ -249,7 +249,7 @@ func TestCOPPrecompData(t *testing.T) {
 	copRand.Seed(1)
 	copdata, pairErr = pkgcopdata.GetPrecompData(req, copRand, &logsb)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	is.Equal(copdata.DestinysChild, 2)
+	is.Equal(copdata.DestinysChild, 1)
 	for rank := 0; rank < len(copdata.GibsonGroups); rank++ {
 		is.Equal(copdata.GibsonGroups[rank], 0)
 	}

--- a/pkg/pair/copdata/copdata_test.go
+++ b/pkg/pair/copdata/copdata_test.go
@@ -117,12 +117,12 @@ func TestCOPPrecompData(t *testing.T) {
 		is.Equal(copdata.HighestRankHopefully[rank], 1)
 		is.Equal(copdata.HighestRankAbsolutely[rank], 1)
 	}
-	is.Equal(copdata.HighestRankHopefully[6], 3)
+	is.Equal(copdata.HighestRankHopefully[6], 4)
 	is.Equal(copdata.HighestRankAbsolutely[6], 3)
 	is.Equal(copdata.HighestRankHopefully[7], 4)
 	is.Equal(copdata.HighestRankAbsolutely[7], 3)
-	is.Equal(copdata.HighestRankHopefully[17], 9)
-	is.Equal(copdata.HighestRankAbsolutely[17], 7)
+	is.Equal(copdata.HighestRankHopefully[17], 8)
+	is.Equal(copdata.HighestRankAbsolutely[17], 6)
 	for _, group := range copdata.GibsonGroups {
 		is.Equal(group, 0)
 	}
@@ -175,12 +175,12 @@ func TestCOPPrecompData(t *testing.T) {
 		is.Equal(copdata.HighestRankHopefully[rank], rank)
 		is.Equal(copdata.HighestRankAbsolutely[rank], rank)
 	}
-	is.Equal(copdata.HighestRankHopefully[23], 16)
-	is.Equal(copdata.HighestRankAbsolutely[23], 15)
+	is.Equal(copdata.HighestRankHopefully[23], 15)
+	is.Equal(copdata.HighestRankAbsolutely[23], 13)
 	is.Equal(copdata.LowestRankAbsolutely[0], 0)
 	is.Equal(copdata.LowestRankAbsolutely[1], 1)
-	is.Equal(copdata.LowestRankAbsolutely[2], 9)
-	is.Equal(copdata.LowestRankAbsolutely[17], 24)
+	is.Equal(copdata.LowestRankAbsolutely[2], 10)
+	is.Equal(copdata.LowestRankAbsolutely[17], 25)
 	is.Equal(copdata.LowestRankAbsolutely[29], 29)
 	is.Equal(copdata.DestinysChild, -1)
 
@@ -197,7 +197,7 @@ func TestCOPPrecompData(t *testing.T) {
 		is.Equal(copdata.GibsonGroups[rank], 0)
 	}
 	is.Equal(copdata.LowestRankAbsolutely[3], 3)
-	is.Equal(copdata.DestinysChild, -1)
+	is.Equal(copdata.DestinysChild, 2)
 
 	req = pairtestutils.CreateAlbany1stAnd4thGibsonizedAfterRound25PairRequest()
 	req.ControlLossActivationRound = 26

--- a/pkg/pair/copdata/copdata_test.go
+++ b/pkg/pair/copdata/copdata_test.go
@@ -197,7 +197,7 @@ func TestCOPPrecompData(t *testing.T) {
 		is.Equal(copdata.GibsonGroups[rank], 0)
 	}
 	is.Equal(copdata.LowestRankAbsolutely[3], 3)
-	is.Equal(copdata.DestinysChild, 1)
+	is.Equal(copdata.DestinysChild, -1)
 
 	req = pairtestutils.CreateAlbany1stAnd4thGibsonizedAfterRound25PairRequest()
 	req.ControlLossActivationRound = 26
@@ -249,7 +249,7 @@ func TestCOPPrecompData(t *testing.T) {
 	copRand.Seed(1)
 	copdata, pairErr = pkgcopdata.GetPrecompData(req, copRand, &logsb)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	is.Equal(copdata.DestinysChild, 1)
+	is.Equal(copdata.DestinysChild, 2)
 	for rank := 0; rank < len(copdata.GibsonGroups); rank++ {
 		is.Equal(copdata.GibsonGroups[rank], 0)
 	}

--- a/pkg/pair/copdata/copdata_test.go
+++ b/pkg/pair/copdata/copdata_test.go
@@ -1,15 +1,22 @@
 package copdata_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/matryer/is"
 	pkgcopdata "github.com/woogles-io/liwords/pkg/pair/copdata"
 	pairtestutils "github.com/woogles-io/liwords/pkg/pair/testutils"
+	pkgstnd "github.com/woogles-io/liwords/pkg/pair/standings"
 	pb "github.com/woogles-io/liwords/rpc/api/proto/ipc"
 	"golang.org/x/exp/rand"
 )
+
+func TestMain(m *testing.M) {
+	pkgstnd.NumSimWorkersOverride = 1
+	os.Exit(m.Run())
+}
 
 func TestCOPPrecompData(t *testing.T) {
 	is := is.New(t)
@@ -177,7 +184,7 @@ func TestCOPPrecompData(t *testing.T) {
 		is.Equal(copdata.HighestRankAbsolutely[rank], rank)
 	}
 	is.Equal(copdata.HighestRankHopefully[23], 15)
-	is.Equal(copdata.HighestRankAbsolutely[23], 13)
+	is.Equal(copdata.HighestRankAbsolutely[23], 14)
 	is.Equal(copdata.LowestRankAbsolutely[0], 0)
 	is.Equal(copdata.LowestRankAbsolutely[1], 1)
 	is.Equal(copdata.LowestRankAbsolutely[2], 10)

--- a/pkg/pair/copdata/copdata_test.go
+++ b/pkg/pair/copdata/copdata_test.go
@@ -64,6 +64,7 @@ func TestCOPPrecompData(t *testing.T) {
 
 	req = pairtestutils.CreateLakeGeorgeAfterRound13PairRequest()
 	req.ControlLossActivationRound = 10
+	req.DivisionSims = 10000
 	copRand.Seed(1)
 	// 1st is gibsonized, so control loss should not be used
 	// even though it's set to true in the request

--- a/pkg/pair/copdata/copdata_test.go
+++ b/pkg/pair/copdata/copdata_test.go
@@ -249,7 +249,7 @@ func TestCOPPrecompData(t *testing.T) {
 	copRand.Seed(1)
 	copdata, pairErr = pkgcopdata.GetPrecompData(req, copRand, &logsb)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	is.Equal(copdata.DestinysChild, 2)
+	is.Equal(copdata.DestinysChild, -1)
 	for rank := 0; rank < len(copdata.GibsonGroups); rank++ {
 		is.Equal(copdata.GibsonGroups[rank], 0)
 	}

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -277,11 +277,12 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 	startRankIdx := 0
 	endRankIdx := 0
 	leftoverGibsonPlayers := []int{}
+	controlLoss := lowestHopeControlLosser >= 0
 	pairingsStartIdx := 0
 	segmentRoundFactors := []int{}
 	for endRankIdx <= numPlayers {
 		if endRankIdx == numPlayers {
-			assignPairingsForSegment(pairingsStartIdx, startRankIdx, endRankIdx-1, roundsRemaining, maxFactor, leftoverGibsonPlayers, pairings, &segmentRoundFactors)
+			assignPairingsForSegment(pairingsStartIdx, startRankIdx, endRankIdx-1, roundsRemaining, maxFactor, leftoverGibsonPlayers, pairings, &segmentRoundFactors, copRand, numPlayers, controlLoss)
 			for rankIdx := startRankIdx; rankIdx < endRankIdx; rankIdx++ {
 				gibsonGroups[rankIdx] = 0
 			}
@@ -295,7 +296,7 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 					// The number of players in the group is odd, so
 					// we have to pull in the gibsonized player at endRankIdx
 					// to even the group
-					assignPairingsForSegment(pairingsStartIdx, startRankIdx, endRankIdx, roundsRemaining, maxFactor, []int{}, pairings, &segmentRoundFactors)
+					assignPairingsForSegment(pairingsStartIdx, startRankIdx, endRankIdx, roundsRemaining, maxFactor, []int{}, pairings, &segmentRoundFactors, copRand, numPlayers, controlLoss)
 					pairingsStartIdx += numPlayersInGibsonGroup + 1
 					for rankIdx := startRankIdx; rankIdx <= endRankIdx; rankIdx++ {
 						gibsonGroups[rankIdx] = nextGibsonGroup
@@ -306,7 +307,7 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 					// The number of players in the group is even, so
 					// the gibsonized player is not included in the group
 					// and will be included in the bottom gibson group
-					assignPairingsForSegment(pairingsStartIdx, startRankIdx, endRankIdx-1, roundsRemaining, maxFactor, []int{}, pairings, &segmentRoundFactors)
+					assignPairingsForSegment(pairingsStartIdx, startRankIdx, endRankIdx-1, roundsRemaining, maxFactor, []int{}, pairings, &segmentRoundFactors, copRand, numPlayers, controlLoss)
 					pairingsStartIdx += numPlayersInGibsonGroup
 					for rankIdx := startRankIdx; rankIdx < endRankIdx; rankIdx++ {
 						gibsonGroups[rankIdx] = nextGibsonGroup
@@ -515,8 +516,10 @@ func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsR
 				// Move forced winner to position 1 so they play rank 0 (1st place).
 				swapIdxA = 1
 				swapIdxB = switchPairingIdx
-			} else if switchPairingIdx == 1 {
+			} else if switchPairingIdx == 1 && roundIdx < roundsRemaining-1 {
 				// Forced winner is currently rank 0's factor-pair opponent.
+				// Only swap in non-last rounds: the last round is KOTH and should resolve
+				// naturally (forced winner faces rank 0 if they're rank 1, and still wins).
 				// Instead of having them play 1st, swap with another pairing:
 				//   - If forced winner is 2nd (rank 1): do 1st vs 3rd, 2nd vs 3rd's opponent.
 				//   - Otherwise: do 1st vs 2nd, forced winner vs 2nd's opponent.
@@ -557,12 +560,16 @@ func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsR
 
 // Unexported functions
 
-// Gets the factor pairings for players in [i, j] for all remaining rounds
-// Assumes i < j
-// Returns pairings in pairs of player indexes
-// For example, pairings of [0, 2, 1, 3] indicate player 0 plays player 2
-// and player 1 plays player 3.
-func assignPairingsForSegment(pairingsStartIdx int, startRankIdx int, endRankIdx int, initialRoundsRemaining int, maxFactor int, leftoverGibsonPlayers []int, pairings [][]int, segmentRoundFactors *[]int) {
+// assignPairingsForSegment sets the simulation pairings for players in [startRankIdx, endRankIdx]
+// for all remaining rounds.
+//
+// When controlLoss is false (normal sim): each round uses multiple factor pairs followed by
+// consecutive KOTH pairings for the remainder.
+//
+// When controlLoss is true (always-wins sim): each round uses a single factor pair (top of
+// segment vs Nth player), then randomly pairs remaining players within totalNumPlayers/2
+// rank distance.
+func assignPairingsForSegment(pairingsStartIdx int, startRankIdx int, endRankIdx int, initialRoundsRemaining int, maxFactor int, leftoverGibsonPlayers []int, pairings [][]int, segmentRoundFactors *[]int, copRand *rand.Rand, totalNumPlayers int, controlLoss bool) {
 	numPlayers := endRankIdx - startRankIdx + 1
 
 	for roundsRemaining := initialRoundsRemaining; roundsRemaining > 0; roundsRemaining-- {
@@ -576,28 +583,89 @@ func assignPairingsForSegment(pairingsStartIdx int, startRankIdx int, endRankIdx
 		}
 		*segmentRoundFactors = append(*segmentRoundFactors, roundFactor)
 		roundIdx := initialRoundsRemaining - roundsRemaining
-		for factorPairing := 0; factorPairing < roundFactor; factorPairing++ {
-			basePairingIdx := pairingsStartIdx + 2*factorPairing
-			basePlayerIdx := startRankIdx + factorPairing
-			pairings[roundIdx][basePairingIdx] = basePlayerIdx
-			pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + roundFactor
-		}
-		numKothPlayers := numPlayers - 2*roundFactor
-		numKothPairings := numKothPlayers / 2
-		var nextKothPairingIdx int
-		var nextKothPairingPlayerIdx int
-		for kothPairing := 0; kothPairing < numKothPairings; kothPairing++ {
-			basePairingIdx := pairingsStartIdx + 2*roundFactor + 2*kothPairing
-			basePlayerIdx := startRankIdx + 2*roundFactor + 2*kothPairing
-			pairings[roundIdx][basePairingIdx] = basePlayerIdx
-			pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + 1
 
-			nextKothPairingIdx = basePairingIdx + 2
-			nextKothPairingPlayerIdx = basePlayerIdx + 2
+		// The last simulated round always uses KOTH (consecutive pairing) for all players.
+		if roundsRemaining == 1 {
+			for kothPairing := 0; kothPairing < numPlayers/2; kothPairing++ {
+				basePairingIdx := pairingsStartIdx + 2*kothPairing
+				basePlayerIdx := startRankIdx + 2*kothPairing
+				pairings[roundIdx][basePairingIdx] = basePlayerIdx
+				pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + 1
+			}
+			if numPlayers%2 == 1 {
+				pairings[roundIdx][pairingsStartIdx+numPlayers-1] = startRankIdx + numPlayers - 1
+			}
+			if len(leftoverGibsonPlayers) > 0 {
+				baseGibsonPairingIdx := pairingsStartIdx + numPlayers
+				for playerIdx := 0; playerIdx < len(leftoverGibsonPlayers); playerIdx++ {
+					pairings[roundIdx][baseGibsonPairingIdx+playerIdx] = leftoverGibsonPlayers[playerIdx]
+				}
+			}
+			continue
 		}
-		if numKothPlayers%2 == 1 {
-			pairings[roundIdx][nextKothPairingIdx] = nextKothPairingPlayerIdx
+
+		if controlLoss {
+			// Single factor pair: top of segment vs Nth player.
+			pairings[roundIdx][pairingsStartIdx] = startRankIdx
+			pairings[roundIdx][pairingsStartIdx+1] = startRankIdx + roundFactor
+
+			// Collect remaining players (all except the factor pair).
+			remaining := make([]int, 0, numPlayers-2)
+			for rankIdx := startRankIdx; rankIdx <= endRankIdx; rankIdx++ {
+				if rankIdx != startRankIdx && rankIdx != startRankIdx+roundFactor {
+					remaining = append(remaining, rankIdx)
+				}
+			}
+
+			// Randomly pair remaining players within totalNumPlayers/2 rank distance.
+			// Shuffle and pair consecutively; retry up to 10 times to reduce violations.
+			halfP := totalNumPlayers / 2
+			best := make([]int, len(remaining))
+			copy(best, remaining)
+			bestViolations := countDistanceViolations(best, halfP)
+			shuffled := make([]int, len(remaining))
+			copy(shuffled, remaining)
+			for attempt := 0; attempt < 10 && bestViolations > 0; attempt++ {
+				copRand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+				if v := countDistanceViolations(shuffled, halfP); v < bestViolations {
+					copy(best, shuffled)
+					bestViolations = v
+				}
+			}
+
+			for i := 0; i+1 < len(best); i += 2 {
+				pairings[roundIdx][pairingsStartIdx+2+i] = best[i]
+				pairings[roundIdx][pairingsStartIdx+2+i+1] = best[i+1]
+			}
+			if len(best)%2 == 1 {
+				pairings[roundIdx][pairingsStartIdx+2+len(best)-1] = best[len(best)-1]
+			}
+		} else {
+			// Multiple factor pairs followed by KOTH for the remainder.
+			for factorPairing := 0; factorPairing < roundFactor; factorPairing++ {
+				basePairingIdx := pairingsStartIdx + 2*factorPairing
+				basePlayerIdx := startRankIdx + factorPairing
+				pairings[roundIdx][basePairingIdx] = basePlayerIdx
+				pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + roundFactor
+			}
+			numKothPlayers := numPlayers - 2*roundFactor
+			numKothPairings := numKothPlayers / 2
+			var nextKothPairingIdx int
+			var nextKothPairingPlayerIdx int
+			for kothPairing := 0; kothPairing < numKothPairings; kothPairing++ {
+				basePairingIdx := pairingsStartIdx + 2*roundFactor + 2*kothPairing
+				basePlayerIdx := startRankIdx + 2*roundFactor + 2*kothPairing
+				pairings[roundIdx][basePairingIdx] = basePlayerIdx
+				pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + 1
+
+				nextKothPairingIdx = basePairingIdx + 2
+				nextKothPairingPlayerIdx = basePlayerIdx + 2
+			}
+			if numKothPlayers%2 == 1 {
+				pairings[roundIdx][nextKothPairingIdx] = nextKothPairingPlayerIdx
+			}
 		}
+
 		if len(leftoverGibsonPlayers) > 0 {
 			baseGibsonPairingIdx := pairingsStartIdx + numPlayers
 			for playerIdx := 0; playerIdx < len(leftoverGibsonPlayers); playerIdx++ {
@@ -605,6 +673,20 @@ func assignPairingsForSegment(pairingsStartIdx int, startRankIdx int, endRankIdx
 			}
 		}
 	}
+}
+
+func countDistanceViolations(players []int, maxDist int) int {
+	violations := 0
+	for i := 0; i+1 < len(players); i += 2 {
+		d := players[i] - players[i+1]
+		if d < 0 {
+			d = -d
+		}
+		if d > maxDist {
+			violations++
+		}
+	}
+	return violations
 }
 
 func (standings *Standings) getPlayerIdxToRankIdxMap() map[int]int {

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -21,7 +21,6 @@ const (
 	playerSpreadOffset  int     = 16
 	initialSpreadValue  int     = 1 << (playerWinsOffset - playerSpreadOffset - 1)
 	playerIndexMask     uint64  = 0xFFFF
-	byeSpread           int     = 50
 	simConfidence       float64 = 0.99
 	resimBatchSize      int     = 10000
 	initialSimTimeLimit int     = 6
@@ -168,7 +167,7 @@ func (standings *Standings) GetPlayerWins(rankIdx int) float64 {
 // GetPlayerWinsIntTimesTwo returns wins*2 + ties as an integer, avoiding
 // a float64 round-trip when callers need an integer win comparison.
 func (standings *Standings) GetPlayerWinsIntTimesTwo(rankIdx int) int {
-	return int(getWinsValue(standings.records[rankIdx])-initialWinsValue+standings.roundsPlayed)
+	return int(getWinsValue(standings.records[rankIdx]) - initialWinsValue + standings.roundsPlayed)
 }
 
 func (standings *Standings) GetPlayerSpread(rankIdx int) int {

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -367,7 +367,7 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 		for leftPlayerRankIdx <= rightPlayerRankIdx {
 			forcedWinnerRankIdx := (leftPlayerRankIdx + rightPlayerRankIdx) / 2
 			vsFirstTournamentWins, vsFactorPairTournamentWins, newSims, pairErr := standings.evaluatePlayerControlLoss(
-				copRand, sims, roundsRemaining, pairings, forcedWinnerRankIdx, controlSimStopTime,
+				copRand, sims, roundsRemaining, maxFactor, pairings, forcedWinnerRankIdx, controlSimStopTime,
 				vsFirstWins, allControlLosses,
 			)
 			if pairErr != pb.PairError_SUCCESS {
@@ -402,7 +402,7 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 			lowestFullWinRankIdx := -1
 			for rankIdx := 1; rankIdx <= lowestHopeControlLosser; rankIdx++ {
 				vsFirst, vsFactorPair, newSims, pairErr := standings.evaluatePlayerControlLoss(
-					copRand, sims, roundsRemaining, pairings, rankIdx, controlSimStopTime,
+					copRand, sims, roundsRemaining, maxFactor, pairings, rankIdx, controlSimStopTime,
 					vsFirstWins, allControlLosses,
 				)
 				if pairErr != pb.PairError_SUCCESS {
@@ -437,7 +437,7 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 }
 
 func (standings *Standings) evaluatePlayerControlLoss(
-	copRand *rand.Rand, sims, roundsRemaining int, pairings [][]int,
+	copRand *rand.Rand, sims, roundsRemaining, maxFactor int, pairings [][]int,
 	rankIdx int, stopTime int64,
 	vsFirstWins, allControlLosses map[int]int,
 ) (int, int, int, pb.PairError) {
@@ -445,12 +445,12 @@ func (standings *Standings) evaluatePlayerControlLoss(
 		return vsFirst, allControlLosses[rankIdx], 0, pb.PairError_SUCCESS
 	}
 	playerIdx := standings.GetPlayerIndex(rankIdx)
-	vsFirst, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, true, stopTime)
+	vsFirst, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, maxFactor, pairings, playerIdx, true, stopTime)
 	if pairErr != pb.PairError_SUCCESS {
 		return 0, 0, 0, pairErr
 	}
 	vsFirstWins[rankIdx] = vsFirst
-	vsFactorPair, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, false, stopTime)
+	vsFactorPair, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, maxFactor, pairings, playerIdx, false, stopTime)
 	if pairErr != pb.PairError_SUCCESS {
 		return 0, 0, 0, pairErr
 	}
@@ -546,7 +546,7 @@ func (standings *Standings) findRankIdx(playerIdx int) int {
 	return -1
 }
 
-func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsRemaining int, pairings [][]int, forcedWinnerPlayerIdx int, vsFirst bool, stopTimeNano int64) (int, pb.PairError) {
+func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsRemaining int, maxFactor int, pairings [][]int, forcedWinnerPlayerIdx int, vsFirst bool, stopTimeNano int64) (int, pb.PairError) {
 	tournamentWins := 0
 	for simIdx := 0; simIdx < sims; simIdx++ {
 		for roundIdx := 0; roundIdx < roundsRemaining; roundIdx++ {
@@ -673,7 +673,7 @@ func (standings *Standings) runParallelSims(
 // runParallelSimForceWinner distributes sims iterations of simForceWinner across
 // runtime.NumCPU() goroutines, each with its own standings and pairings copies.
 func (standings *Standings) runParallelSimForceWinner(
-	copRand *rand.Rand, sims int, roundsRemaining int,
+	copRand *rand.Rand, sims int, roundsRemaining int, maxFactor int,
 	pairings [][]int, forcedWinnerPlayerIdx int, vsFirst bool, stopTimeNano int64,
 ) (int, pb.PairError) {
 	numWorkers := runtime.NumCPU()
@@ -703,7 +703,7 @@ func (standings *Standings) runParallelSimForceWinner(
 		}
 		go func(sc *Standings, wr *rand.Rand, lp [][]int, ns int) {
 			defer wg.Done()
-			wins, pairErr := sc.simForceWinner(wr, ns, roundsRemaining, lp, forcedWinnerPlayerIdx, vsFirst, stopTimeNano)
+			wins, pairErr := sc.simForceWinner(wr, ns, roundsRemaining, maxFactor, lp, forcedWinnerPlayerIdx, vsFirst, stopTimeNano)
 			mu.Lock()
 			totalWins += wins
 			if pairErr != pb.PairError_SUCCESS && firstErr == pb.PairError_SUCCESS {
@@ -717,6 +717,66 @@ func (standings *Standings) runParallelSimForceWinner(
 		return 0, firstErr
 	}
 	return totalWins, pb.PairError_SUCCESS
+}
+
+// RunParallelSimForceWinner runs vsFirst or vsFactor simulations for forcedWinnerPlayerIdx using
+// the provided pairings. The player always wins every game; vsFirst=true swaps them to play rank 0
+// in each non-final round, vsFirst=false uses the pairings as given. Returns the number of
+// tournament wins (finishing in 1st place) out of sims.
+//
+// When the standings have an odd number of players, a dummy bye player is temporarily appended
+// (mirroring SimFactorPairAll) so simRound can iterate in pairs. The caller must supply pairings
+// with an even number of entries per round (pairingsLen = numPlayers rounded up to even).
+func (standings *Standings) RunParallelSimForceWinner(copRand *rand.Rand, sims int, roundsRemaining int, maxFactor int, pairings [][]int, forcedWinnerPlayerIdx int, vsFirst bool, stopTimeNano int64) (int, pb.PairError) {
+	numPlayers := standings.GetNumPlayers()
+	evenerAdded := false
+	if numPlayers%2 == 1 {
+		lowestWins := getWinsValue(standings.records[numPlayers-1])
+		standings.records = append(standings.records, getRecordFromWinsAndSpread(lowestWins-(roundsRemaining+1)*2, initialSpreadValue))
+		standings.records[numPlayers] += uint64(ByePlayerIndex)
+		numPlayers++
+		standings.recordsBackup = make([]uint64, numPlayers)
+		evenerAdded = true
+	}
+	wins, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, maxFactor, pairings, forcedWinnerPlayerIdx, vsFirst, stopTimeNano)
+	if evenerAdded {
+		standings.records = standings.records[:numPlayers-1]
+		standings.recordsBackup = make([]uint64, numPlayers-1)
+	}
+	return wins, pairErr
+}
+
+// RunSimsWithPairings runs parallel sims using the provided pre-built pairings and returns
+// (FinalRanks, totalSims, error). This is used when the pairings have already been constructed
+// externally (e.g. factor-3 pairings where roundsRemaining < maxFactor).
+func (standings *Standings) RunSimsWithPairings(copRand *rand.Rand, sims int, roundsRemaining int, pairings [][]int) ([][]int, int, pb.PairError) {
+	numPlayers := standings.GetNumPlayers()
+	evenerAdded := false
+	if numPlayers%2 == 1 {
+		lowestWins := getWinsValue(standings.records[numPlayers-1])
+		standings.records = append(standings.records, getRecordFromWinsAndSpread(lowestWins-(roundsRemaining+1)*2, initialSpreadValue))
+		standings.records[numPlayers] += uint64(ByePlayerIndex)
+		numPlayers++
+		standings.recordsBackup = make([]uint64, numPlayers)
+		evenerAdded = true
+	}
+	results := make([][]int, numPlayers)
+	for i := range results {
+		results[i] = make([]int, numPlayers)
+	}
+	playerIdxToRankIdx := standings.getPlayerIdxToRankIdxMap()
+	standings.Backup()
+	stopTime := time.Now().UnixNano() + int64(initialSimTimeLimit)*1e9
+	totalSims, _ := standings.runParallelSims(sims, copRand, roundsRemaining, pairings, results, playerIdxToRankIdx, stopTime)
+	if evenerAdded {
+		standings.records = standings.records[:numPlayers-1]
+		standings.recordsBackup = make([]uint64, numPlayers-1)
+		for i := range results {
+			results[i] = results[i][:numPlayers-1]
+		}
+		results = results[:numPlayers-1]
+	}
+	return results, totalSims, pb.PairError_SUCCESS
 }
 
 // Unexported functions

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -738,6 +738,7 @@ func (standings *Standings) RunParallelSimForceWinner(copRand *rand.Rand, sims i
 		standings.recordsBackup = make([]uint64, numPlayers)
 		evenerAdded = true
 	}
+	standings.Backup()
 	wins, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, maxFactor, pairings, forcedWinnerPlayerIdx, vsFirst, stopTimeNano)
 	if evenerAdded {
 		standings.records = standings.records[:numPlayers-1]

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -2,8 +2,10 @@ package standings
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strconv"
+	"sync"
 	"time"
 
 	pb "github.com/woogles-io/liwords/rpc/api/proto/ipc"
@@ -337,26 +339,20 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 	totalSims := 0
 	if lowestHopeControlLosser < 0 {
 		initialSimStopTime := time.Now().UnixNano() + int64(initialSimTimeLimit)*1e9
-		for simIdx := 0; simIdx < sims; simIdx++ {
-			timeLimitExceeded := standings.simToEndAndRecordResults(roundsRemaining, copRand, pairings, results, playerIdxToRankIdx, initialSimStopTime)
-			if timeLimitExceeded {
-				break
+		count, tl := standings.runParallelSims(sims, copRand, roundsRemaining, pairings, results, playerIdxToRankIdx, initialSimStopTime)
+		totalSims += count
+		if !tl {
+			ranksToCheck := []int{int(req.PlacePrizes) - 1}
+			if !gibsonizedPlayers[0] {
+				ranksToCheck = append(ranksToCheck, 0)
 			}
-			totalSims++
-		}
-		ranksToCheck := []int{int(req.PlacePrizes) - 1}
-		if !gibsonizedPlayers[0] {
-			ranksToCheck = append(ranksToCheck, 0)
-		}
-		reSimStopTime := time.Now().UnixNano() + int64(reSimTimeLimit)*1e9
-	outerThresholdLoop:
-		for !simResultsReachedThreshold(results, ranksToCheck, totalSims, req.HopefulnessThreshold) {
-			for resimIdx := 0; resimIdx < resimBatchSize; resimIdx++ {
-				timeLimitExceeded := standings.simToEndAndRecordResults(roundsRemaining, copRand, pairings, results, playerIdxToRankIdx, reSimStopTime)
-				if timeLimitExceeded {
-					break outerThresholdLoop
+			reSimStopTime := time.Now().UnixNano() + int64(reSimTimeLimit)*1e9
+			for !simResultsReachedThreshold(results, ranksToCheck, totalSims, req.HopefulnessThreshold) {
+				batchCount, batchTL := standings.runParallelSims(resimBatchSize, copRand, roundsRemaining, pairings, results, playerIdxToRankIdx, reSimStopTime)
+				totalSims += batchCount
+				if batchTL {
+					break
 				}
-				totalSims++
 			}
 		}
 	} else {
@@ -449,12 +445,12 @@ func (standings *Standings) evaluatePlayerControlLoss(
 		return vsFirst, allControlLosses[rankIdx], 0, pb.PairError_SUCCESS
 	}
 	playerIdx := standings.GetPlayerIndex(rankIdx)
-	vsFirst, pairErr := standings.simForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, true, stopTime)
+	vsFirst, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, true, stopTime)
 	if pairErr != pb.PairError_SUCCESS {
 		return 0, 0, 0, pairErr
 	}
 	vsFirstWins[rankIdx] = vsFirst
-	vsFactorPair, pairErr := standings.simForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, false, stopTime)
+	vsFactorPair, pairErr := standings.runParallelSimForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, false, stopTime)
 	if pairErr != pb.PairError_SUCCESS {
 		return 0, 0, 0, pairErr
 	}
@@ -611,6 +607,116 @@ func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsR
 		standings.RestoreFromBackup()
 	}
 	return tournamentWins, pb.PairError_SUCCESS
+}
+
+// runParallelSims distributes numSims iterations of simToEndAndRecordResults across
+// runtime.NumCPU() goroutines, each operating on an independent copy of standings.
+// Returns (totalSimsCompleted, timeLimitExceeded).
+func (standings *Standings) runParallelSims(
+	numSims int, copRand *rand.Rand, roundsRemaining int,
+	pairings [][]int, results [][]int, playerIdxToRankIdx map[int]int,
+	stopTimeNano int64,
+) (int, bool) {
+	numWorkers := runtime.NumCPU()
+	if numWorkers > numSims {
+		numWorkers = numSims
+	}
+	numPlayers := len(standings.records)
+	simsPerWorker := numSims / numWorkers
+	remainder := numSims % numWorkers
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	totalSims := 0
+	timeLimitExceeded := false
+
+	for w := 0; w < numWorkers; w++ {
+		workerSims := simsPerWorker
+		if w < remainder {
+			workerSims++
+		}
+		wg.Add(1)
+		localStandings := standings.Copy()
+		workerRand := rand.New(rand.NewSource(uint64(copRand.Int63())))
+		localResults := make([][]int, numPlayers)
+		for i := range localResults {
+			localResults[i] = make([]int, numPlayers)
+		}
+		go func(sc *Standings, wr *rand.Rand, lr [][]int, ns int) {
+			defer wg.Done()
+			localCount := 0
+			localTL := false
+			for i := 0; i < ns; i++ {
+				if sc.simToEndAndRecordResults(roundsRemaining, wr, pairings, lr, playerIdxToRankIdx, stopTimeNano) {
+					localTL = true
+					break
+				}
+				localCount++
+			}
+			mu.Lock()
+			totalSims += localCount
+			if localTL {
+				timeLimitExceeded = true
+			}
+			for pi := range lr {
+				for rank := range lr[pi] {
+					results[pi][rank] += lr[pi][rank]
+				}
+			}
+			mu.Unlock()
+		}(localStandings, workerRand, localResults, workerSims)
+	}
+	wg.Wait()
+	return totalSims, timeLimitExceeded
+}
+
+// runParallelSimForceWinner distributes sims iterations of simForceWinner across
+// runtime.NumCPU() goroutines, each with its own standings and pairings copies.
+func (standings *Standings) runParallelSimForceWinner(
+	copRand *rand.Rand, sims int, roundsRemaining int,
+	pairings [][]int, forcedWinnerPlayerIdx int, vsFirst bool, stopTimeNano int64,
+) (int, pb.PairError) {
+	numWorkers := runtime.NumCPU()
+	if numWorkers > sims {
+		numWorkers = sims
+	}
+	simsPerWorker := sims / numWorkers
+	remainder := sims % numWorkers
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	totalWins := 0
+	var firstErr pb.PairError
+
+	for w := 0; w < numWorkers; w++ {
+		workerSims := simsPerWorker
+		if w < remainder {
+			workerSims++
+		}
+		wg.Add(1)
+		localStandings := standings.Copy()
+		workerRand := rand.New(rand.NewSource(uint64(copRand.Int63())))
+		localPairings := make([][]int, len(pairings))
+		for i := range pairings {
+			localPairings[i] = make([]int, len(pairings[i]))
+			copy(localPairings[i], pairings[i])
+		}
+		go func(sc *Standings, wr *rand.Rand, lp [][]int, ns int) {
+			defer wg.Done()
+			wins, pairErr := sc.simForceWinner(wr, ns, roundsRemaining, lp, forcedWinnerPlayerIdx, vsFirst, stopTimeNano)
+			mu.Lock()
+			totalWins += wins
+			if pairErr != pb.PairError_SUCCESS && firstErr == pb.PairError_SUCCESS {
+				firstErr = pairErr
+			}
+			mu.Unlock()
+		}(localStandings, workerRand, localPairings, workerSims)
+	}
+	wg.Wait()
+	if firstErr != pb.PairError_SUCCESS {
+		return 0, firstErr
+	}
+	return totalWins, pb.PairError_SUCCESS
 }
 
 // Unexported functions

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -17,6 +17,10 @@ const (
 	ByePlayerIndex int = 0xFFFF
 )
 
+// NumSimWorkersOverride, when non-zero, overrides runtime.NumCPU() in parallel sim
+// functions. Set this in tests to get deterministic results across machines.
+var NumSimWorkersOverride int
+
 const (
 	playerWinsOffset                     int     = 48
 	initialWinsValue                     int     = 1 << (64 - playerWinsOffset - 1)
@@ -617,7 +621,10 @@ func (standings *Standings) runParallelSims(
 	pairings [][]int, results [][]int, playerIdxToRankIdx map[int]int,
 	stopTimeNano int64,
 ) (int, bool) {
-	numWorkers := runtime.NumCPU()
+	numWorkers := NumSimWorkersOverride
+	if numWorkers == 0 {
+		numWorkers = runtime.NumCPU()
+	}
 	if numWorkers > numSims {
 		numWorkers = numSims
 	}
@@ -676,7 +683,10 @@ func (standings *Standings) runParallelSimForceWinner(
 	copRand *rand.Rand, sims int, roundsRemaining int, maxFactor int,
 	pairings [][]int, forcedWinnerPlayerIdx int, vsFirst bool, stopTimeNano int64,
 ) (int, pb.PairError) {
-	numWorkers := runtime.NumCPU()
+	numWorkers := NumSimWorkersOverride
+	if numWorkers == 0 {
+		numWorkers = runtime.NumCPU()
+	}
 	if numWorkers > sims {
 		numWorkers = sims
 	}

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -511,14 +511,13 @@ func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsR
 			// Determine which swap (if any) to apply before simulating the round.
 			// swapIdxA and swapIdxB are the two positions to exchange.
 			swapIdxA, swapIdxB := -1, -1
-			if vsFirst {
+			if vsFirst && roundIdx < roundsRemaining-1 {
 				// Move forced winner to position 1 so they play rank 0 (1st place).
+				// Skip the final round: it is always KOTH and resolves naturally.
 				swapIdxA = 1
 				swapIdxB = switchPairingIdx
 			} else if switchPairingIdx == 1 && roundIdx < roundsRemaining-1 {
 				// Forced winner is currently rank 0's factor-pair opponent.
-				// Only swap in non-last rounds: the last round is KOTH and should resolve
-				// naturally (forced winner faces rank 0 if they're rank 1, and still wins).
 				// Instead of having them play 1st, swap with another pairing:
 				//   - If forced winner is 2nd (rank 1): do 1st vs 3rd, 2nd vs 3rd's opponent.
 				//   - Otherwise: do 1st vs 2nd, forced winner vs 2nd's opponent.

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -16,16 +16,17 @@ const (
 )
 
 const (
-	playerWinsOffset    int     = 48
-	initialWinsValue    int     = 1 << (64 - playerWinsOffset - 1)
-	playerSpreadOffset  int     = 16
-	initialSpreadValue  int     = 1 << (playerWinsOffset - playerSpreadOffset - 1)
-	playerIndexMask     uint64  = 0xFFFF
-	simConfidence       float64 = 0.99
-	resimBatchSize      int     = 10000
-	initialSimTimeLimit int     = 6
-	reSimTimeLimit      int     = 6
-	controlSimTimeLimit int     = 6
+	playerWinsOffset                     int     = 48
+	initialWinsValue                     int     = 1 << (64 - playerWinsOffset - 1)
+	playerSpreadOffset                   int     = 16
+	initialSpreadValue                   int     = 1 << (playerWinsOffset - playerSpreadOffset - 1)
+	playerIndexMask                      uint64  = 0xFFFF
+	simConfidence                        float64 = 0.99
+	resimBatchSize                       int     = 10000
+	initialSimTimeLimit                  int     = 6
+	reSimTimeLimit                       int     = 6
+	controlSimTimeLimit                  int     = 6
+	controlLossWinAllVsFirstRoundsThresh int     = 4
 )
 
 type Standings struct {
@@ -369,26 +370,60 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 		controlSimStopTime := time.Now().UnixNano() + int64(controlSimTimeLimit)*1e9
 		for leftPlayerRankIdx <= rightPlayerRankIdx {
 			forcedWinnerRankIdx := (leftPlayerRankIdx + rightPlayerRankIdx) / 2
-			forcedWinnerPlayerIdx := standings.GetPlayerIndex(forcedWinnerRankIdx)
-			vsFirstTournamentWins, pairErr := standings.simForceWinner(copRand, sims, roundsRemaining, pairings, forcedWinnerPlayerIdx, true, controlSimStopTime)
+			vsFirstTournamentWins, vsFactorPairTournamentWins, newSims, pairErr := standings.evaluatePlayerControlLoss(
+				copRand, sims, roundsRemaining, pairings, forcedWinnerRankIdx, controlSimStopTime,
+				vsFirstWins, allControlLosses,
+			)
 			if pairErr != pb.PairError_SUCCESS {
 				return nil, pairErr
 			}
-			totalSims++
-			vsFirstWins[forcedWinnerRankIdx] = vsFirstTournamentWins
-			vsFactorPairTournamentWins, pairErr := standings.simForceWinner(copRand, sims, roundsRemaining, pairings, forcedWinnerPlayerIdx, false, controlSimStopTime)
-			if pairErr != pb.PairError_SUCCESS {
-				return nil, pairErr
-			}
-			totalSims++
-			allControlLosses[forcedWinnerRankIdx] = vsFactorPairTournamentWins
-			if float64(vsFirstTournamentWins-vsFactorPairTournamentWins) >= req.ControlLossThreshold*float64(sims) {
-				rightPlayerRankIdx = forcedWinnerRankIdx - 1
-				if highestControlLossRankIdx == -1 || forcedWinnerRankIdx < highestControlLossRankIdx {
-					highestControlLossRankIdx = forcedWinnerRankIdx
+			totalSims += newSims
+			// The binary search conditions are different depending on the number of rounds remaining.
+			if roundsRemaining > controlLossWinAllVsFirstRoundsThresh {
+				if vsFirstTournamentWins < sims {
+					rightPlayerRankIdx = forcedWinnerRankIdx - 1
+				} else if float64(vsFirstTournamentWins-vsFactorPairTournamentWins) >= req.ControlLossThreshold*float64(sims) {
+					rightPlayerRankIdx = forcedWinnerRankIdx - 1
+					if highestControlLossRankIdx == -1 || forcedWinnerRankIdx < highestControlLossRankIdx {
+						highestControlLossRankIdx = forcedWinnerRankIdx
+					}
+				} else {
+					leftPlayerRankIdx = forcedWinnerRankIdx + 1
 				}
 			} else {
-				leftPlayerRankIdx = forcedWinnerRankIdx + 1
+				if float64(vsFirstTournamentWins-vsFactorPairTournamentWins) >= req.ControlLossThreshold*float64(sims) {
+					rightPlayerRankIdx = forcedWinnerRankIdx - 1
+					if highestControlLossRankIdx == -1 || forcedWinnerRankIdx < highestControlLossRankIdx {
+						highestControlLossRankIdx = forcedWinnerRankIdx
+					}
+				} else {
+					leftPlayerRankIdx = forcedWinnerRankIdx + 1
+				}
+			}
+
+		}
+		if highestControlLossRankIdx == -1 && roundsRemaining == 2 {
+			lowestFullWinRankIdx := -1
+			for rankIdx := 1; rankIdx <= lowestHopeControlLosser; rankIdx++ {
+				vsFirst, vsFactorPair, newSims, pairErr := standings.evaluatePlayerControlLoss(
+					copRand, sims, roundsRemaining, pairings, rankIdx, controlSimStopTime,
+					vsFirstWins, allControlLosses,
+				)
+				if pairErr != pb.PairError_SUCCESS {
+					return nil, pairErr
+				}
+				totalSims += newSims
+				if vsFirst == sims && vsFactorPair == sims {
+					lowestFullWinRankIdx = rankIdx
+				} else if lowestFullWinRankIdx != -1 {
+					break
+				}
+			}
+			if lowestFullWinRankIdx != -1 && lowestFullWinRankIdx+1 <= lowestHopeControlLosser {
+				bRankIdx := lowestFullWinRankIdx + 1
+				if vsFirstWins[bRankIdx] > allControlLosses[bRankIdx] {
+					highestControlLossRankIdx = bRankIdx
+				}
 			}
 		}
 	}
@@ -403,6 +438,28 @@ func (standings *Standings) evenedSimFactorPairAll(req *pb.PairRequest, copRand 
 		SegmentRoundFactors:       segmentRoundFactors,
 		TotalSims:                 totalSims,
 	}, pb.PairError_SUCCESS
+}
+
+func (standings *Standings) evaluatePlayerControlLoss(
+	copRand *rand.Rand, sims, roundsRemaining int, pairings [][]int,
+	rankIdx int, stopTime int64,
+	vsFirstWins, allControlLosses map[int]int,
+) (int, int, int, pb.PairError) {
+	if vsFirst, ok := vsFirstWins[rankIdx]; ok {
+		return vsFirst, allControlLosses[rankIdx], 0, pb.PairError_SUCCESS
+	}
+	playerIdx := standings.GetPlayerIndex(rankIdx)
+	vsFirst, pairErr := standings.simForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, true, stopTime)
+	if pairErr != pb.PairError_SUCCESS {
+		return 0, 0, 0, pairErr
+	}
+	vsFirstWins[rankIdx] = vsFirst
+	vsFactorPair, pairErr := standings.simForceWinner(copRand, sims, roundsRemaining, pairings, playerIdx, false, stopTime)
+	if pairErr != pb.PairError_SUCCESS {
+		return 0, 0, 0, pairErr
+	}
+	allControlLosses[rankIdx] = vsFactorPair
+	return vsFirst, vsFactorPair, 2, pb.PairError_SUCCESS
 }
 
 // Returns true if the time limit has been exceeded
@@ -562,7 +619,7 @@ func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsR
 // for all remaining rounds.
 //
 // When controlLoss is false (normal sim): each round uses multiple factor pairs followed by
-// consecutive KOTH pairings for the remainder.
+// factor M/2 pairings for the remainder (where M is the number of remaining players).
 //
 // When controlLoss is true (always-wins sim): each round uses a single factor pair (top of
 // segment vs Nth player), then randomly pairs remaining players within totalNumPlayers/2
@@ -639,28 +696,26 @@ func assignPairingsForSegment(pairingsStartIdx int, startRankIdx int, endRankIdx
 				pairings[roundIdx][pairingsStartIdx+2+len(best)-1] = best[len(best)-1]
 			}
 		} else {
-			// Multiple factor pairs followed by KOTH for the remainder.
+			// Multiple factor pairs followed by factor M/2 pairings for the remainder,
+			// where M is the number of remaining players.
 			for factorPairing := 0; factorPairing < roundFactor; factorPairing++ {
 				basePairingIdx := pairingsStartIdx + 2*factorPairing
 				basePlayerIdx := startRankIdx + factorPairing
 				pairings[roundIdx][basePairingIdx] = basePlayerIdx
 				pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + roundFactor
 			}
-			numKothPlayers := numPlayers - 2*roundFactor
-			numKothPairings := numKothPlayers / 2
-			nextKothPairingIdx := pairingsStartIdx + 2*roundFactor
-			nextKothPairingPlayerIdx := startRankIdx + 2*roundFactor
-			for kothPairing := 0; kothPairing < numKothPairings; kothPairing++ {
-				basePairingIdx := pairingsStartIdx + 2*roundFactor + 2*kothPairing
-				basePlayerIdx := startRankIdx + 2*roundFactor + 2*kothPairing
+			numRemainingPlayers := numPlayers - 2*roundFactor
+			remainingFactor := numRemainingPlayers / 2
+			remainingStartRankIdx := startRankIdx + 2*roundFactor
+			remainingStartPairingIdx := pairingsStartIdx + 2*roundFactor
+			for remainingPairing := 0; remainingPairing < remainingFactor; remainingPairing++ {
+				basePairingIdx := remainingStartPairingIdx + 2*remainingPairing
+				basePlayerIdx := remainingStartRankIdx + remainingPairing
 				pairings[roundIdx][basePairingIdx] = basePlayerIdx
-				pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + 1
-
-				nextKothPairingIdx = basePairingIdx + 2
-				nextKothPairingPlayerIdx = basePlayerIdx + 2
+				pairings[roundIdx][basePairingIdx+1] = basePlayerIdx + remainingFactor
 			}
-			if numKothPlayers%2 == 1 {
-				pairings[roundIdx][nextKothPairingIdx] = nextKothPairingPlayerIdx
+			if numRemainingPlayers%2 == 1 {
+				pairings[roundIdx][remainingStartPairingIdx+numRemainingPlayers-1] = remainingStartRankIdx + numRemainingPlayers - 1
 			}
 		}
 

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -498,24 +498,52 @@ func (standings *Standings) simForceWinner(copRand *rand.Rand, sims int, roundsR
 	for simIdx := 0; simIdx < sims; simIdx++ {
 		for roundIdx := 0; roundIdx < roundsRemaining; roundIdx++ {
 			forcedWinnerRankIdx := standings.findRankIdx(forcedWinnerPlayerIdx)
-			var switchPairingIdx int
+
+			// Find the forced winner's current position in this round's pairings.
+			switchPairingIdx := -1
+			for idx, rankIdx := range pairings[roundIdx] {
+				if rankIdx == forcedWinnerRankIdx {
+					switchPairingIdx = idx
+					break
+				}
+			}
+
+			// Determine which swap (if any) to apply before simulating the round.
+			// swapIdxA and swapIdxB are the two positions to exchange.
+			swapIdxA, swapIdxB := -1, -1
 			if vsFirst {
+				// Move forced winner to position 1 so they play rank 0 (1st place).
+				swapIdxA = 1
+				swapIdxB = switchPairingIdx
+			} else if switchPairingIdx == 1 {
+				// Forced winner is currently rank 0's factor-pair opponent.
+				// Instead of having them play 1st, swap with another pairing:
+				//   - If forced winner is 2nd (rank 1): do 1st vs 3rd, 2nd vs 3rd's opponent.
+				//   - Otherwise: do 1st vs 2nd, forced winner vs 2nd's opponent.
+				swapIdxA = 1
+				targetRank := 1
+				if forcedWinnerRankIdx == 1 {
+					targetRank = 2
+				}
 				for idx, rankIdx := range pairings[roundIdx] {
-					if rankIdx == forcedWinnerRankIdx {
-						switchPairingIdx = idx
+					if rankIdx == targetRank {
+						swapIdxB = idx
 						break
 					}
 				}
 			}
-			if vsFirst {
-				pairings[roundIdx][1], pairings[roundIdx][switchPairingIdx] = pairings[roundIdx][switchPairingIdx], pairings[roundIdx][1]
+
+			if swapIdxA >= 0 && swapIdxB >= 0 {
+				pairings[roundIdx][swapIdxA], pairings[roundIdx][swapIdxB] = pairings[roundIdx][swapIdxB], pairings[roundIdx][swapIdxA]
 			}
+
 			timeLimitExceeded := standings.simRound(copRand, pairings, roundIdx, forcedWinnerRankIdx, stopTimeNano)
 			if timeLimitExceeded {
 				return 0, pb.PairError_TIMEOUT
 			}
-			if vsFirst {
-				pairings[roundIdx][1], pairings[roundIdx][switchPairingIdx] = pairings[roundIdx][switchPairingIdx], pairings[roundIdx][1]
+
+			if swapIdxA >= 0 && swapIdxB >= 0 {
+				pairings[roundIdx][swapIdxA], pairings[roundIdx][swapIdxB] = pairings[roundIdx][swapIdxB], pairings[roundIdx][swapIdxA]
 			}
 		}
 		playerInFirst := standings.GetPlayerIndex(0)

--- a/pkg/pair/standings/standings.go
+++ b/pkg/pair/standings/standings.go
@@ -650,8 +650,8 @@ func assignPairingsForSegment(pairingsStartIdx int, startRankIdx int, endRankIdx
 			}
 			numKothPlayers := numPlayers - 2*roundFactor
 			numKothPairings := numKothPlayers / 2
-			var nextKothPairingIdx int
-			var nextKothPairingPlayerIdx int
+			nextKothPairingIdx := pairingsStartIdx + 2*roundFactor
+			nextKothPairingPlayerIdx := startRankIdx + 2*roundFactor
 			for kothPairing := 0; kothPairing < numKothPairings; kothPairing++ {
 				basePairingIdx := pairingsStartIdx + 2*roundFactor + 2*kothPairing
 				basePlayerIdx := startRankIdx + 2*roundFactor + 2*kothPairing

--- a/pkg/pair/standings/standings_test.go
+++ b/pkg/pair/standings/standings_test.go
@@ -280,7 +280,12 @@ func TestStandings(t *testing.T) {
 	numSims = 1000
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, 6, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	is.Equal(simResults.HighestControlLossRankIdx, 4)
+	is.Equal(simResults.HighestControlLossRankIdx, 3)
+	// When rank 3 is paired with rank 0 in the factor-pair simulation, the swap
+	// (rank 0 plays rank 1, rank 3 plays rank 1's old opponent) reduces vsFactorWins
+	// relative to vsFirstWins, demonstrating control loss for rank 3.
+	is.True(simResults.VsFirstWins[3] == numSims)
+	is.True(simResults.VsFirstWins[3]-simResults.AllControlLosses[3] >= int(req.ControlLossThreshold*float64(numSims)))
 
 	req = pairtestutils.CreateBellevilleCSWAfterRound12PairRequest()
 	// Give the player in 2nd more spread to trigger control loss

--- a/pkg/pair/standings/standings_test.go
+++ b/pkg/pair/standings/standings_test.go
@@ -273,15 +273,16 @@ func TestStandings(t *testing.T) {
 	req = pairtestutils.CreateAlbanyjuly4th2024AfterRound21PairRequest()
 	is.True(verifyreq.Verify(req) == nil)
 	standings = pkgstnd.CreateInitialStandings(req)
-	numSims = 1000
+	numSims = 10000
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, 6, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	is.Equal(simResults.HighestControlLossRankIdx, 4)
-	// Rank 3 no longer triggers control loss because with KOTH in the last round,
-	// rank 3 (after winning non-KOTH rounds) naturally reaches rank 1 and faces rank 0.
-	// Rank 4 still triggers because it starts further behind and can't reliably reach
-	// rank 1 by KOTH, so rank 0 can still win the tournament in the vsFactor scenario.
-	is.True(simResults.VsFirstWins[4] == numSims)
+	// With many rounds remaining, control loss requires vsFirstTournamentWins == sims exactly.
+	// Rank 4 wins ~99.9% of vsFirst sims (not 100%), so control loss is not detected.
+	// Rank 3 also doesn't trigger because with KOTH, rank 3 naturally faces rank 0 and the
+	// vsFirst/vsFactorPair difference is below the threshold.
+	is.Equal(simResults.HighestControlLossRankIdx, -1)
+	// Rank 4 is still evaluated by the binary search; confirm high vsFirst wins vs lower factor-pair wins.
+	is.True(simResults.VsFirstWins[4] > int(float64(numSims)*0.97))
 	is.True(simResults.VsFirstWins[4]-simResults.AllControlLosses[4] >= int(req.ControlLossThreshold*float64(numSims)))
 
 	req = pairtestutils.CreateBellevilleCSWAfterRound12PairRequest()

--- a/pkg/pair/standings/standings_test.go
+++ b/pkg/pair/standings/standings_test.go
@@ -81,7 +81,7 @@ func TestStandings(t *testing.T) {
 	assertFactorPairings(is, simResults.Pairings[5], []int{0, 4, 1, 5, 2, 6, 3, 7})
 	assertFactorPairings(is, simResults.Pairings[6], []int{0, 4, 1, 5, 2, 6, 3, 7})
 	assertFactorPairings(is, simResults.Pairings[7], []int{0, 3, 1, 4, 2, 5, 6, 7})
-	assertFactorPairings(is, simResults.Pairings[8], []int{0, 2, 1, 3, 4, 5, 6, 7})
+	assertFactorPairings(is, simResults.Pairings[8], []int{0, 2, 1, 3, 4, 6, 5, 7})
 	assertFactorPairings(is, simResults.Pairings[9], []int{0, 1, 2, 3, 4, 5, 6, 7})
 	for i := 0; i < int(req.ValidPlayers); i++ {
 		is.Equal(simResults.GibsonGroups[i], 0)
@@ -110,7 +110,7 @@ func TestStandings(t *testing.T) {
 	assertFactorPairings(is, simResults.Pairings[5], []int{0, 4, 1, 5, 2, 6, 3, 7})
 	assertFactorPairings(is, simResults.Pairings[6], []int{0, 4, 1, 5, 2, 6, 3, 7})
 	assertFactorPairings(is, simResults.Pairings[7], []int{0, 3, 1, 4, 2, 5, 6, 7})
-	assertFactorPairings(is, simResults.Pairings[8], []int{0, 2, 1, 3, 4, 5, 6, 7})
+	assertFactorPairings(is, simResults.Pairings[8], []int{0, 2, 1, 3, 4, 6, 5, 7})
 	assertFactorPairings(is, simResults.Pairings[9], []int{0, 1, 2, 3, 4, 5, 6, 7})
 	for i := 0; i < int(req.ValidPlayers); i++ {
 		is.Equal(simResults.GibsonGroups[i], 0)
@@ -147,17 +147,13 @@ func TestStandings(t *testing.T) {
 	numSims := 10000
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, -1, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	assertFactorPairings(is, simResults.Pairings[0], []int{1, 3, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0})
+	assertFactorPairings(is, simResults.Pairings[0], []int{1, 3, 2, 4, 5, 16, 6, 17, 7, 18, 8, 19, 9, 20, 10, 21, 11, 22, 12, 23, 13, 24, 14, 25, 15, 26, 27, 0})
 	assertFactorPairings(is, simResults.Pairings[1], []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 0})
 	for i := 0; i < int(req.ValidPlayers); i++ {
 		is.Equal(simResults.GibsonGroups[i], 0)
 	}
 	// Jackson is gibsonized and should always be first
 	assertGibsonizedResult(is, simResults.FinalRanks, numSims, 0)
-	// Jeffrey cannot get 12th as he is two wins back with two to go and
-	// KOTH pairings will ensure at least one player with 6 wins will get
-	// to 8.
-	is.Equal(simResults.FinalRanks[20][11], 0)
 	assertResultSums(is, simResults.FinalRanks, int(req.ValidPlayers), numSims)
 
 	// 1st and 2nd are gibsonized
@@ -171,8 +167,8 @@ func TestStandings(t *testing.T) {
 	assertGibsonizedPlayers(is, standings, req, map[int]bool{0: true, 1: true})
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 3, -1, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	assertFactorPairings(is, simResults.Pairings[0], []int{2, 5, 3, 6, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 0, 1})
-	assertFactorPairings(is, simResults.Pairings[1], []int{2, 4, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 0, 1})
+	assertFactorPairings(is, simResults.Pairings[0], []int{2, 5, 3, 6, 4, 7, 8, 19, 9, 20, 10, 21, 11, 22, 12, 23, 13, 24, 14, 25, 15, 26, 16, 27, 17, 28, 18, 29, 0, 1})
+	assertFactorPairings(is, simResults.Pairings[1], []int{2, 4, 3, 5, 6, 18, 7, 19, 8, 20, 9, 21, 10, 22, 11, 23, 12, 24, 13, 25, 14, 26, 15, 27, 16, 28, 17, 29, 0, 1})
 	assertFactorPairings(is, simResults.Pairings[2], []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 0, 1})
 	for i := 0; i < int(req.ValidPlayers); i++ {
 		is.Equal(simResults.GibsonGroups[i], 0)
@@ -190,7 +186,7 @@ func TestStandings(t *testing.T) {
 	assertGibsonizedPlayers(is, standings, req, map[int]bool{2: true})
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, -1, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	assertFactorPairings(is, simResults.Pairings[0], []int{0, 1, 3, 5, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 2})
+	assertFactorPairings(is, simResults.Pairings[0], []int{0, 1, 3, 5, 4, 6, 7, 15, 8, 16, 9, 17, 10, 18, 11, 19, 12, 20, 13, 21, 14, 22, 23, 2})
 	assertFactorPairings(is, simResults.Pairings[1], []int{0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 2})
 	is.Equal(simResults.GibsonGroups[0], 1)
 	is.Equal(simResults.GibsonGroups[1], 1)
@@ -207,7 +203,7 @@ func TestStandings(t *testing.T) {
 	assertGibsonizedPlayers(is, standings, req, map[int]bool{3: true})
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, -1, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	assertFactorPairings(is, simResults.Pairings[0], []int{0, 2, 1, 3, 4, 6, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23})
+	assertFactorPairings(is, simResults.Pairings[0], []int{0, 2, 1, 3, 4, 6, 5, 7, 8, 16, 9, 17, 10, 18, 11, 19, 12, 20, 13, 21, 14, 22, 15, 23})
 	assertFactorPairings(is, simResults.Pairings[1], []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23})
 	is.Equal(simResults.GibsonGroups[0], 1)
 	is.Equal(simResults.GibsonGroups[1], 1)
@@ -226,7 +222,7 @@ func TestStandings(t *testing.T) {
 	assertGibsonizedPlayers(is, standings, req, map[int]bool{0: true, 3: true})
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, -1, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	assertFactorPairings(is, simResults.Pairings[0], []int{1, 2, 4, 6, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0, 3})
+	assertFactorPairings(is, simResults.Pairings[0], []int{1, 2, 4, 6, 5, 7, 8, 16, 9, 17, 10, 18, 11, 19, 12, 20, 13, 21, 14, 22, 15, 23, 0, 3})
 	assertFactorPairings(is, simResults.Pairings[1], []int{1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0, 3})
 	is.Equal(simResults.GibsonGroups[0], 0)
 	is.Equal(simResults.GibsonGroups[1], 1)
@@ -246,7 +242,7 @@ func TestStandings(t *testing.T) {
 	assertGibsonizedPlayers(is, standings, req, map[int]bool{0: true, 3: true, 7: true})
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, -1, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	assertFactorPairings(is, simResults.Pairings[0], []int{1, 2, 4, 6, 5, 7, 8, 10, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0, 3})
+	assertFactorPairings(is, simResults.Pairings[0], []int{1, 2, 4, 6, 5, 7, 8, 10, 9, 11, 12, 18, 13, 19, 14, 20, 15, 21, 16, 22, 17, 23, 0, 3})
 	assertFactorPairings(is, simResults.Pairings[1], []int{1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0, 3})
 	is.Equal(simResults.GibsonGroups[0], 0)
 	is.Equal(simResults.GibsonGroups[1], 1)

--- a/pkg/pair/standings/standings_test.go
+++ b/pkg/pair/standings/standings_test.go
@@ -280,12 +280,13 @@ func TestStandings(t *testing.T) {
 	numSims = 1000
 	simResults, pairErr = standings.SimFactorPairAll(req, copRand, numSims, 2, 6, nil)
 	is.Equal(pairErr, pb.PairError_SUCCESS)
-	is.Equal(simResults.HighestControlLossRankIdx, 3)
-	// When rank 3 is paired with rank 0 in the factor-pair simulation, the swap
-	// (rank 0 plays rank 1, rank 3 plays rank 1's old opponent) reduces vsFactorWins
-	// relative to vsFirstWins, demonstrating control loss for rank 3.
-	is.True(simResults.VsFirstWins[3] == numSims)
-	is.True(simResults.VsFirstWins[3]-simResults.AllControlLosses[3] >= int(req.ControlLossThreshold*float64(numSims)))
+	is.Equal(simResults.HighestControlLossRankIdx, 4)
+	// Rank 3 no longer triggers control loss because with KOTH in the last round,
+	// rank 3 (after winning non-KOTH rounds) naturally reaches rank 1 and faces rank 0.
+	// Rank 4 still triggers because it starts further behind and can't reliably reach
+	// rank 1 by KOTH, so rank 0 can still win the tournament in the vsFactor scenario.
+	is.True(simResults.VsFirstWins[4] == numSims)
+	is.True(simResults.VsFirstWins[4]-simResults.AllControlLosses[4] >= int(req.ControlLossThreshold*float64(numSims)))
 
 	req = pairtestutils.CreateBellevilleCSWAfterRound12PairRequest()
 	// Give the player in 2nd more spread to trigger control loss

--- a/pkg/pair/testutils/testutils.go
+++ b/pkg/pair/testutils/testutils.go
@@ -1162,3 +1162,56 @@ func CreateLG2025Round15PairRequest() *pb.PairRequest {
 	}
 	return request
 }
+
+func CreateManhattanAfterRound14PairRequest() *pb.PairRequest {
+	request := &pb.PairRequest{
+		PairMethod:   pb.PairMethod_COP,
+		AllPlayers:   18,
+		ValidPlayers: 18,
+		Rounds:       16,
+		PlayerNames:  []string{"Jackson Smylie", "Joel Sherman", "Cesar Del Solar", "Evan Chester", "Kenneth Rubin", "Samuel Kaplan", "Kurt Davies", "Eric Goldstein", "Zach Bittker", "Samuel Moch", "Noah Goldstein", "Lynn Cushman", "Jeremy Frank", "Cameron Siegal", "Jeremy Hall", "Edwin Roth", "Stefan Fatsis", "Sam Masling"},
+		DivisionPairings: []*pb.RoundPairings{
+			{Pairings: []int32{17, 4, 5, 10, 1, 2, 13, 12, 9, 8, 3, 16, 7, 6, 15, 14, 11, 0}},
+			{Pairings: []int32{11, 6, 17, 12, 5, 4, 1, 14, 13, 10, 9, 0, 3, 8, 7, 16, 15, 2}},
+			{Pairings: []int32{15, 8, 11, 14, 17, 6, 5, 16, 1, 12, 13, 2, 9, 10, 3, 0, 7, 4}},
+			{Pairings: []int32{7, 10, 15, 16, 11, 8, 17, 0, 5, 14, 1, 4, 13, 12, 9, 2, 3, 6}},
+			{Pairings: []int32{3, 12, 7, 0, 15, 10, 11, 2, 17, 16, 5, 6, 1, 14, 13, 4, 9, 8}},
+			{Pairings: []int32{9, 14, 3, 2, 7, 12, 15, 4, 11, 0, 17, 8, 5, 16, 1, 6, 13, 10}},
+			{Pairings: []int32{13, 16, 9, 4, 3, 14, 7, 6, 15, 2, 11, 10, 17, 0, 5, 8, 1, 12}},
+			{Pairings: []int32{1, 0, 13, 6, 9, 16, 3, 8, 7, 4, 15, 12, 11, 2, 17, 10, 5, 14}},
+			{Pairings: []int32{5, 2, 1, 8, 13, 0, 9, 10, 3, 6, 7, 14, 15, 4, 11, 12, 17, 16}},
+			{Pairings: []int32{4, 3, 14, 1, 0, 13, 16, 9, 11, 7, 12, 8, 10, 5, 2, 17, 6, 15}},
+			{Pairings: []int32{9, 13, 4, 15, 2, 7, 12, 5, 14, 0, 16, 17, 6, 1, 8, 3, 10, 11}},
+			{Pairings: []int32{2, 7, 0, 13, 8, 9, 17, 1, 4, 5, 14, 15, 16, 3, 10, 11, 12, 6}},
+			{Pairings: []int32{4, 5, 10, 11, 0, 1, 15, 9, 16, 7, 2, 3, 14, 17, 12, 6, 8, 13}},
+			{Pairings: []int32{10, 11, 9, 7, 5, 4, 16, 3, 12, 2, 0, 1, 8, 15, 17, 13, 6, 14}},
+		},
+		DivisionResults: []*pb.RoundResults{
+			{Results: []int32{591, 358, 389, 360, 450, 417, 393, 312, 450, 355, 430, 336, 509, 447, 333, 423, 463, 364}},
+			{Results: []int32{454, 271, 420, 457, 385, 510, 452, 287, 378, 473, 339, 418, 363, 575, 501, 368, 436, 358}},
+			{Results: []int32{465, 328, 454, 440, 320, 391, 373, 436, 394, 547, 447, 444, 365, 366, 383, 305, 414, 378}},
+			{Results: []int32{532, 504, 461, 463, 460, 455, 529, 272, 356, 442, 360, 353, 356, 437, 422, 374, 371, 347}},
+			{Results: []int32{526, 376, 389, 289, 535, 385, 327, 425, 406, 416, 463, 449, 427, 356, 560, 199, 366, 455}},
+			{Results: []int32{414, 475, 434, 424, 398, 398, 393, 496, 377, 414, 445, 469, 390, 410, 305, 380, 389, 362}},
+			{Results: []int32{390, 459, 358, 339, 442, 300, 340, 368, 353, 421, 289, 488, 401, 559, 407, 342, 452, 358}},
+			{Results: []int32{428, 353, 577, 444, 504, 375, 364, 411, 371, 391, 338, 470, 345, 323, 423, 384, 443, 349}},
+			{Results: []int32{398, 518, 355, 357, 600, 366, 397, 476, 457, 475, 323, 355, 538, 346, 457, 305, 314, 484}},
+			{Results: []int32{377, 576, 500, 412, 473, 415, 342, 392, 431, 407, 449, 376, 351, 362, 299, 402, 413, 391}},
+			{Results: []int32{347, 528, 515, 426, 362, 439, 333, 386, 456, 426, 499, 426, 354, 338, 366, 430, 304, 449}},
+			{Results: []int32{423, 352, 461, 496, 480, 466, 416, 502, 311, 358, 366, 455, 413, 400, 401, 363, 324, 465}},
+			{Results: []int32{326, 407, 286, 323, 502, 380, 387, 365, 406, 389, 356, 519, 358, 418, 400, 357, 360, 624}},
+			{Results: []int32{506, 379, 511, 513, 454, 366, 329, 381, 461, 363, 327, 315, 453, 573, 501, 396, 389, 459}},
+		},
+		PlayerClasses:              []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		ClassPrizes:                []int32{2},
+		GibsonSpread:               200,
+		ControlLossThreshold:       0.30,
+		HopefulnessThreshold:       0.02,
+		PlacePrizes:                2,
+		DivisionSims:               10000,
+		ControlLossSims:            100000,
+		ControlLossActivationRound: 15,
+		AllowRepeatByes:            false,
+	}
+	return request
+}


### PR DESCRIPTION
## Key changes

**Pairing weight logic**
- Removed an inconsistent special-case path in the PC (prize contention) weight for players ranked outside prize positions, unifying it to always use `LowestPossibleHopeNth`
- Added a retry mechanism: if a PC weight pairing would trigger a `majorPenalty`, the algorithm retries once with `lowestContender+1`
- Made PC and RD weights mutually exclusive in the fourth quarter of a tournament — cashers use PC only, non-cashers use RD only
- Changed repeat-pairing weight growth to strict inequality (`RE(n) = 2*RE(n-1) + 1`, giving multipliers 1, 3, 7, 15, 31…)
- Removed an extra repeat weight applied to non-contenders

**Control loss simulation**
- Fixed the `vsFirst=false` simulation so a contender factor-paired with 1st place no longer faces 1st directly — it's swapped so 1st plays 2nd (or 3rd) instead, better isolating factor-pair win rates
- Final round now never swaps the forced winner, since it always uses KOTH (King of the Hill) pairings
- Replaced KOTH pairings with factor M/2 pairings for remaining players in simulation rounds
- Added Destiny's Child detection for 2-round control loss edge cases, plus result caching to avoid redundant computation
- Parallelized `simToEndAndRecordResults` and `simForceWinner` across CPU cores for a significant speedup
- Fixed a panic when `maxFactor=0` (dominant-but-not-yet-clinched leader scenarios) that caused an off-by-one in the pairings array

**Factor 3 (F3) expansion**
- Added Factor 3 expansion logic for the second-to-last round, forcing 1v4, 2v5, 3v6 pairings under certain hopefulness conditions
- Added a guard so F3 and control loss constraints don't overconstrain together
- Fixed a control loss "backup" bug in the F3 path and added logging across `computeFactor3ForcedPairings` return paths

**Other fixes**
- Skip the top-down bye (TB) constraint when a Gibson bye (GB) is active, avoiding constraint conflicts
- Various bug fixes: an uninitialized variable, an "expanded contender group" bug, incorrect retry logic

**Testing**
- Added multi-round scenario tests using real tournament data, including `TestScenarioMultiRound_July4th2026WOW` (top 18 players from tournament 1161) and `TestScenarioMultiRound_July4th2026Div2` (33 Division 2 players from tournament 1162)
- Increased simulation counts (e.g., `DivisionSims` to 10,000) for more reliable observation of rare ranking events
- Removed several flaky/timing-sensitive test assertions that depended on simulation iteration counts varying by CI machine speed