### PR TITLE
auto-pass correspondence games when the time bank expires

### DIFF
--- a/pkg/bus/adjudication_test.go
+++ b/pkg/bus/adjudication_test.go
@@ -88,6 +88,17 @@ func WithCorrespondenceMode(incrementSeconds int32, timeBankMinutes int32) TestG
 	}
 }
 
+// WithRealtimeIncrement configures a real-time game with a per-turn increment
+// and no overtime, so a timed-out turn is reached quickly and deterministically.
+func WithRealtimeIncrement(initialTimeSeconds int32, incrementSeconds int32) TestGameOption {
+	return func(gr *pb.GameRequest) {
+		gr.GameMode = pb.GameMode_REAL_TIME
+		gr.InitialTimeSeconds = initialTimeSeconds
+		gr.IncrementSeconds = incrementSeconds
+		gr.MaxOvertimeMinutes = 0
+	}
+}
+
 type evtConsumer struct {
 	evts []*entity.EventWrapper
 	ch   chan *entity.EventWrapper
@@ -463,6 +474,104 @@ func TestCorrespondenceAutoPassOpponentClockCorrect(t *testing.T) {
 	// elapsed on their turn yet in this reloaded snapshot) is the full
 	// increment.
 	is.Equal(reloadedGame.CachedTimeRemaining(opponent), int(incrementSeconds)*1000)
+
+	cancel()
+	<-donechan
+}
+
+// TestRealtimeWithIncrementTimeoutAutoPasses tests that a real-time game that
+// has a per-turn increment auto-passes on timeout (the opponent can still
+// move) instead of forfeiting. This is gated by the autopassRealtimeWithIncrement
+// const; with that const set to false this game would forfeit (GameEndReason_TIME)
+// like TestRealtimeNoIncrementTimeoutStillForfeits below.
+func TestRealtimeWithIncrementTimeoutAutoPasses(t *testing.T) {
+	is := is.New(t)
+	stores := recreateDB()
+	defer stores.Disconnect()
+
+	cfg := DefaultConfig
+
+	// Real-time game with a 30s initial clock, a 5s increment, and no overtime.
+	initialTimeSeconds := int32(30)
+	g, nower, cancel, donechan, _ := makeCorrespondenceGame(stores, cfg,
+		WithRealtimeIncrement(initialTimeSeconds, 5))
+	is.True(!g.IsCorrespondence())
+	is.True(g.HasIncrement())
+	stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return nower
+	})
+
+	playerOnTurn := g.Game.PlayerOnTurn()
+	numEvtsBefore := len(g.History().Events)
+
+	// Blow past the initial clock (no overtime), so the on-turn player times out.
+	nower.Sleep(int64(initialTimeSeconds)*1000 + 1000)
+	is.True(g.TimeRanOut(playerOnTurn))
+
+	ctx := ctxForTests()
+	playerID := g.History().Players[playerOnTurn].UserId
+	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
+	is.NoErr(err)
+
+	// The game did NOT forfeit: it continues, the on-turn player was
+	// auto-passed, and the turn advanced to the opponent.
+	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
+	is.NoErr(err)
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_NONE)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_PLAYING)
+	is.Equal(reloadedGame.Game.PlayerOnTurn(), 1-playerOnTurn)
+	// A pass event was recorded for the timed-out player.
+	newEvts := reloadedGame.History().Events
+	is.Equal(len(newEvts), numEvtsBefore+1)
+	is.Equal(newEvts[len(newEvts)-1].Type, macondopb.GameEvent_PASS)
+
+	// The opponent's clock is correct: they get their full initial clock from
+	// their turn start (untouched by the timed-out player's pass).
+	is.Equal(reloadedGame.CachedTimeRemaining(1-playerOnTurn), int(initialTimeSeconds)*1000)
+
+	cancel()
+	<-donechan
+}
+
+// TestRealtimeNoIncrementTimeoutStillForfeits tests that a real-time game with
+// NO increment still forfeits on timeout (GameEndReason_TIME). This is the
+// behavior that autopassRealtimeWithIncrement = false would restore for ALL
+// real-time games: an increment is the only thing that makes a real-time game
+// auto-pass instead of forfeit.
+func TestRealtimeNoIncrementTimeoutStillForfeits(t *testing.T) {
+	is := is.New(t)
+	stores := recreateDB()
+	defer stores.Disconnect()
+
+	cfg := DefaultConfig
+
+	// Real-time game with a 30s initial clock, NO increment, and no overtime.
+	g, nower, cancel, donechan, _ := makeCorrespondenceGame(stores, cfg,
+		WithRealtimeIncrement(30, 0))
+	is.True(!g.IsCorrespondence())
+	is.True(!g.HasIncrement())
+	stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return nower
+	})
+
+	// Blow past the initial clock (no increment, no overtime) to time out.
+	nower.Sleep(31 * 1000)
+
+	playerOnTurn := g.Game.PlayerOnTurn()
+	is.True(g.TimeRanOut(playerOnTurn))
+
+	ctx := ctxForTests()
+	playerID := g.History().Players[playerOnTurn].UserId
+	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
+	is.NoErr(err)
+
+	// Real-time game with no increment still forfeits on time.
+	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
+	is.NoErr(err)
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_TIME)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_GAME_OVER)
+	// The player who timed out loses.
+	is.Equal(reloadedGame.WinnerIdx, 1-playerOnTurn)
 
 	cancel()
 	<-donechan

--- a/pkg/bus/adjudication_test.go
+++ b/pkg/bus/adjudication_test.go
@@ -149,7 +149,8 @@ func TestMain(m *testing.M) {
 }
 
 // TestCorrespondenceTimeoutWithoutTimeBank tests that a correspondence game
-// times out when the player exceeds the allowed turn time and has no time bank.
+// auto-passes (instead of forfeiting) when the player exceeds the allowed turn
+// time and has no time bank.
 func TestCorrespondenceTimeoutWithoutTimeBank(t *testing.T) {
 	is := is.New(t)
 	stores := recreateDB()
@@ -167,25 +168,35 @@ func TestCorrespondenceTimeoutWithoutTimeBank(t *testing.T) {
 	// Check that TimeRanOut returns true
 	playerOnTurn := g.Game.PlayerOnTurn()
 	is.True(g.TimeRanOut(playerOnTurn))
+	numEvtsBefore := len(g.History().Events)
 
-	// Call TimedOut to end the game
+	// Call TimedOut. For correspondence games this auto-passes rather than
+	// forfeiting.
 	ctx := ctxForTests()
 	playerID := g.History().Players[playerOnTurn].UserId
 	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
 	is.NoErr(err)
 
-	// Reload game and check it ended due to timeout
+	// Reload game and check it did NOT end. The on-turn player was
+	// auto-passed and the turn advanced to the opponent.
 	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
 	is.NoErr(err)
-	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_TIME)
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_NONE)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_PLAYING)
+	is.Equal(reloadedGame.Game.PlayerOnTurn(), 1-playerOnTurn)
+	// A pass event was recorded for the timed-out player.
+	newEvts := reloadedGame.History().Events
+	is.Equal(len(newEvts), numEvtsBefore+1)
+	is.Equal(newEvts[len(newEvts)-1].Type, macondopb.GameEvent_PASS)
 
 	// Clean up: cancel context and wait for goroutine to finish
 	cancel()
 	<-donechan
 }
 
