### PR TITLE
add a secret setting to always show premium-square labels

### DIFF
--- a/liwords-ui/src/gameroom/board.tsx
+++ b/liwords-ui/src/gameroom/board.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import BoardSpaces from "./board_spaces";
 import { useDrawing } from "./drawing";
 import { useExamineStoreContext } from "../store/store";
+import { useLocalStorageBool } from "../utils/use_local_storage";
 import { PlacementArrow } from "../utils/cwgame/tile_placement";
 import BoardCoordLabels from "./board_coord_labels";
 import Tiles from "./tiles";
@@ -53,6 +54,19 @@ const Board = React.memo((props: Props) => {
 
   const { outerDivProps, svgDrawing } = useDrawing(props.gridSize);
   const { isExamining } = useExamineStoreContext();
+
+  // Secret setting: when enabled, premium-square labels (2x letter, 3x word,
+  // etc.) are always shown instead of only on hover. The gameroom SCSS keys
+  // off the "show-bonus-labels" body class.
+  const [showBonusLabels] = useLocalStorageBool("showBonusLabels");
+  useEffect(() => {
+    if (!showBonusLabels) return;
+    document.body.classList.add("show-bonus-labels");
+    return () => {
+      document.body.classList.remove("show-bonus-labels");
+    };
+  }, [showBonusLabels]);
+
   let zomgClass = "";
   if (props.gridSize === SuperCrosswordGameGridLayout.length) {
     zomgClass = " zomgboard";

--- a/liwords-ui/src/settings/secret.tsx
+++ b/liwords-ui/src/settings/secret.tsx
@@ -17,6 +17,8 @@ export const Secret = React.memo(() => {
   const [hidePool, setHidePool] = useLocalStorageBool("hidePool");
   const [enableBicolorMode, setEnableBicolorMode] =
     useLocalStorageBool("enableBicolorMode");
+  const [showBonusLabels, setShowBonusLabels] =
+    useLocalStorageBool("showBonusLabels");
 
   return (
     <div className="preferences secret">
@@ -115,6 +117,20 @@ export const Secret = React.memo(() => {
                 checked={enableBicolorMode}
                 onChange={setEnableBicolorMode}
                 className="bicolor-toggle"
+              />
+            </div>
+          </div>
+          <div className="toggle-section">
+            <div className="title">Always show premium-square labels</div>
+            <div>
+              <div>
+                Always display bonus-square labels (2x letter, 3x word, etc.)
+                instead of only on hover
+              </div>
+              <Switch
+                checked={showBonusLabels}
+                onChange={setShowBonusLabels}
+                className="bonus-labels-toggle"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
Adds a secret-features toggle, "Always show premium-square labels", that always displays bonus-square labels (2x letter, 3x word, etc.) instead of revealing them only on hover. The toggle persists in localStorage (`showBonusLabels`) via `useLocalStorageBool` and adds a `show-bonus-labels` class to `document.body`; the gameroom SCSS already keys label visibility off `body:not(.show-bonus-labels)`.

No gameplay-integrity impact: bonus-square types come from the fixed, public board layouts and are already rendered into the DOM for every square; this only changes local label visibility for the user who enables it.

## Test plan
- [x] `npx prettier --check src/gameroom/board.tsx src/settings/secret.tsx`
- [ ] `tsc --noEmit`
- [ ] toggle on in Settings > Secret: premium labels show persistently; toggle off: hover-only; persists across reload and syncs across tabs; empty squares and the center star stay unlabeled
