### PR TITLE
use ascii hyphens for missing standings values

### DIFF
--- a/liwords-ui/src/leagues/standings.tsx
+++ b/liwords-ui/src/leagues/standings.tsx
@@ -271,7 +271,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
   const divAvg = (total: number, decimals = 1) =>
     divTotals.gamesPlayed > 0
       ? (total / divTotals.gamesPlayed).toFixed(decimals)
-      : "—";
+      : "-";
 
   const dataSource = division.standings.map((standing) => ({
     key: standing.userId,
@@ -330,7 +330,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
   })();
 
   const noGamesPlayed = dataSource.every((d) => d.gamesPlayed === 0);
-  // April 1 easter egg: March 31 12:00 UTC – April 2 12:00 UTC (covers all timezones)
+  // April 1 easter egg: March 31 12:00 UTC - April 2 12:00 UTC (covers all timezones)
   const now = new Date();
   const y = now.getUTCFullYear();
   const isMiaow =
@@ -530,8 +530,8 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
           title={isMiaow ? "Miaow" : "MiAV"}
           tooltip={
             isMiaow
-              ? `${miaowBackronym} (lower is better; — if no analysis) (div avg: ${divTotals.gamesAnalyzed > 0 ? (divTotals.totalMistakeIndex / divTotals.gamesAnalyzed).toFixed(1) : "—"})`
-              : `Average Mistake Index from BestBot analysis (lower is better; — if no analysis) (div avg: ${divTotals.gamesAnalyzed > 0 ? (divTotals.totalMistakeIndex / divTotals.gamesAnalyzed).toFixed(1) : "—"})`
+              ? `${miaowBackronym} (lower is better; - if no analysis) (div avg: ${divTotals.gamesAnalyzed > 0 ? (divTotals.totalMistakeIndex / divTotals.gamesAnalyzed).toFixed(1) : "-"})`
+              : `Average Mistake Index from BestBot analysis (lower is better; - if no analysis) (div avg: ${divTotals.gamesAnalyzed > 0 ? (divTotals.totalMistakeIndex / divTotals.gamesAnalyzed).toFixed(1) : "-"})`
           }
         />
       ),
@@ -549,7 +549,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
       render: (
         _: unknown,
         record: { avgMistakeIndex: number; gamesAnalyzed: number },
-      ) => (record.gamesAnalyzed > 0 ? record.avgMistakeIndex.toFixed(1) : "—"),
+      ) => (record.gamesAnalyzed > 0 ? record.avgMistakeIndex.toFixed(1) : "-"),
     },
     {
       title: (
@@ -637,7 +637,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
       title: (
         <ColHeader
           title="TAV"
-          tooltip={`Turn average (points per turn) (div avg: ${divTotals.totalTurns > 0 ? (divTotals.totalScore / divTotals.totalTurns).toFixed(1) : "—"})`}
+          tooltip={`Turn average (points per turn) (div avg: ${divTotals.totalTurns > 0 ? (divTotals.totalScore / divTotals.totalTurns).toFixed(1) : "-"})`}
         />
       ),
       key: "turnAvg",
@@ -661,7 +661,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
       title: (
         <ColHeader
           title="HG"
-          tooltip={`High game score (div high: ${divTotals.highGame ?? "—"})`}
+          tooltip={`High game score (div high: ${divTotals.highGame ?? "-"})`}
         />
       ),
       key: "highGame",
@@ -678,7 +678,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
       title: (
         <ColHeader
           title="HT"
-          tooltip={`High turn score (div high: ${divTotals.highTurn ?? "—"})`}
+          tooltip={`High turn score (div high: ${divTotals.highTurn ?? "-"})`}
         />
       ),
       key: "highTurn",


### PR DESCRIPTION
## Summary
The league standings table used a typographic em-dash as the "no data" placeholder in several spots -- the Miaow/MiAV cell and its tooltip, and the div-average / div-high fallbacks in the score-average, turn-average, high-game, and high-turn header tooltips -- while the cell renders elsewhere already use a plain ASCII hyphen. This converts every remaining em-dash placeholder to an ASCII hyphen, so the whole standings table is consistent.

## Test plan
- [ ] `tsc --noEmit`
- [ ] visual: open a league division standings table; confirm the no-data placeholders (the Miaow/MiAV cell and the header-tooltip div averages / div highs) render an ASCII hyphen, not a typographic em-dash