-// TestCorrespondenceTimeoutWithExhaustedTimeBank tests that a correspondence game
-// times out when the player exceeds the allowed turn time and exhausts their time bank.
+// TestCorrespondenceTimeoutWithExhaustedTimeBank tests that a correspondence
+// game auto-passes (instead of forfeiting) when the player exceeds the allowed
+// turn time and exhausts their time bank.
 func TestCorrespondenceTimeoutWithExhaustedTimeBank(t *testing.T) {
 	is := is.New(t)
 	stores := recreateDB()
@@ -205,16 +216,22 @@ func TestCorrespondenceTimeoutWithExhaustedTimeBank(t *testing.T) {
 	playerOnTurn := g.Game.PlayerOnTurn()
 	is.True(g.TimeRanOut(playerOnTurn))
 
-	// Call TimedOut to end the game
+	// Call TimedOut. For correspondence games this auto-passes rather than
+	// forfeiting.
 	ctx := ctxForTests()
 	playerID := g.History().Players[playerOnTurn].UserId
 	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
 	is.NoErr(err)
 
-	// Reload game and check it ended due to timeout
+	// Reload game and check it did NOT end. The bank was drained to zero and
+	// the on-turn player was auto-passed.
 	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
 	is.NoErr(err)
-	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_TIME)
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_NONE)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_PLAYING)
+	is.Equal(reloadedGame.Game.PlayerOnTurn(), 1-playerOnTurn)
+	// The timed-out player's bank is fully drained.
+	is.Equal(reloadedGame.Timers.TimeBank[playerOnTurn], int64(0))
 
 	// Clean up: cancel context and wait for goroutine to finish
 	cancel()
@@ -274,6 +291,179 @@ func TestCorrespondenceWithinAllowedTime(t *testing.T) {
 	is.Equal(g.GameEndReason, pb.GameEndReason_NONE)
 
 	// Clean up: cancel context and wait for goroutine to finish
+	cancel()
+	<-donechan
+}
+
+// TestCorrespondenceRepeatedTimeoutsEndViaSixPasses tests that repeated
+// correspondence timeouts produce auto-passes that accumulate into the
+// six-consecutive-pass rule, ending the game naturally (winner by score)
+// rather than by timeout/forfeit. Both players abandon the game.
+func TestCorrespondenceRepeatedTimeoutsEndViaSixPasses(t *testing.T) {
+	is := is.New(t)
+	stores := recreateDB()
+	defer stores.Disconnect()
+
+	cfg := DefaultConfig
+
+	// 60 second increment, no time bank.
+	g, nower, cancel, donechan, _ := makeCorrespondenceGame(stores, cfg, WithCorrespondenceMode(60, 0))
+	// Make reloaded games (including those loaded inside TimedOut) share the
+	// same fake nower so the timeout checks are deterministic.
+	stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return nower
+	})
+
+	ctx := ctxForTests()
+
+	// Drive timeouts until the game ends. Each timeout auto-passes the
+	// on-turn player; six consecutive passes end the game. Guard with a
+	// generous iteration cap to avoid an infinite loop on regression.
+	var reloadedGame *entity.Game
+	var err error
+	ended := false
+	for i := 0; i < 12; i++ {
+		// Advance well past the per-turn allowance so the on-turn player
+		// times out.
+		nower.Sleep(120 * 1000)
+
+		reloadedGame, err = stores.GameStore.Get(ctx, g.GameID())
+		is.NoErr(err)
+		if reloadedGame.Game.Playing() == macondopb.PlayState_GAME_OVER {
+			ended = true
+			break
+		}
+		playerOnTurn := reloadedGame.Game.PlayerOnTurn()
+		playerID := reloadedGame.History().Players[playerOnTurn].UserId
+		err = gameplay.TimedOut(ctx, stores, playerID, g.GameID())
+		is.NoErr(err)
+	}
+
+	is.True(ended) // game must have ended via passes
+
+	// Reload final state.
+	reloadedGame, err = stores.GameStore.Get(ctx, g.GameID())
+	is.NoErr(err)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_GAME_OVER)
+	// Ended naturally via the six-consecutive-pass rule, NOT a timeout
+	// forfeit. Six passes produce CONSECUTIVE_ZEROES (winner by score).
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_CONSECUTIVE_ZEROES)
+	is.True(reloadedGame.GameEndReason != pb.GameEndReason_TIME)
+	// A winner was decided by score (winner index is 0 or 1, not -1).
+	is.True(reloadedGame.WinnerIdx == 0 || reloadedGame.WinnerIdx == 1)
+
+	// Exactly six consecutive scoreless passes were recorded.
+	evts := reloadedGame.History().Events
+	passCount := 0
+	for _, e := range evts {
+		if e.Type == macondopb.GameEvent_PASS {
+			passCount++
+		}
+	}
+	is.Equal(passCount, 6)
+
+	cancel()
+	<-donechan
+}
+
+// TestRealtimeTimeoutStillForfeits tests that a real-time (non-correspondence)
+// game still forfeits on timeout. The auto-pass change applies only to
+// correspondence games.
+func TestRealtimeTimeoutStillForfeits(t *testing.T) {
+	is := is.New(t)
+	stores := recreateDB()
+	defer stores.Disconnect()
+
+	cfg := DefaultConfig
+
+	// No correspondence option: the default gameReq is REAL_TIME with a
+	// 25-minute clock and 10 minutes of max overtime.
+	g, nower, cancel, donechan, _ := makeCorrespondenceGame(stores, cfg)
+	is.True(!g.IsCorrespondence())
+	stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return nower
+	})
+
+	// Advance past the 25-minute clock plus 10 minutes of overtime.
+	nower.Sleep((25 + 10 + 1) * 60 * 1000)
+
+	playerOnTurn := g.Game.PlayerOnTurn()
+	is.True(g.TimeRanOut(playerOnTurn))
+
+	ctx := ctxForTests()
+	playerID := g.History().Players[playerOnTurn].UserId
+	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
+	is.NoErr(err)
+
+	// Real-time games still forfeit on timeout.
+	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
+	is.NoErr(err)
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_TIME)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_GAME_OVER)
+	// The player who timed out loses.
+	is.Equal(reloadedGame.WinnerIdx, 1-playerOnTurn)
+
+	cancel()
+	<-donechan
+}
+
+// TestCorrespondenceAutoPassOpponentClockCorrect tests that when a
+// correspondence auto-pass is processed late (e.g. up to 60s after expiry by
+// the adjudicator ticker), the opponent's clock starts correctly: the opponent
+// keeps their full per-turn increment and full time bank, unaffected by how
+// late the timed-out player's pass was recorded.
+func TestCorrespondenceAutoPassOpponentClockCorrect(t *testing.T) {
+	is := is.New(t)
+	stores := recreateDB()
+	defer stores.Disconnect()
+
+	cfg := DefaultConfig
+
+	// 60 second increment, 5 minute time bank.
+	incrementSeconds := int32(60)
+	bankMinutes := int32(5)
+	g, nower, cancel, donechan, _ := makeCorrespondenceGame(stores, cfg,
+		WithCorrespondenceMode(incrementSeconds, bankMinutes))
+	stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return nower
+	})
+
+	playerOnTurn := g.Game.PlayerOnTurn()
+	opponent := 1 - playerOnTurn
+
+	// Simulate the adjudicator firing very late: the player blew their
+	// per-turn allowance, their whole bank, AND another ~10 minutes of
+	// ticker latency on top.
+	overByMs := int64(incrementSeconds)*1000 +
+		int64(bankMinutes)*60*1000 +
+		int64(10)*60*1000
+	nower.Sleep(overByMs)
+
+	is.True(g.TimeRanOut(playerOnTurn))
+
+	ctx := ctxForTests()
+	playerID := g.History().Players[playerOnTurn].UserId
+	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
+	is.NoErr(err)
+
+	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
+	is.NoErr(err)
+	// Game continues; opponent is on turn.
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_NONE)
+	is.Equal(reloadedGame.Game.PlayerOnTurn(), opponent)
+
+	// The timed-out player's bank is fully drained, capped at zero (never
+	// negative regardless of how late the pass was processed).
+	is.Equal(reloadedGame.Timers.TimeBank[playerOnTurn], int64(0))
+
+	// The opponent's clock is untouched by the latency: full bank remaining
+	// and a full per-turn increment available from their turn start.
+	is.Equal(reloadedGame.Timers.TimeBank[opponent], int64(bankMinutes)*60*1000)
+	// Opponent is now on turn; their remaining (cached, since no time has
+	// elapsed on their turn yet in this reloaded snapshot) is the full
+	// increment.
+	is.Equal(reloadedGame.CachedTimeRemaining(opponent), int(incrementSeconds)*1000)
+
 	cancel()
 	<-donechan
 }

