### PR TITLE
remove unused variables flagged by eslint

### DIFF
--- a/liwords-ui/src/broadcasts/BroadcastRoom.tsx
+++ b/liwords-ui/src/broadcasts/BroadcastRoom.tsx
@@ -90,7 +90,7 @@ export const BroadcastRoom: React.FC = () => {
     { enabled: !!slug && activeRound > 0, refetchInterval: 30_000 },
   );
 
-  const { data: statsData, isLoading: statsLoading } = useQuery(
+  const { data: statsData } = useQuery(
     getBroadcastGameStats,
     { slug: slug ?? "" },
     { enabled: !!slug, refetchInterval: 30_000 },

--- a/liwords-ui/src/broadcasts/tabs/HighlightsTab.tsx
+++ b/liwords-ui/src/broadcasts/tabs/HighlightsTab.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router";
 import { LinkOutlined } from "@ant-design/icons";
 import type { BroadcastGameStat } from "../../gen/api/proto/broadcast_service/broadcast_service_pb";
 
-const { Text, Title } = Typography;
+const { Text } = Typography;
 
 type Stat = BroadcastGameStat;
 

--- a/liwords-ui/src/tournament/tournament_wizard.tsx
+++ b/liwords-ui/src/tournament/tournament_wizard.tsx
@@ -7,10 +7,8 @@ import {
   Divider,
   Form,
   Input,
-  InputNumber,
   message,
   Radio,
-  Select,
   Steps,
   Switch,
   Typography,
@@ -42,10 +40,7 @@ import {
   RoundControl,
 } from "../gen/api/proto/ipc/tournament_pb";
 import { timestampFromMs } from "@bufbuild/protobuf/wkt";
-import {
-  doesCurrentUserUse24HourTime,
-  protobufTimestampToDayjsIgnoringNanos,
-} from "../utils/datetime";
+import { doesCurrentUserUse24HourTime } from "../utils/datetime";
 import type { Dayjs } from "dayjs";
 import "./tournament_wizard.scss";
 


### PR DESCRIPTION
## Summary
Removes five pre-existing `@typescript-eslint/no-unused-vars` warnings on master (0 errors before, 0 after):
- `broadcasts/BroadcastRoom.tsx`: drop the unused `isLoading: statsLoading` from a `useQuery` destructure.
- `broadcasts/tabs/HighlightsTab.tsx`: drop unused `Title` from the `Typography` destructure.
- `tournament/tournament_wizard.tsx`: drop unused imports `InputNumber`, `Select`, and `protobufTimestampToDayjsIgnoringNanos`.

## Test plan
- [x] `npm run lint` -- 0 warnings (was 5)
- [x] `npx prettier --check` on the three changed files
