### PR TITLE
make nav menus open on click like the gear menu

### DIFF
--- a/liwords-ui/src/navigation/topbar.tsx
+++ b/liwords-ui/src/navigation/topbar.tsx
@@ -139,7 +139,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: playMenuItems }}
           placement="bottom"
-          trigger={["hover", "click"]}
+          trigger={["click"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
@@ -152,7 +152,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: studyMenuItems }}
           placement="bottom"
-          trigger={["hover", "click"]}
+          trigger={["click"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }
@@ -168,7 +168,7 @@ const TopMenu = React.memo((props: Props) => {
           overlayClassName="user-menu"
           menu={{ items: moreMenuItems }}
           placement="bottom"
-          trigger={["hover", "click"]}
+          trigger={["click"]}
           getPopupContainer={() =>
             document.getElementById("root") as HTMLElement
           }


### PR DESCRIPTION
## Summary
The Play, Study, and More nav dropdowns were `trigger={["hover", "click"]}` (introduced by `8c76b3640`). The mixed hover+click trigger leaves the menu stuck open: a click latches it open and a subsequent hover-leave no longer dismisses it, and on touch devices there is no mouseleave to close it at all. This reverts all three nav dropdowns to `trigger={["click"]}`, matching the user/gear menu and every other `Dropdown` in the app. Open/close becomes a clean toggle.

## Test plan
- [ ] `tsc --noEmit`, `npx prettier --check src/navigation/topbar.tsx`
- [ ] desktop: click Play -> opens; click again or click outside -> closes; repeat Study/More; none stuck open after clicking an item or switching menus; hovering does NOT open
- [ ] touch: tap to open, tap an item / tap outside to close; none stuck open