--- a/pkg/bus/adjudication_test.go
+++ b/pkg/bus/adjudication_test.go
@@ -479,12 +479,13 @@ func TestCorrespondenceAutoPassOpponentClockCorrect(t *testing.T) {
 	<-donechan
 }
 
-// TestRealtimeWithIncrementTimeoutAutoPasses tests that a real-time game that
-// has a per-turn increment auto-passes on timeout (the opponent can still
-// move) instead of forfeiting. This is gated by the autopassRealtimeWithIncrement
-// const; with that const set to false this game would forfeit (GameEndReason_TIME)
-// like TestRealtimeNoIncrementTimeoutStillForfeits below.
-func TestRealtimeWithIncrementTimeoutAutoPasses(t *testing.T) {
+// TestRealtimeWithIncrementTimeoutForfeits tests that a real-time game that has
+// a per-turn increment forfeits on timeout (GameEndReason_TIME) like every other
+// real-time game. Auto-passing real-time-with-increment games is gated by the
+// autopassRealtimeWithIncrement const, which is false: only correspondence games
+// auto-pass, so an increment no longer changes a real-time game's timeout
+// behavior (cf. TestRealtimeNoIncrementTimeoutStillForfeits below).
+func TestRealtimeWithIncrementTimeoutForfeits(t *testing.T) {
 	is := is.New(t)
 	stores := recreateDB()
 	defer stores.Disconnect()
@@ -502,7 +503,6 @@ func TestRealtimeWithIncrementTimeoutAutoPasses(t *testing.T) {
 	})
 
 	playerOnTurn := g.Game.PlayerOnTurn()
-	numEvtsBefore := len(g.History().Events)
 
 	// Blow past the initial clock (no overtime), so the on-turn player times out.
 	nower.Sleep(int64(initialTimeSeconds)*1000 + 1000)
@@ -513,21 +513,13 @@ func TestRealtimeWithIncrementTimeoutAutoPasses(t *testing.T) {
 	err := gameplay.TimedOut(ctx, stores, playerID, g.GameID())
 	is.NoErr(err)
 
-	// The game did NOT forfeit: it continues, the on-turn player was
-	// auto-passed, and the turn advanced to the opponent.
+	// The game forfeits on time even though it has an increment.
 	reloadedGame, err := stores.GameStore.Get(ctx, g.GameID())
 	is.NoErr(err)
-	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_NONE)
-	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_PLAYING)
-	is.Equal(reloadedGame.Game.PlayerOnTurn(), 1-playerOnTurn)
-	// A pass event was recorded for the timed-out player.
-	newEvts := reloadedGame.History().Events
-	is.Equal(len(newEvts), numEvtsBefore+1)
-	is.Equal(newEvts[len(newEvts)-1].Type, macondopb.GameEvent_PASS)
-
-	// The opponent's clock is correct: they get their full initial clock from
-	// their turn start (untouched by the timed-out player's pass).
-	is.Equal(reloadedGame.CachedTimeRemaining(1-playerOnTurn), int(initialTimeSeconds)*1000)
+	is.Equal(reloadedGame.GameEndReason, pb.GameEndReason_TIME)
+	is.Equal(reloadedGame.Game.Playing(), macondopb.PlayState_GAME_OVER)
+	// The player who timed out loses.
+	is.Equal(reloadedGame.WinnerIdx, 1-playerOnTurn)
 
 	cancel()
 	<-donechan

--- a/pkg/entity/game.go
+++ b/pkg/entity/game.go
@@ -98,6 +98,12 @@ type Quickdata struct {
 	PlayerInfo        []*pb.PlayerInfo `json:"pi"`
 	OriginalRatings   []float64
 	NewRatings        []float64
+	// AutopassTimedOut[i] is true if player i was auto-passed because their
+	// time (and time bank) ran out -- i.e. they abandoned the game. The game
+	// still ends by score, but this lets automod and league standings treat
+	// the abandonment as a timeout even though the end reason is
+	// CONSECUTIVE_ZEROES.
+	AutopassTimedOut [2]bool `json:"apto"`
 }
 
 func (q *Quickdata) Value() (driver.Value, error) {
@@ -665,6 +671,41 @@ func (g *Game) HasIncrement() bool {
 		return false
 	}
 	return g.GameReq.IncrementSeconds > 0
+}
+
+// MarkAutopassTimedOut records that the player at idx was auto-passed because
+// their time (and time bank) ran out -- they abandoned the game. Idempotent;
+// safe to call on each repeated auto-pass. See Quickdata.AutopassTimedOut.
+func (g *Game) MarkAutopassTimedOut(idx int) {
+	if g.Quickdata == nil {
+		g.Quickdata = &Quickdata{}
+	}
+	if idx >= 0 && idx < len(g.Quickdata.AutopassTimedOut) {
+		g.Quickdata.AutopassTimedOut[idx] = true
+	}
+}
+
+// AutopassTimedOut reports whether the player at idx abandoned the game via an
+// auto-passed timeout.
+func (g *Game) AutopassTimedOut(idx int) bool {
+	if g.Quickdata == nil || idx < 0 || idx >= len(g.Quickdata.AutopassTimedOut) {
+		return false
+	}
+	return g.Quickdata.AutopassTimedOut[idx]
+}
+
+// AutopassAbandonerIdx returns the index of a player who abandoned via an
+// auto-passed timeout, or -1 if none. If both did, it returns the lower index.
+func (g *Game) AutopassAbandonerIdx() int {
+	if g.Quickdata == nil {
+		return -1
+	}
+	for i := range g.Quickdata.AutopassTimedOut {
+		if g.Quickdata.AutopassTimedOut[i] {
+			return i
+		}
+	}
+	return -1
 }
 
 // AddTimeToPlayer adds milliseconds to the specified player's remaining time.

