### PR TITLE
fix: archive adjudicated games in maintenance task

### DIFF
--- a/aws/cfn/maintenance-tasks.yaml
+++ b/aws/cfn/maintenance-tasks.yaml
@@ -24,6 +24,15 @@ Resources:
                   - ses:SendEmail
                   - ses:SendRawEmail
                 Resource: '*'
+        - PolicyName: GameHistoryS3Policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: 'arn:aws:s3:::woogles-gamehistories/*'
       Tags:
         - Key: Application
           Value: liwords

--- a/cmd/maintenance/league_tasks.go
+++ b/cmd/maintenance/league_tasks.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"time"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/gomodule/redigo/redis"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
@@ -14,6 +17,8 @@ import (
 	"github.com/woogles-io/liwords/pkg/gameplay"
 	"github.com/woogles-io/liwords/pkg/league"
 	"github.com/woogles-io/liwords/pkg/stores"
+	gamestore "github.com/woogles-io/liwords/pkg/stores/game"
+	"github.com/woogles-io/liwords/pkg/utilities"
 	pb "github.com/woogles-io/liwords/rpc/api/proto/ipc"
 )
 
@@ -55,6 +60,23 @@ func initLeagueStores(ctx context.Context, cfg *config.Config) (*stores.Stores, 
 
 	// Wire up the league standings updater to avoid circular dependencies
 	allStores.SetLeagueStandingsUpdater(league.NewStandingsUpdaterImpl(allStores.LeagueStore))
+
+	// Wire up the game history archiver so adjudicated games are archived to S3.
+	// Requires GAMEHISTORY_UPLOAD_BUCKET and AWS_REGION env vars in the task definition.
+	// Credentials come from the ECS task role (liwordsMaintenanceTaskRole) automatically.
+	if bucket := os.Getenv("GAMEHISTORY_UPLOAD_BUCKET"); bucket != "" {
+		awscfg, awsErr := awsconfig.LoadDefaultConfig(ctx)
+		if awsErr != nil {
+			log.Warn().Err(awsErr).Msg("league-stores: aws-config-failed, game archival will be skipped")
+		} else {
+			s3Client := s3.NewFromConfig(awscfg, utilities.CustomClientOptions)
+			allStores.GameHistoryArchiver = gamestore.NewHistoryArchiver(bucket, s3Client, allStores.GameStore)
+			allStores.GameStore.SetHistoryFetcher(allStores.GameHistoryArchiver)
+			log.Info().Str("bucket", bucket).Msg("league-stores: game history archiver initialized")
+		}
+	} else {
+		log.Warn().Msg("league-stores: GAMEHISTORY_UPLOAD_BUCKET not set, game archival will be skipped")
+	}
 
 	return allStores, nil
 }

--- a/pkg/gameplay/end.go
+++ b/pkg/gameplay/end.go
@@ -267,12 +267,9 @@ func performEndgameDuties(ctx context.Context, g *entity.Game,
 	}
 
 	if stores.GameHistoryArchiver != nil {
-		go func() {
-			archCtx := zerolog.Ctx(ctx).WithContext(context.WithoutCancel(ctx))
-			if archErr := stores.GameHistoryArchiver.ArchiveAndCleanup(archCtx, g); archErr != nil {
-				zerolog.Ctx(archCtx).Error().Err(archErr).Str("gameID", g.GameID()).Msg("archive-cleanup-error")
-			}
-		}()
+		if archErr := stores.GameHistoryArchiver.ArchiveAndCleanup(ctx, g); archErr != nil {
+			zerolog.Ctx(ctx).Error().Err(archErr).Str("gameID", g.GameID()).Msg("archive-cleanup-error")
+		}
 	}
 
 	// Insert entries into game_players table for query optimization

--- a/pkg/league/force_finish_games.go
+++ b/pkg/league/force_finish_games.go
@@ -69,6 +69,7 @@ func (ffm *ForceFinishManager) ForceFinishUnfinishedGames(
 		// - Inserts game_players rows
 		// - Updates league standings (via injected LeagueStandingsUpdater)
 		// - Sends events to clients
+		// - Archives game history to S3 (synchronously via performEndgameDuties)
 		err = gameplay.AdjudicateGame(ctx, gameEntity, ffm.stores)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("failed to adjudicate game %s: %v", gameRow.GameID.String, err))


### PR DESCRIPTION
ArchiveAndCleanup was never called for games adjudicated by the league hourly runner (ForceFinishUnfinishedGames) because the maintenance task's initLeagueStores never wired up GameHistoryArchiver. Those games were saved to DB correctly but left with history_s3_key NULL.

Three changes:
- cmd/maintenance/league_tasks.go: initialize GameHistoryArchiver in initLeagueStores using the ECS task role credentials, gated on GAMEHISTORY_UPLOAD_BUCKET env var
- pkg/gameplay/end.go: call ArchiveAndCleanup synchronously instead of in a fire-and-forget goroutine — the client already receives GAME_ENDED_EVENT before this point so there is no user-visible latency impact, and this fixes the race where a short-lived process (maintenance task) could exit before the goroutine completed
- aws/cfn/maintenance-tasks.yaml: add S3 PutObject/GetObject permission for woogles-gamehistories to liwordsMaintenanceTaskRole

Requires GAMEHISTORY_UPLOAD_BUCKET=woogles-gamehistories and AWS_REGION=us-east-2 to be added to the liwords-maintenance ECS task definition.