### PR TITLE
restore game chat after exiting bestbot analysis

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -278,9 +278,12 @@ const ChatAreaDiv: React.FC<{
   children: React.ReactNode;
 }> = ({ baseClassName, children }) => {
   const { showComputerAnalysis } = useAnalyzerContext();
+  const { isExamining } = useExamineStoreContext();
   return (
     <div
-      className={`${baseClassName}${showComputerAnalysis ? " ca-fullscreen" : ""}`}
+      className={`${baseClassName}${
+        isExamining && showComputerAnalysis ? " ca-fullscreen" : ""
+      }`}
       id="left-sidebar"
     >
       {children}
@@ -292,7 +295,8 @@ const ChatIfVisible: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const { showComputerAnalysis } = useAnalyzerContext();
-  if (showComputerAnalysis) return null;
+  const { isExamining } = useExamineStoreContext();
+  if (isExamining && showComputerAnalysis) return null;
   return <>{children}</>;
 };
 


### PR DESCRIPTION
## Summary
In a finished BestBot game, opening the computer-analysis panel sets `showComputerAnalysis = true`. `ChatAreaDiv` and `ChatIfVisible` keyed chat visibility (and the `ca-fullscreen` layout) on that flag alone. Exiting examine mode (`handleExamineEnd`) only sets `isExamining = false` and the analyzer's reset effect only clears the flag when the game is not done, so after exiting analysis the chat stayed hidden and the sidebar stayed in fullscreen with nothing in it (the analyzer panel itself is gated by `isExamining` and already gone).

Gate both the chat-hiding and the `ca-fullscreen` class on `isExamining && showComputerAnalysis`, so the chat reappears once you leave examine mode. Behavior during an active analysis (both flags true) is unchanged.

## Test plan
- [x] `npx prettier --check src/gameroom/table.tsx`
- [ ] `tsc --noEmit`
- [ ] manual: finish a game vs BestBot -> examine -> open Computer Analysis -> exit examine; confirm the chat reappears and the sidebar is no longer stuck fullscreen; confirm chat stays hidden while analysis is open during examine