--- a/pkg/entity/game.go
+++ b/pkg/entity/game.go
@@ -656,6 +656,17 @@ func (g *Game) IsCorrespondence() bool {
 	return g.GameReq.GameMode == pb.GameMode_CORRESPONDENCE
 }
 
+// HasIncrement returns true if this game has a per-turn time increment
+// (IncrementSeconds > 0). An increment means the opponent can still move in
+// the future, which is what lets a timed-out game continue via auto-pass
+// instead of forfeiting.
+func (g *Game) HasIncrement() bool {
+	if g.GameReq == nil || g.GameReq.GameRequest == nil {
+		return false
+	}
+	return g.GameReq.IncrementSeconds > 0
+}
+
 // AddTimeToPlayer adds milliseconds to the specified player's remaining time.
 func (g *Game) AddTimeToPlayer(playerIdx int, milliseconds int) {
 	if playerIdx >= 0 && playerIdx < len(g.Timers.TimeRemaining) {

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -729,6 +729,14 @@ func handleEventAfterLockingGame(ctx context.Context, stores *stores.Stores, use
 					Type:   pb.ClientGameplayEvent_PASS,
 					GameId: cge.GameId,
 				}
+				// Record that this player abandoned via timeout (their time
+				// bank is exhausted). The game still ends by score via the
+				// six-pass rule, but this lets automod and league standings
+				// treat it as a timeout even though the end reason will be
+				// CONSECUTIVE_ZEROES. Idempotent across repeated adjudicator
+				// fires; the ticker route also reaches here via
+				// handleEventAfterLockingGame.
+				entGame.MarkAutopassTimedOut(onTurn)
 			}
 		} else {
 			// Real-time game with no increment: forfeit on time (unchanged).

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -676,14 +676,36 @@ func handleEventAfterLockingGame(ctx context.Context, stores *stores.Stores, use
 
 		// If an ending game gets "challenge" just before "timed out",
 		// ignore the challenge, pass instead.
+		//
+		// Correspondence games auto-pass on timeout instead of forfeiting:
+		// the on-turn player's submitted move is discarded and replaced with
+		// a pass, the turn advances to the opponent, and the game ends
+		// naturally via the six-consecutive-pass rule. The pass is recorded
+		// by PlayMove -> RecordTimeOfMove at the expiry-capped time, so the
+		// opponent's clock starts correctly regardless of how late the move
+		// arrives. A resignation is exempt and falls through to the resign
+		// handler so it still ends the game with the resigner as the loser;
+		// real-time games are unchanged and still forfeit on time.
 		if entGame.Game.Playing() == macondopb.PlayState_WAITING_FOR_FINAL_PASS {
 			log.Debug().Msg("timed out, so passing instead of processing the submitted move")
 			cge = &pb.ClientGameplayEvent{
 				Type:   pb.ClientGameplayEvent_PASS,
 				GameId: cge.GameId,
 			}
+		} else if entGame.IsCorrespondence() {
+			if cge.Type == pb.ClientGameplayEvent_RESIGN {
+				// Honor a correspondence resignation even after time ran out.
+				log.Debug().Msg("correspondence timed out, but processing the submitted resignation")
+				// fall through to the resign handler below
+			} else {
+				log.Debug().Msg("correspondence timed out, so auto-passing instead of forfeiting")
+				cge = &pb.ClientGameplayEvent{
+					Type:   pb.ClientGameplayEvent_PASS,
+					GameId: cge.GameId,
+				}
+			}
 		} else {
-			// Basically skip to the bottom and exit.
+			// Real-time game: forfeit on time (unchanged).
 			return entGame, setTimedOut(ctx, entGame, onTurn, stores)
 		}
 	}
@@ -807,8 +829,19 @@ func TimedOut(ctx context.Context, stores *stores.Stores, timedout string, gameI
 	}
 	// Ok, the time did run out after all.
 
-	// If opponent played out, auto-pass instead of forfeiting.
-	if entGame.Game.Playing() == macondopb.PlayState_WAITING_FOR_FINAL_PASS {
+	// Auto-pass instead of forfeiting when either:
+	//   - the opponent has already played out (WAITING_FOR_FINAL_PASS), or
+	//   - this is a correspondence game (auto-pass on bank/per-turn expiry).
+	// In both cases the on-turn player's turn becomes a pass, the turn
+	// advances, and the game ends naturally via the six-consecutive-pass
+	// rule. handleEventAfterLockingGame -> PlayMove -> RecordTimeOfMove
+	// records the pass at the expiry-capped time, so the opponent's clock
+	// starts correctly even though the correspondence adjudicator may fire
+	// up to AdjudicateCorrespondenceInterval (60s) after expiry. The
+	// adjudicator re-fires every interval, so an abandoning player keeps
+	// auto-passing each turn until the six-pass rule ends the game.
+	if entGame.Game.Playing() == macondopb.PlayState_WAITING_FOR_FINAL_PASS ||
+		entGame.IsCorrespondence() {
 		log.Debug().Msg("timed out, so auto-passing instead of forfeiting")
 		_, err = handleEventAfterLockingGame(ctx, stores,
 			entGame.Game.PlayerIDOnTurn(), &pb.ClientGameplayEvent{

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -43,6 +43,29 @@ var (
 	errGameAlreadyStarted = errors.New("game already started")
 )
 
+// autopassRealtimeWithIncrement: when true, a real-time game that has a
+// per-turn increment (IncrementSeconds > 0) auto-passes on timeout -- the
+// opponent can still move, so the game continues and ends naturally by score
+// -- instead of forfeiting. Flip to false to restore forfeit-on-time for all
+// real-time games (correspondence games still auto-pass regardless).
+//
+// NOTE: this changes real-time flagging semantics. In a blitz game WITH an
+// increment, running out of time is no longer an instant loss: the player
+// auto-passes, the opponent plays on, and a player who is ahead on score can
+// still win. This const is the single rollback switch for that behavior.
+const autopassRealtimeWithIncrement = true
+
+// shouldAutopassOnTimeout reports whether a timed-out game should auto-pass
+// the on-turn player (turn advances, game continues and ends by score)
+// instead of forfeiting on time. True for any correspondence game, and -- when
+// autopassRealtimeWithIncrement is enabled -- for a real-time game that has a
+// per-turn increment. Used by both timeout routes (the move path and the
+// ticker path) so they stay consistent.
+func shouldAutopassOnTimeout(entGame *entity.Game) bool {
+	return entGame.IsCorrespondence() ||
+		(autopassRealtimeWithIncrement && entGame.HasIncrement())
+}
+
 const (
 	IdentificationAuthority = "io.woogles"
 )
@@ -677,35 +700,36 @@ func handleEventAfterLockingGame(ctx context.Context, stores *stores.Stores, use
 		// If an ending game gets "challenge" just before "timed out",
 		// ignore the challenge, pass instead.
 		//
-		// Correspondence games auto-pass on timeout instead of forfeiting:
-		// the on-turn player's submitted move is discarded and replaced with
-		// a pass, the turn advances to the opponent, and the game ends
-		// naturally via the six-consecutive-pass rule. The pass is recorded
-		// by PlayMove -> RecordTimeOfMove at the expiry-capped time, so the
-		// opponent's clock starts correctly regardless of how late the move
-		// arrives. A resignation is exempt and falls through to the resign
-		// handler so it still ends the game with the resigner as the loser;
-		// real-time games are unchanged and still forfeit on time.
+		// Auto-pass-on-timeout games discard the on-turn player's submitted
+		// move and replace it with a pass: the turn advances to the opponent
+		// and the game ends naturally via the six-consecutive-pass rule. The
+		// pass is recorded by PlayMove -> RecordTimeOfMove at the expiry-capped
+		// time, so the opponent's clock starts correctly regardless of how late
+		// the move arrives. A resignation is exempt and falls through to the
+		// resign handler so it still ends the game with the resigner as the
+		// loser. This covers all correspondence games and (per
+		// autopassRealtimeWithIncrement) real-time games that have a per-turn
+		// increment; real-time games without an increment still forfeit on time.
 		if entGame.Game.Playing() == macondopb.PlayState_WAITING_FOR_FINAL_PASS {
 			log.Debug().Msg("timed out, so passing instead of processing the submitted move")
 			cge = &pb.ClientGameplayEvent{
 				Type:   pb.ClientGameplayEvent_PASS,
 				GameId: cge.GameId,
 			}
-		} else if entGame.IsCorrespondence() {
+		} else if shouldAutopassOnTimeout(entGame) {
 			if cge.Type == pb.ClientGameplayEvent_RESIGN {
-				// Honor a correspondence resignation even after time ran out.
-				log.Debug().Msg("correspondence timed out, but processing the submitted resignation")
+				// Honor a resignation even after time ran out.
+				log.Debug().Msg("timed out, but processing the submitted resignation")
 				// fall through to the resign handler below
 			} else {
-				log.Debug().Msg("correspondence timed out, so auto-passing instead of forfeiting")
+				log.Debug().Msg("timed out, so auto-passing instead of forfeiting")
 				cge = &pb.ClientGameplayEvent{
 					Type:   pb.ClientGameplayEvent_PASS,
 					GameId: cge.GameId,
 				}
 			}
 		} else {
-			// Real-time game: forfeit on time (unchanged).
+			// Real-time game with no increment: forfeit on time (unchanged).
 			return entGame, setTimedOut(ctx, entGame, onTurn, stores)
 		}
 	}
@@ -831,7 +855,9 @@ func TimedOut(ctx context.Context, stores *stores.Stores, timedout string, gameI
 
 	// Auto-pass instead of forfeiting when either:
 	//   - the opponent has already played out (WAITING_FOR_FINAL_PASS), or
-	//   - this is a correspondence game (auto-pass on bank/per-turn expiry).
+	//   - the game auto-passes on timeout (shouldAutopassOnTimeout): any
+	//     correspondence game, plus -- per autopassRealtimeWithIncrement -- a
+	//     real-time game that has a per-turn increment.
 	// In both cases the on-turn player's turn becomes a pass, the turn
 	// advances, and the game ends naturally via the six-consecutive-pass
 	// rule. handleEventAfterLockingGame -> PlayMove -> RecordTimeOfMove
@@ -841,7 +867,7 @@ func TimedOut(ctx context.Context, stores *stores.Stores, timedout string, gameI
 	// adjudicator re-fires every interval, so an abandoning player keeps
 	// auto-passing each turn until the six-pass rule ends the game.
 	if entGame.Game.Playing() == macondopb.PlayState_WAITING_FOR_FINAL_PASS ||
-		entGame.IsCorrespondence() {
+		shouldAutopassOnTimeout(entGame) {
 		log.Debug().Msg("timed out, so auto-passing instead of forfeiting")
 		_, err = handleEventAfterLockingGame(ctx, stores,
 			entGame.Game.PlayerIDOnTurn(), &pb.ClientGameplayEvent{

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -44,16 +44,18 @@ var (
 )
 
 // autopassRealtimeWithIncrement: when true, a real-time game that has a
-// per-turn increment (IncrementSeconds > 0) auto-passes on timeout -- the
-// opponent can still move, so the game continues and ends naturally by score
-// -- instead of forfeiting. Flip to false to restore forfeit-on-time for all
-// real-time games (correspondence games still auto-pass regardless).
+// per-turn increment (IncrementSeconds > 0) also auto-passes on timeout --
+// the opponent can still move, so the game continues and ends naturally by
+// score -- instead of forfeiting. Default is false: only correspondence
+// games auto-pass; all real-time games (with or without an increment)
+// forfeit on time, the long-standing behavior.
 //
-// NOTE: this changes real-time flagging semantics. In a blitz game WITH an
-// increment, running out of time is no longer an instant loss: the player
-// auto-passes, the opponent plays on, and a player who is ahead on score can
-// still win. This const is the single rollback switch for that behavior.
-const autopassRealtimeWithIncrement = true
+// Set to true to also auto-pass real-time-with-increment games. NOTE that
+// this changes real-time semantics: in a blitz game WITH an increment,
+// running out of time would no longer be an instant loss -- the player
+// auto-passes, the opponent plays on, and a player ahead on score can still
+// win. This const is the single switch for that behavior.
+const autopassRealtimeWithIncrement = false
 
 // shouldAutopassOnTimeout reports whether a timed-out game should auto-pass
 // the on-turn player (turn advances, game continues and ends by score)

--- a/pkg/gameplay/game_playing_test.go
+++ b/pkg/gameplay/game_playing_test.go
@@ -103,6 +103,17 @@ func WithCorrespondenceMode(incrementSeconds int32, timeBankMinutes int32) TestG
 	}
 }
 
+// WithRealtimeIncrement configures a real-time game with a per-turn increment
+// and no overtime, so a timed-out turn is reached quickly and deterministically.
+func WithRealtimeIncrement(initialTimeSeconds int32, incrementSeconds int32) TestGameOption {
+	return func(gr *pb.GameRequest) {
+		gr.GameMode = pb.GameMode_REAL_TIME
+		gr.InitialTimeSeconds = initialTimeSeconds
+		gr.IncrementSeconds = incrementSeconds
+		gr.MaxOvertimeMinutes = 0
+	}
+}
+
 func makeGame(cfg *config.Config, stores *stores.Stores, opts ...TestGameOption) (
 	*entity.Game, *entity.FakeNower, context.CancelFunc, chan bool, *evtConsumer) {
 
@@ -660,6 +671,64 @@ func TestCorrespondenceResignAfterTimeoutStillResigns(t *testing.T) {
 	is.Equal(entGame.GameEndReason, pb.GameEndReason_RESIGNED)
 	is.Equal(entGame.WinnerIdx, 1)
 	is.Equal(entGame.LoserIdx, 0)
+
+	gs.cancel()
+	<-gs.donechan
+	teardownGame(gs)
+}
+
+// TestRealtimeWithIncrementLateMoveAutoPasses tests the move-path for a
+// real-time game that has a per-turn increment: a real move submitted after
+// the player's time has run out is discarded and turned into an auto-pass
+// (rather than forfeiting). The turn advances and the game continues. This is
+// gated by the autopassRealtimeWithIncrement const; with that const false the
+// move path would forfeit on time instead.
+func TestRealtimeWithIncrementLateMoveAutoPasses(t *testing.T) {
+	is := is.New(t)
+	ctx := ctxForTests()
+
+	// Real-time game with a 30s initial clock, a 5s increment, and no overtime.
+	initialTimeSeconds := int32(30)
+	gs := setupNewGame(WithRealtimeIncrement(initialTimeSeconds, 5))
+	gs.stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return gs.nower
+	})
+
+	is.Equal(gs.g.IsCorrespondence(), false)
+	is.Equal(gs.g.HasIncrement(), true)
+	is.Equal(gs.g.PlayerOnTurn(), 0)
+
+	gs.g.SetRacksForBoth([]*tilemapping.Rack{
+		tilemapping.RackFromString("ABEJNOR", gs.g.Alphabet()),
+		tilemapping.RackFromString("AGLSYYZ", gs.g.Alphabet()),
+	})
+	gs.stores.GameStore.Set(ctx, gs.g)
+
+	// Blow past the initial clock (no overtime) so the on-turn player times out.
+	gs.nower.Sleep(int64(initialTimeSeconds)*1000 + 1000)
+	is.True(gs.g.TimeRanOut(0))
+
+	// jesse tries to play BANJO well after timing out. The move is discarded
+	// and replaced with a pass.
+	cge := &pb.ClientGameplayEvent{
+		Type:           pb.ClientGameplayEvent_TILE_PLACEMENT,
+		GameId:         gs.g.GameID(),
+		PositionCoords: "8D",
+		MachineLetters: []byte{2, 1, 14, 10, 15}, // BANJO
+	}
+	entGame, err := gameplay.HandleEvent(ctx, gs.stores, "3xpEkpRAy3AizbVmDg3kdi", cge)
+	is.NoErr(err)
+
+	// Game continues, turn advanced to cesar (player 1).
+	is.Equal(entGame.Game.Playing(), macondopb.PlayState_PLAYING)
+	is.Equal(entGame.GameEndReason, pb.GameEndReason_NONE)
+	is.Equal(entGame.Game.PlayerOnTurn(), 1)
+
+	// The recorded event was a PASS, not BANJO. No points were scored.
+	evts := entGame.History().Events
+	lastEvt := evts[len(evts)-1]
+	is.Equal(lastEvt.Type, macondopb.GameEvent_PASS)
+	is.Equal(lastEvt.Score, int32(0))
 
 	gs.cancel()
 	<-gs.donechan

--- a/pkg/gameplay/game_playing_test.go
+++ b/pkg/gameplay/game_playing_test.go
@@ -683,13 +683,13 @@ func TestCorrespondenceResignAfterTimeoutStillResigns(t *testing.T) {
 	teardownGame(gs)
 }
 
-// TestRealtimeWithIncrementLateMoveAutoPasses tests the move-path for a
-// real-time game that has a per-turn increment: a real move submitted after
-// the player's time has run out is discarded and turned into an auto-pass
-// (rather than forfeiting). The turn advances and the game continues. This is
-// gated by the autopassRealtimeWithIncrement const; with that const false the
-// move path would forfeit on time instead.
-func TestRealtimeWithIncrementLateMoveAutoPasses(t *testing.T) {
+// TestRealtimeWithIncrementLateMoveForfeits tests the move-path for a real-time
+// game that has a per-turn increment: with autopassRealtimeWithIncrement false
+// (the current setting), a real move submitted after the player's time has run
+// out forfeits on time rather than auto-passing. Auto-pass is limited to
+// correspondence games; real-time games -- with or without an increment --
+// forfeit.
+func TestRealtimeWithIncrementLateMoveForfeits(t *testing.T) {
 	is := is.New(t)
 	ctx := ctxForTests()
 
@@ -714,8 +714,8 @@ func TestRealtimeWithIncrementLateMoveAutoPasses(t *testing.T) {
 	gs.nower.Sleep(int64(initialTimeSeconds)*1000 + 1000)
 	is.True(gs.g.TimeRanOut(0))
 
-	// jesse tries to play BANJO well after timing out. The move is discarded
-	// and replaced with a pass.
+	// jesse tries to play BANJO well after timing out. With auto-pass limited to
+	// correspondence games, this real-time game forfeits on time instead.
 	cge := &pb.ClientGameplayEvent{
 		Type:           pb.ClientGameplayEvent_TILE_PLACEMENT,
 		GameId:         gs.g.GameID(),
@@ -725,16 +725,11 @@ func TestRealtimeWithIncrementLateMoveAutoPasses(t *testing.T) {
 	entGame, err := gameplay.HandleEvent(ctx, gs.stores, "3xpEkpRAy3AizbVmDg3kdi", cge)
 	is.NoErr(err)
 
-	// Game continues, turn advanced to cesar (player 1).
-	is.Equal(entGame.Game.Playing(), macondopb.PlayState_PLAYING)
-	is.Equal(entGame.GameEndReason, pb.GameEndReason_NONE)
-	is.Equal(entGame.Game.PlayerOnTurn(), 1)
-
-	// The recorded event was a PASS, not BANJO. No points were scored.
-	evts := entGame.History().Events
-	lastEvt := evts[len(evts)-1]
-	is.Equal(lastEvt.Type, macondopb.GameEvent_PASS)
-	is.Equal(lastEvt.Score, int32(0))
+	// The game forfeited on time: it is over and the timed-out player (jesse,
+	// player 0) lost.
+	is.Equal(entGame.Game.Playing(), macondopb.PlayState_GAME_OVER)
+	is.Equal(entGame.GameEndReason, pb.GameEndReason_TIME)
+	is.Equal(entGame.WinnerIdx, 1)
 
 	gs.cancel()
 	<-gs.donechan

--- a/pkg/gameplay/game_playing_test.go
+++ b/pkg/gameplay/game_playing_test.go
@@ -93,6 +93,16 @@ func WithInitialTimeSeconds(seconds int32) TestGameOption {
 	}
 }
 
+func WithCorrespondenceMode(incrementSeconds int32, timeBankMinutes int32) TestGameOption {
+	return func(gr *pb.GameRequest) {
+		gr.GameMode = pb.GameMode_CORRESPONDENCE
+		gr.IncrementSeconds = incrementSeconds
+		gr.TimeBankMinutes = timeBankMinutes
+		gr.InitialTimeSeconds = incrementSeconds
+		gr.MaxOvertimeMinutes = 0 // Correspondence games don't use max overtime
+	}
+}
+
 func makeGame(cfg *config.Config, stores *stores.Stores, opts ...TestGameOption) (
 	*entity.Game, *entity.FakeNower, context.CancelFunc, chan bool, *evtConsumer) {
 
@@ -556,5 +566,102 @@ func TestQuickdata(t *testing.T) {
 	gs.cancel()
 	<-gs.donechan
 
+	teardownGame(gs)
+}
+
+// TestCorrespondenceLateMoveAutoPasses tests the move-path: a real move
+// submitted to a correspondence game after the player's time has run out is
+// discarded and turned into an auto-pass (rather than forfeiting). The turn
+// advances and the game continues.
+func TestCorrespondenceLateMoveAutoPasses(t *testing.T) {
+	is := is.New(t)
+	ctx := ctxForTests()
+
+	// 60 second increment, no time bank.
+	gs := setupNewGame(WithCorrespondenceMode(60, 0))
+	// Make HandleEvent's reload of the (cache-bypassing) correspondence game
+	// share the same fake nower for deterministic timing.
+	gs.stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return gs.nower
+	})
+
+	is.Equal(gs.g.IsCorrespondence(), true)
+	is.Equal(gs.g.PlayerOnTurn(), 0)
+
+	// Give jesse (player 0) a known rack with a playable word, then let the
+	// clock blow past the per-turn allowance with no bank to fall back on.
+	gs.g.SetRacksForBoth([]*tilemapping.Rack{
+		tilemapping.RackFromString("ABEJNOR", gs.g.Alphabet()),
+		tilemapping.RackFromString("AGLSYYZ", gs.g.Alphabet()),
+	})
+	gs.stores.GameStore.Set(ctx, gs.g)
+
+	gs.nower.Sleep(120 * 1000) // 120 seconds, 2x the 60s allowance
+	is.True(gs.g.TimeRanOut(0))
+
+	// jesse tries to play BANJO well after timing out. The move is discarded
+	// and replaced with a pass.
+	cge := &pb.ClientGameplayEvent{
+		Type:           pb.ClientGameplayEvent_TILE_PLACEMENT,
+		GameId:         gs.g.GameID(),
+		PositionCoords: "8D",
+		MachineLetters: []byte{2, 1, 14, 10, 15}, // BANJO
+	}
+	entGame, err := gameplay.HandleEvent(ctx, gs.stores, "3xpEkpRAy3AizbVmDg3kdi", cge)
+	is.NoErr(err)
+
+	// Game continues, turn advanced to cesar (player 1).
+	is.Equal(entGame.Game.Playing(), macondopb.PlayState_PLAYING)
+	is.Equal(entGame.GameEndReason, pb.GameEndReason_NONE)
+	is.Equal(entGame.Game.PlayerOnTurn(), 1)
+
+	// The recorded event was a PASS, not BANJO. No points were scored.
+	evts := entGame.History().Events
+	lastEvt := evts[len(evts)-1]
+	is.Equal(lastEvt.Type, macondopb.GameEvent_PASS)
+	is.Equal(lastEvt.Score, int32(0))
+
+	gs.cancel()
+	<-gs.donechan
+	teardownGame(gs)
+}
+
+// TestCorrespondenceResignAfterTimeoutStillResigns tests that a resignation
+// submitted to a correspondence game after the player's time has run out is
+// still honored (ending the game with the resigner as the loser) rather than
+// being turned into an auto-pass.
+func TestCorrespondenceResignAfterTimeoutStillResigns(t *testing.T) {
+	is := is.New(t)
+	ctx := ctxForTests()
+
+	gs := setupNewGame(WithCorrespondenceMode(60, 0))
+	gs.stores.GameStore.SetTimerModuleCreator(func() entity.Nower {
+		return gs.nower
+	})
+
+	is.Equal(gs.g.IsCorrespondence(), true)
+	is.Equal(gs.g.PlayerOnTurn(), 0)
+
+	// Blow past the per-turn allowance with no bank.
+	gs.nower.Sleep(120 * 1000)
+	is.True(gs.g.TimeRanOut(0))
+
+	// jesse (player 0, on turn and timed out) resigns.
+	entGame, err := gameplay.HandleEvent(ctx, gs.stores, "3xpEkpRAy3AizbVmDg3kdi",
+		&pb.ClientGameplayEvent{
+			Type:   pb.ClientGameplayEvent_RESIGN,
+			GameId: gs.g.GameID(),
+		})
+	is.NoErr(err)
+
+	// The resignation is honored: the game ends, reason is RESIGNED, and the
+	// resigner (player 0) loses to the opponent (player 1).
+	is.Equal(entGame.Game.Playing(), macondopb.PlayState_GAME_OVER)
+	is.Equal(entGame.GameEndReason, pb.GameEndReason_RESIGNED)
+	is.Equal(entGame.WinnerIdx, 1)
+	is.Equal(entGame.LoserIdx, 0)
+
+	gs.cancel()
+	<-gs.donechan
 	teardownGame(gs)
 }

--- a/pkg/gameplay/game_playing_test.go
+++ b/pkg/gameplay/game_playing_test.go
@@ -632,6 +632,12 @@ func TestCorrespondenceLateMoveAutoPasses(t *testing.T) {
 	is.Equal(lastEvt.Type, macondopb.GameEvent_PASS)
 	is.Equal(lastEvt.Score, int32(0))
 
+	// The abandonment was recorded: player 0 was auto-passed on timeout,
+	// player 1 was not.
+	is.True(entGame.AutopassTimedOut(0))
+	is.True(!entGame.AutopassTimedOut(1))
+	is.Equal(entGame.AutopassAbandonerIdx(), 0)
+
 	gs.cancel()
 	<-gs.donechan
 	teardownGame(gs)

--- a/pkg/league/standings.go
+++ b/pkg/league/standings.go
@@ -698,7 +698,12 @@ func (sm *StandingsManager) recalculateDivisionExtendedStats(
 			p1Standing.HighGame = p1Score
 		}
 
-		// Track timeouts (game_end_reason 1 = TIME)
+		// Track timeouts (game_end_reason 1 = TIME).
+		// NOTE: auto-pass abandonments end as CONSECUTIVE_ZEROES (3), not TIME,
+		// so a full recompute does not yet re-attribute those timeouts the way
+		// the live path (extractGameStats) does. Threading the abandonment
+		// marker through GetDivisionGamesWithStats (a query + sqlc change) is a
+		// follow-up; until then a recompute undercounts auto-pass timeouts.
 		if game.GameEndReason == 1 {
 			// The loser timed out - determine who lost
 			if game.Player0Won.Valid {

--- a/pkg/league/standings_updater.go
+++ b/pkg/league/standings_updater.go
@@ -39,6 +39,16 @@ func extractGameStats(g *entity.Game) (p0Stats, p1Stats GameStats) {
 			p1Stats.TimedOut = true
 		}
 	}
+	// An auto-passed abandonment ends as CONSECUTIVE_ZEROES, not TIME, but the
+	// player who was auto-passed on timeout still timed out -- count it, keyed
+	// to the actual abandoner (who may have been ahead on score) rather than to
+	// the game's score-loser.
+	if g.AutopassTimedOut(0) {
+		p0Stats.TimedOut = true
+	}
+	if g.AutopassTimedOut(1) {
+		p1Stats.TimedOut = true
+	}
 
 	// Extract stats from computed game stats if available
 	if g.Stats != nil {

--- a/pkg/mod/automod.go
+++ b/pkg/mod/automod.go
@@ -67,6 +67,14 @@ func Automod(ctx context.Context, us user.Store, ns NotorietyStore, u0 *entity.U
 	history := g.History()
 	// Perhaps too cute, but solves cases where g.LoserIdex is -1
 	nonNegativeLoserIdx := g.LoserIdx * g.LoserIdx
+	// An auto-passed abandonment ends the game by score, so the score-loser is
+	// not necessarily the bad actor -- the player who abandoned (was auto-
+	// passed on timeout) is, even if they happened to be ahead on the board and
+	// "won". Attribute notoriety to the abandoner instead of the score-loser.
+	isAbandonment := g.AutopassAbandonerIdx() >= 0
+	if isAbandonment {
+		nonNegativeLoserIdx = g.AutopassAbandonerIdx()
+	}
 	loserId := history.Players[nonNegativeLoserIdx].UserId
 	winnerIdx := 1 - nonNegativeLoserIdx
 
@@ -77,11 +85,15 @@ func Automod(ctx context.Context, us user.Store, ns NotorietyStore, u0 *entity.U
 
 	isBotGame := u0.IsBot || u1.IsBot
 
-	if (g.GameEndReason == ipc.GameEndReason_TIME || g.GameEndReason == ipc.GameEndReason_RESIGNED) &&
-		totalGameTime > int32(UnreasonableTime) && !isBotGame {
+	// Auto-passed abandonment enters this block regardless of the time control
+	// (a correspondence game abandons over days, but its nominal time control
+	// can be tiny), so the UnreasonableTime gate only applies to TIME/RESIGNED.
+	if (((g.GameEndReason == ipc.GameEndReason_TIME || g.GameEndReason == ipc.GameEndReason_RESIGNED) &&
+		totalGameTime > int32(UnreasonableTime)) || isAbandonment) && !isBotGame {
 		// g.LoserIdx should never be -1, but if it is somehow, then the whole app will
-		// crash, so let's just be sure
-		if g.LoserIdx == -1 {
+		// crash, so let's just be sure. For an abandonment we already resolved a
+		// valid abandoner index above, so a score tie (LoserIdx == -1) is fine.
+		if !isAbandonment && g.LoserIdx == -1 {
 			return errors.New("game ended in resignation but does not have a winner")
 		}
 		// Someone lost on time, determine if the loser made no plays at all


### PR DESCRIPTION
## Summary
Auto-pass a correspondence turn once the player's **time bank is exhausted**, instead of leaving the game stuck, so an abandoned correspondence/league game ends naturally by score (the six-consecutive-pass rule) rather than hanging. Builds on the two existing auto-pass commits; this PR adds the product scoping and the downstream rewiring needed to ship it safely.

Behavior (decisions baked in):
- **Correspondence only.** Auto-pass triggers only after the time bank can no longer cover the per-turn overage (`TimeRanOut` for a reset-to-increment game: per-turn allowance exceeded AND bank `< deficit`). The per-turn (main) timer expiring just starts draining the bank -- no auto-pass until the bank is gone. Real-time games, **including real-time-with-increment**, keep forfeiting on time (`autopassRealtimeWithIncrement` is now `false`; flip to `true` to opt them back in).
- **Abandoners are still flagged.** An auto-passed abandonment ends as `CONSECUTIVE_ZEROES`, not `TIME`, and the abandoner is not necessarily the score-loser (a player ahead on the board can be auto-passed and still win). A per-player marker (`Quickdata.AutopassTimedOut`, set at the single auto-pass choke point that both the move route and the adjudicator route pass through) records who abandoned, so:
  - **automod** still flags the abandoner `NO_PLAY` / `SITTING` / `NO_PLAY_DENIED_NUDGE` -- attributed to the abandoner regardless of who won on score, and gated independently of the nominal time control (a correspondence control can be tiny while the game spans days).
  - **league standings** still count the abandonment as a `Timeout` for the abandoner (live per-game-end path).

Commits are kept separate and un-folded for easy revert:
1. limit auto-pass-on-timeout to correspondence games
2. record which player abandoned via auto-pass timeout (marker infra)
3. treat auto-pass abandonment as notorious in automod
4. count auto-pass abandonment as a league timeout

## Known limitations / follow-ups
- **League recompute path**: `RecalculateSeasonExtendedStats` reads the stored `game_end_reason` via `GetDivisionGamesWithStats` and does not yet see the abandonment marker, so a full season recompute undercounts auto-pass timeouts. The live path is correct; threading the marker through that query (a query + sqlc change, e.g. a denormalized `game_players` column or `games.quickdata` in the SELECT) is a follow-up, documented in-code at the recompute site.
- **Lingering**: after each auto-pass the abandoner's per-turn time resets to a full increment, so an abandoned game takes ~6 x (increment + adjudicator interval) to reach the six-pass end -- roughly 6 days for a 1-day-increment correspondence game. Accepted; a faster "end once the bank is exhausted" path could be a follow-up.
- **Frontend**: the on-turn player suddenly sees a PASS they did not make; no FE change in this PR.

## Test plan
Most touched paths are DB-gated integration tests (run in CI):
- [ ] `go test ./pkg/gameplay/ -run TestCorrespondence` (incl. the new `AutopassTimedOut` marker assertions in `TestCorrespondenceLateMoveAutoPasses`) -- requires Postgres
- [ ] `go test ./pkg/mod/ -run TestNotoriety` -- requires Postgres
- [ ] `go test ./pkg/league/...` -- requires Postgres
- [ ] `go test ./pkg/bus/ -run Adjudication` (the correspondence adjudicator drives the repeated auto-pass)
- [x] `go build ./pkg/entity/ ./pkg/gameplay/ ./pkg/mod/ ./pkg/league/` -- clean
- [x] `gofmt -l` clean and `go vet` clean on the touched packages
- [ ] Manual (real DB): a correspondence abandon-to-completion ends `GAME_OVER` via `CONSECUTIVE_ZEROES` with the correct winner by score; the abandoner is flagged by automod and recorded as a league `Timeout`; both-abandon still terminates at six passes; real-time-with-increment still forfeits on time.

Draft until the CI DB suite and a manual league-abandonment run are green.
