### PR TITLE
add chat option to league player-name menus

### DIFF
--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -33,6 +34,14 @@ import { create, toBinary } from "@bufbuild/protobuf";
 import { MessageType } from "../gen/api/proto/ipc/ipc_pb";
 import { encodeToSocketFmt } from "../utils/protobuf";
 
+// ChatHandle exposes an imperative way to open a direct-message channel from
+// outside the Chat component (e.g. a sibling league surface). The "Chat"
+// context-menu action on player names normally only works for components
+// rendered inside Chat, because the DM-open logic is local to Chat's state.
+export type ChatHandle = {
+  openDirectMessage: (userId: string, username: string) => void;
+};
+
 export type Props = {
   sendChat: (msg: string, chan: string) => void;
   defaultChannel: string;
@@ -47,6 +56,7 @@ export type Props = {
   suppressDefault?: boolean;
   playerInfoMap?: Map<string, string>;
   onInfoTextClick?: (userId: string) => void;
+  ref?: React.Ref<ChatHandle>;
 };
 
 // userid -> channel -> string
@@ -260,6 +270,17 @@ export const Chat = React.memo((props: Props) => {
       }
     },
     [loginState],
+  );
+
+  // Allow parents (e.g. league surfaces rendered as siblings of Chat) to open
+  // a direct-message channel, reusing the same logic the in-chat "Chat" action
+  // uses.
+  useImperativeHandle(
+    props.ref,
+    () => ({
+      openDirectMessage: sendNewMessage,
+    }),
+    [sendNewMessage],
   );
 
   useEffect(() => {

--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from "react";
 import {
   Col,
   Row,
@@ -22,7 +28,7 @@ import moment from "moment";
 import type { Timestamp } from "@bufbuild/protobuf/wkt";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { TopBar } from "../navigation/topbar";
-import { Chat } from "../chat/chat";
+import { Chat, ChatHandle } from "../chat/chat";
 import {
   getLeague,
   getAllSeasons,
@@ -127,6 +133,14 @@ export const LeaguePage = (props: Props) => {
   const rosterMounted = useRef(false);
   if (showRoster) rosterMounted.current = true;
   const pendingDivisionJump = useRef<number>(0);
+
+  // Ref to the league Chat so that player-name menus on sibling surfaces
+  // (standings, players-needing-to-start, season-games modal) can open a
+  // direct message, since the DM-open logic lives inside Chat.
+  const chatRef = useRef<ChatHandle>(null);
+  const openDirectMessage = useCallback((uuid: string, username: string) => {
+    chatRef.current?.openDirectMessage(uuid, username);
+  }, []);
 
   // Fetch league data
   const { data: leagueData, isPending: leaguePending } = useQuery(
@@ -579,6 +593,7 @@ export const LeaguePage = (props: Props) => {
             {league && (
               <div className="chat-area">
                 <Chat
+                  ref={chatRef}
                   sendChat={props.sendChat}
                   defaultChannel={`chat.league.${league.uuid.replace(/-/g, "")}`}
                   defaultDescription={`League Chat: ${league.name}`}
@@ -879,6 +894,7 @@ export const LeaguePage = (props: Props) => {
                         seasonId={displaySeasonId || ""}
                         seasonNumber={displayedSeason?.seasonNumber || 0}
                         currentUserId={userID}
+                        onChat={openDirectMessage}
                         promotionFormula={displayedSeason?.promotionFormula}
                         timeBankWarnings={timeBankWarningsMap}
                         nextSeasonRegistrations={nextSeasonRegistrations}
@@ -928,6 +944,7 @@ export const LeaguePage = (props: Props) => {
                       seasonNumber={displayedSeason.seasonNumber}
                       playerToDivisionMap={playerToDivisionMap}
                       setSelectedDivisionId={setSelectedDivisionId}
+                      onChat={openDirectMessage}
                     />
                   )}
                 </div>
@@ -1302,7 +1319,7 @@ export const LeaguePage = (props: Props) => {
                     <UsernameWithContext
                       username={username}
                       userID={record.userId}
-                      omitSendMessage
+                      sendMessage={openDirectMessage}
                       omitFriend
                       omitBlock
                     />

--- a/liwords-ui/src/leagues/leagues.scss
+++ b/liwords-ui/src/leagues/leagues.scss
@@ -564,18 +564,20 @@
           }
         }
 
-        // Clickable player names
-        .clickable-player {
-          cursor: pointer;
-          text-decoration: none;
+        // Clickable player names. The username itself is a context-menu
+        // trigger (UsernameWithContext); the decoration icons are siblings.
+        .standings-player {
           color: inherit;
+          text-decoration: none;
 
-          &:hover {
-            text-decoration: underline;
-            color: #1890ff;
+          .user-context-menu {
+            &:hover {
+              color: #1890ff;
+              text-decoration: underline;
 
-            @include colorModed {
-              color: #40a9ff;
+              @include colorModed {
+                color: #40a9ff;
+              }
             }
           }
         }

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -39,6 +39,7 @@ type PlayerGameHistoryModalProps = {
   username: string;
   seasonId: string;
   seasonNumber: number;
+  onChat?: (uuid: string, username: string) => void;
 };
 
 export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
@@ -48,6 +49,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
   username,
   seasonId,
   seasonNumber,
+  onChat,
 }) => {
   const { data, isLoading, error } = useQuery(getPlayerSeasonGames, {
     userId,
@@ -146,7 +148,12 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
       className="league-game-modal"
       title={
         <React.Fragment>
-          <UsernameWithContext username={username} userID={userId} />
+          <UsernameWithContext
+            username={username}
+            userID={userId}
+            sendMessage={onChat}
+            omitSendMessage={!onChat}
+          />
           's Season {seasonNumber} Games
         </React.Fragment>
       }

--- a/liwords-ui/src/leagues/standings.tsx
+++ b/liwords-ui/src/leagues/standings.tsx
@@ -18,6 +18,7 @@ import {
 } from "../gen/api/proto/ipc/league_pb";
 import { SeasonRegistrationsResponse } from "../gen/api/proto/league_service/league_service_pb";
 import { PlayerGameHistoryModal } from "./player_game_history_modal";
+import { UsernameWithContext } from "../shared/usernameWithContext";
 
 // Get placement status icon and tooltip
 const getPlacementIndicator = (
@@ -102,6 +103,7 @@ type DivisionStandingsProps = {
   nextSeasonRegistrations?: SeasonRegistrationsResponse;
   seasonActive?: boolean;
   onRegister?: () => void; // Callback to navigate to registration
+  onChat?: (uuid: string, username: string) => void; // Open a direct message
 };
 
 export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
@@ -115,6 +117,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
   nextSeasonRegistrations,
   seasonActive,
   onRegister,
+  onChat,
 }) => {
   const [selectedPlayer, setSelectedPlayer] = useState<{
     userId: string;
@@ -408,15 +411,26 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
 
         return (
           <span
-            className="clickable-player"
-            onClick={() => handlePlayerClick(record.userId, username)}
+            className="standings-player"
             style={
               isCurrentUser
                 ? { color: "#d4af37", fontWeight: "bold" }
                 : undefined
             }
           >
-            <strong>{username}</strong>
+            <strong>
+              <UsernameWithContext
+                username={username}
+                userID={record.userId}
+                sendMessage={onChat}
+                omitSendMessage={!onChat}
+                omitBadges
+                infoText="View game history"
+                handleInfoText={() =>
+                  handlePlayerClick(record.userId, username)
+                }
+              />
+            </strong>
             {placementIndicator && (
               <Tooltip title={placementIndicator.tooltip}>
                 <span style={{ marginLeft: 4, opacity: 0.7 }}>
@@ -864,6 +878,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
           username={selectedPlayer.username}
           seasonId={seasonId}
           seasonNumber={seasonNumber}
+          onChat={onChat}
         />
       )}
     </div>

--- a/liwords-ui/src/leagues/zero_move_games_dashboard.tsx
+++ b/liwords-ui/src/leagues/zero_move_games_dashboard.tsx
@@ -10,6 +10,7 @@ type ZeroMoveGamesDashboardProps = {
   seasonNumber: number;
   playerToDivisionMap: Map<string, Division>;
   setSelectedDivisionId: React.Dispatch<React.SetStateAction<string>>;
+  onChat?: (uuid: string, username: string) => void;
 };
 
 export const ZeroMoveGamesDashboard: React.FC<ZeroMoveGamesDashboardProps> = ({
@@ -17,6 +18,7 @@ export const ZeroMoveGamesDashboard: React.FC<ZeroMoveGamesDashboardProps> = ({
   seasonNumber,
   playerToDivisionMap,
   setSelectedDivisionId,
+  onChat,
 }) => {
   const { data, isLoading, error } = useQuery(
     getSeasonPlayersWithUnstartedGames,
@@ -37,6 +39,8 @@ export const ZeroMoveGamesDashboard: React.FC<ZeroMoveGamesDashboardProps> = ({
             key={player.userId}
             username={player.username}
             userID={player.userId}
+            sendMessage={onChat}
+            omitSendMessage={!onChat}
             infoText={
               division
                 ? division.divisionName || `Division ${division.divisionNumber}`


### PR DESCRIPTION
## Summary
- Expose an imperative `ChatHandle.openDirectMessage` from `Chat` (via `useImperativeHandle`/ref-as-prop) so sibling league surfaces can open a DM, reusing the in-chat "Chat" action.
- Wire an `onChat` callback from `LeaguePage` through standings, the season-games modal (`PlayerGameHistoryModal`), and the players-needing-to-start list (`ZeroMoveGamesDashboard`), replacing the bespoke clickable span with `UsernameWithContext`.
- Standings player names now use the shared context menu ("Chat" + "View game history"); self-chat is auto-suppressed.
- Rename SCSS `.clickable-player` -> `.standings-player`.

## Test plan
- [ ] `tsc --noEmit`, `npx prettier --check`, `npx eslint` on the changed files
- [ ] manual: in a league, open a player-name menu on standings, the season-games modal title, and the players-needing-to-start list; confirm "Chat" opens the DM in the league chat pane and "View game history" still opens the modal; own name shows no "Chat"
