### PR TITLE
split started tournaments into a live section on the events tab

### DIFF
--- a/liwords-ui/src/lobby/announcements.tsx
+++ b/liwords-ui/src/lobby/announcements.tsx
@@ -525,6 +525,28 @@ export const TournamentsAndLeaguesContent = ({
     return start > now && start <= in14Days;
   });
 
+  // upcomingTournaments holds tournaments that have not yet ended (or have no
+  // end time). Split them: not-yet-started ones stay "Upcoming", while
+  // already-started ones become "Live". Tournaments with a start time in the
+  // past but no end time are treated as live (ongoing indefinitely), and any
+  // not-ended tournament without a start time is also shown as live so it is
+  // not silently dropped.
+  const notStartedTournaments = upcomingTournaments.filter((t) => {
+    if (!t.scheduledStartTime) return false;
+    const start = new Date(Number(t.scheduledStartTime.seconds) * 1000);
+    return now < start;
+  });
+  // Source list is ordered by start time ascending; reversing yields
+  // descending (latest start first) for the live section.
+  const liveTournaments = upcomingTournaments
+    .filter((t) => {
+      if (!t.scheduledStartTime) return true;
+      const start = new Date(Number(t.scheduledStartTime.seconds) * 1000);
+      return now >= start;
+    })
+    .slice()
+    .reverse();
+
   const isEmpty =
     (!showBroadcasts ||
       (activeBroadcasts.length === 0 && pastBroadcasts.length === 0)) &&
@@ -556,11 +578,11 @@ export const TournamentsAndLeaguesContent = ({
         </>
       )}
 
-      {upcomingTournaments.length > 0 && (
+      {notStartedTournaments.length > 0 && (
         <>
           <h4>Upcoming Tournaments</h4>
           <div className="tournaments-list">
-            {upcomingTournaments.map((t) => (
+            {notStartedTournaments.map((t) => (
               <TournamentCard key={t.id} tournament={t} />
             ))}
           </div>
@@ -573,6 +595,17 @@ export const TournamentsAndLeaguesContent = ({
           <div className="leagues-list">
             {activeLeagues.map((ls) => (
               <LeagueStatusCard key={ls.league.uuid} leagueData={ls} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {liveTournaments.length > 0 && (
+        <>
+          <h4>Live Tournaments</h4>
+          <div className="tournaments-list">
+            {liveTournaments.map((t) => (
+              <TournamentCard key={t.id} tournament={t} />
             ))}
           </div>
         </>

--- a/liwords-ui/src/lobby/upcoming_tournaments.tsx
+++ b/liwords-ui/src/lobby/upcoming_tournaments.tsx
@@ -167,14 +167,48 @@ export const UpcomingTournamentsWidget = () => {
     })();
   }, [tournamentClient]);
 
+  // upcomingTournaments holds tournaments that have not yet ended (or have no
+  // end time). Split them: not-yet-started ones stay "Upcoming", while
+  // already-started ones become "Live". Tournaments with a start time in the
+  // past but no end time are treated as live (ongoing indefinitely), and any
+  // not-ended tournament without a start time is also shown as live so it is
+  // not silently dropped.
+  const now = new Date();
+  const notStartedTournaments = upcomingTournaments.filter((t) => {
+    if (!t.scheduledStartTime) return false;
+    const start = new Date(Number(t.scheduledStartTime.seconds) * 1000);
+    return now < start;
+  });
+  // Source list is ordered by start time ascending; reversing yields
+  // descending (latest start first) for the live section.
+  const liveTournaments = upcomingTournaments
+    .filter((t) => {
+      if (!t.scheduledStartTime) return true;
+      const start = new Date(Number(t.scheduledStartTime.seconds) * 1000);
+      return now >= start;
+    })
+    .slice()
+    .reverse();
+
   return (
     <Card className="upcoming-tournaments-widget" title="Tournaments">
       <div className="tournaments-container">
-        {upcomingTournaments.length > 0 && (
+        {notStartedTournaments.length > 0 && (
           <>
             <h4>Upcoming Tournaments</h4>
             <div className="tournaments-list">
-              {upcomingTournaments.map((t) => (
+              {notStartedTournaments.map((t) => (
+                <TournamentCard key={t.id} tournament={t} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {liveTournaments.length > 0 && (
+          <>
+            <h4>Live Tournaments</h4>
+            <div className="tournaments-list">
+              {liveTournaments.map((t) => (
                 <TournamentCard key={t.id} tournament={t} />
               ))}
             </div>


### PR DESCRIPTION
## Summary
The Events tab and the tournaments widget previously listed every not-yet-ended tournament under a single "Upcoming Tournaments" heading, including ones already in progress. This splits that list:
- **Upcoming Tournaments**: only tournaments whose start time is still in the future.
- **Live Tournaments**: tournaments that have already started but not ended. A past start with no end time is treated as live; any not-ended tournament with no start time is also surfaced as live so it is never silently dropped.

The live list is shown latest-start-first. The combined empty-state logic is unchanged. Applies to both the Events tab and the tournaments widget.

## Test plan
- [ ] `tsc --noEmit`
- [ ] Events tab: a tournament with a past start and future end appears under "Live Tournaments" with the "Live" badge; a future start stays under "Upcoming Tournaments"
- [ ] widget: same split; live ordering latest-start-first
- [ ] empty state still renders when there are no tournaments/leagues/broadcasts
