### PR TITLE
show next-game button alongside play in correspondence game controls

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -131,6 +131,10 @@ type Props = {
   changeCurrentRack?: (rack: MachineWord, evtIdx: number) => void;
   gameMode?: number;
   annotated?: boolean;
+  // Correspondence-only: jump to the user's next on-turn game.
+  hasNextCorresGame?: boolean;
+  corresGamesWaiting?: number;
+  onNextCorresGame?: () => void;
 };
 
 export const BoardPanel = React.memo((props: Props) => {
@@ -1346,6 +1350,9 @@ export const BoardPanel = React.memo((props: Props) => {
         exitableExaminer={props.exitableExaminer}
         puzzleMode={props.puzzleMode}
         boardEditingMode={props.boardEditingMode}
+        hasNextCorresGame={props.hasNextCorresGame}
+        corresGamesWaiting={props.corresGamesWaiting}
+        onNextCorresGame={props.onNextCorresGame}
       />
     );
   }

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -285,6 +285,11 @@ export type Props = {
   showAbort: boolean;
   exitableExaminer?: boolean;
   boardEditingMode?: boolean;
+  // Correspondence-only: jump to the user's next on-turn game.
+  // nextCorresGame is non-null only when such a game exists (set by table.tsx).
+  hasNextCorresGame?: boolean;
+  corresGamesWaiting?: number;
+  onNextCorresGame?: () => void;
 };
 
 const GameControls = React.memo((props: Props) => {
@@ -648,14 +653,42 @@ const GameControls = React.memo((props: Props) => {
             <span className="key-command">4</span>
           </Button>
         </div>
-        <Button
-          type="primary"
-          className="play"
-          onClick={props.onCommit}
-          disabled={!props.myTurn || props.finalPassOrChallenge}
-        >
-          {props.puzzleMode ? "Solve" : "Play"}
-        </Button>
+        {(() => {
+          // Correspondence-only "Next (x)" affordance. Puzzles never show it.
+          const showNext = !props.puzzleMode && !!props.hasNextCorresGame;
+          const nextButton = showNext ? (
+            <Button
+              type="primary"
+              className="play next-game"
+              onClick={props.onNextCorresGame}
+            >
+              <RightOutlined /> Next
+              {props.corresGamesWaiting && props.corresGamesWaiting > 1 ? (
+                <span className="next-game-count">
+                  ({props.corresGamesWaiting})
+                </span>
+              ) : null}
+            </Button>
+          ) : null;
+          // When it's not the user's turn, the Play button would be a dead
+          // disabled control. If a next game exists, show "Next" in its place.
+          if (!props.myTurn && showNext) {
+            return nextButton;
+          }
+          return (
+            <React.Fragment>
+              <Button
+                type="primary"
+                className={showNext ? "play play-with-next" : "play"}
+                onClick={props.onCommit}
+                disabled={!props.myTurn || props.finalPassOrChallenge}
+              >
+                {props.puzzleMode ? "Solve" : "Play"}
+              </Button>
+              {nextButton}
+            </React.Fragment>
+          );
+        })()}
       </div>
       {props.boardEditingMode && (
         <div className="secondary-controls">

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -2973,6 +2973,28 @@ p.rune {
       height: calc($board-size-mobile * 0.25);
       margin: 0 6px;
     }
+
+    // Correspondence-only "Next (x)" jump button. Sits beside Play (or in its
+    // place when it is not the user's turn). Keep it a compact, normal-height
+    // button rather than the big square Play uses on mobile.
+    &.play.next-game {
+      min-width: auto;
+      width: auto;
+      height: calc(($board-size-mobile / 8) - 9px);
+
+      .next-game-count {
+        margin-left: 4px;
+        opacity: 0.7;
+      }
+    }
+
+    // When Play is shown alongside Next, shrink it from the big mobile square
+    // to a compact button so both fit on one row.
+    &.play.play-with-next {
+      min-width: auto;
+      width: auto;
+      height: calc(($board-size-mobile / 8) - 9px);
+    }
   }
 
   & > :first-child {
@@ -3248,6 +3270,11 @@ p.rune {
         min-width: auto;
         width: auto;
         height: 36px;
+      }
+
+      &.play.next-game .next-game-count {
+        margin-left: 4px;
+        opacity: 0.7;
       }
     }
   }

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -1324,6 +1324,9 @@ export const Table = React.memo((props: Props) => {
             handleSetHover={handleSetHover}
             handleUnsetHover={hideDefinitionHover}
             definitionPopover={definitionPopover}
+            hasNextCorresGame={!!nextCorresGame}
+            corresGamesWaiting={corresGamesWaiting}
+            onNextCorresGame={handleNextCorresGame}
           />
           {!gameDone && (
             <MetaEventControl


### PR DESCRIPTION
## Summary
Adds a "Next" jump button to the in-board game controls for correspondence games, beside the existing topbar/navigation-card affordances. When it is your turn, "Next" appears next to "Play"; when it is the opponent's turn (where "Play" would be a dead disabled control), "Next" takes its place. The button is suppressed in puzzle mode and only appears when you have another correspondence game on your turn; a `(n)` count shows when more than one other game is waiting.

Reuses the existing `nextCorresGame` / `corresGamesWaiting` computation and `handleNextCorresGame` handler; this change only threads three optional props through `BoardPanel` into `GameControls` and adds the button markup plus mobile/desktop SCSS.

## Test plan
- [ ] `tsc --noEmit`, `npx prettier --check` on the changed files
- [ ] your turn + another on-turn game: "Play" and "Next (n)" both render; clicking "Next" jumps to the most-urgent other on-turn game
- [ ] opponent's turn + another on-turn game: "Next" renders in place of the disabled "Play"
- [ ] exactly one other waiting: "Next" with no count; none: no "Next" button
- [ ] non-correspondence and puzzle mode: no "Next" button
