### PR TITLE
fix non-monotonic possible-rank bounds in league standings

### DIFF
--- a/pkg/league/monotonic_replay_test.go
+++ b/pkg/league/monotonic_replay_test.go
@@ -59,9 +59,17 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 type divKey struct{ season, div string }
+
+// worst single CalculatePossibleRanks call seen during a replay (perf guard:
+// the production budget is the worst per-division-snapshot, ~29ms).
+var (
+	maxCalcDur           time.Duration
+	maxCalcN, maxCalcRem int
+)
 
 type replayGame struct {
 	p0, p1 int32
@@ -96,6 +104,8 @@ func TestRankBoundsMonotonicReplay(t *testing.T) {
 
 	t.Logf("replayed %d division-seasons (%d skipped: incomplete schedule), %d snapshots",
 		rep.divisions, rep.skipped, rep.snapshots)
+	t.Logf("worst single CalculatePossibleRanks: %v (n=%d, remaining games=%d)",
+		maxCalcDur, maxCalcN, maxCalcRem)
 	t.Logf("monotonicity violations: %d total (MM=%d maxflow->maxflow, MB=%d maxflow->brute boundary, BB=%d brute->brute)",
 		rep.monoViol, rep.viaMM, rep.viaMB, rep.viaBB)
 	t.Logf("final-result mismatches: %d", rep.finalMiss)
@@ -258,7 +268,11 @@ func replayDivision(rep *replayReport, season, div string, played []replayGame, 
 		}
 		remCount := len(unf)
 
+		t0 := time.Now()
 		bounds := CalculatePossibleRanks(standings, unf)
+		if d := time.Since(t0); d > maxCalcDur {
+			maxCalcDur, maxCalcN, maxCalcRem = d, len(standings), remCount
+		}
 		rep.snapshots++
 		inMaxflow := remCount > bruteForceThreshold
 

--- a/pkg/league/monotonic_replay_test.go
+++ b/pkg/league/monotonic_replay_test.go
@@ -1,0 +1,408 @@
+package league
+
+// Rank-bounds monotonicity + final-result reproducer.
+//
+// Replays real league games against the production rank-bounds code and checks
+// that the displayed possible-rank range only ever tightens.
+//
+// Export the full schedule (completed games with results + still-unplayed
+// pairings) in one snapshot via LEAGUE_REPLAY_CSV:
+//
+//	\copy (
+//	  SELECT gp.league_season_id, reg.division_id, gp.game_uuid,
+//	         gp.player_id AS p0_id, gp.opponent_id AS p1_id,
+//	         gp.score AS p0_score, gp.opponent_score AS p1_score,
+//	         gp.won AS p0_won, gp.updated_at AS completed_at, true AS played
+//	    FROM game_players gp
+//	    JOIN league_registrations reg
+//	      ON reg.user_id = gp.player_id AND reg.season_id = gp.league_season_id
+//	   WHERE gp.league_season_id IS NOT NULL AND gp.player_index = 0
+//	     AND gp.game_end_reason NOT IN (0,5,7)
+//	  UNION ALL
+//	  SELECT g.season_id, g.league_division_id, g.uuid,
+//	         g.player0_id, g.player1_id,
+//	         NULL::int, NULL::int, NULL::boolean, NULL::timestamptz, false
+//	    FROM games g
+//	   WHERE g.league_id IS NOT NULL AND g.game_end_reason = 0
+//	   ORDER BY league_season_id, division_id, played DESC, completed_at, game_uuid
+//	) TO 'league-all.csv' CSV HEADER;
+//
+// One transaction snapshot, so played and unplayed are disjoint and consistent.
+// League games are all created at season start, so played ∪ unplayed is the
+// fixed schedule. (A 9-column played-only dump without the `played` column also
+// works; its in-progress divisions are then skipped.)
+//
+// For each (season, division) we walk the played games in completion order. At
+// each snapshot the standings come from the played prefix and BOTH
+// gamesRemaining and the unfinished list come from (unplayed ∪ played-suffix),
+// so the inputs are internally consistent regardless of expectedGames /
+// force-finish quirks, and correct for >15-player divisions where the schedule
+// is a capped subset (not full round robin).
+//
+// Two invariants are checked:
+//
+//  1. Monotonicity: the displayed range only ever tightens. bestRank
+//     non-decreasing, worstRank non-increasing. A decrease in best (e.g. "7
+//     then 6") or increase in worst breaks the promise the feature makes.
+//  2. Final result: a fully-completed division's bounds must equal the real
+//     final standings (tie-aware: best = 1 + strictly-above, worst = best +
+//     equally-placed).
+//
+// Skipped unless LEAGUE_REPLAY_CSV is set, so normal CI does not need (and the
+// repo never commits) the prod data file.
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type divKey struct{ season, div string }
+
+type replayGame struct {
+	p0, p1 int32
+	s0, s1 int
+	result int // +1 = p0 won, -1 = p1 won, 0 = draw
+}
+
+type replayReport struct {
+	divisions, skipped, snapshots int
+	monoViol, finalMiss           int
+	// Violations bucketed by the regime transition that exposed them:
+	// MM = maxflow->maxflow, MB = maxflow->brute boundary, BB = brute->brute.
+	// brute is exact, so a nonzero BB would mean the bug is not maxflow-only.
+	viaMM, viaMB, viaBB                    int
+	cleanDivs, anomalyDivs                 int
+	cleanViol, anomalyViol                 int
+	monoSamples, finalSamples, jointWinner []string
+}
+
+func TestRankBoundsMonotonicReplay(t *testing.T) {
+	path := os.Getenv("LEAGUE_REPLAY_CSV")
+	if path == "" {
+		t.Skip("set LEAGUE_REPLAY_CSV to the exported league-all.csv to run")
+	}
+
+	played, unplayed, order := loadSchedule(t, path)
+
+	var rep replayReport
+	for _, k := range order {
+		replayDivision(&rep, k.season, k.div, played[k], unplayed[k])
+	}
+
+	t.Logf("replayed %d division-seasons (%d skipped: incomplete schedule), %d snapshots",
+		rep.divisions, rep.skipped, rep.snapshots)
+	t.Logf("monotonicity violations: %d total (MM=%d maxflow->maxflow, MB=%d maxflow->brute boundary, BB=%d brute->brute)",
+		rep.monoViol, rep.viaMM, rep.viaMB, rep.viaBB)
+	t.Logf("final-result mismatches: %d", rep.finalMiss)
+	t.Logf("violations by division kind: clean (no timeout-sign game)=%d in %d divs; anomaly=%d in %d divs",
+		rep.cleanViol, rep.cleanDivs, rep.anomalyViol, rep.anomalyDivs)
+	if len(rep.jointWinner) > 0 {
+		t.Logf("joint winners (tie for 1st): %d division(s):\n%s",
+			len(rep.jointWinner), strings.Join(rep.jointWinner, "\n"))
+	}
+
+	if rep.monoViol > 0 {
+		t.Errorf("rank-bounds widened %d time(s); first %d:\n%s",
+			rep.monoViol, len(rep.monoSamples), strings.Join(rep.monoSamples, "\n"))
+	}
+	if rep.finalMiss > 0 {
+		t.Errorf("final bounds disagreed with actual standings %d time(s); first %d:\n%s",
+			rep.finalMiss, len(rep.finalSamples), strings.Join(rep.finalSamples, "\n"))
+	}
+}
+
+// loadSchedule reads the unified dump, grouping each division's played games
+// (in completion order) and still-unplayed pairings. A 9-column played-only
+// dump (no `played` column) is treated as all played.
+func loadSchedule(t *testing.T, path string) (map[divKey][]replayGame, map[divKey][]unfinishedGame, []divKey) {
+	rows := readCSV(t, path)
+	played := map[divKey][]replayGame{}
+	unplayed := map[divKey][]unfinishedGame{}
+	var order []divKey
+	seen := map[divKey]bool{}
+	for i, row := range rows {
+		if i == 0 || len(row) < 9 {
+			continue // header / short row
+		}
+		div := row[1]
+		if div == "" {
+			continue // registration without a division assignment
+		}
+		k := divKey{row[0], div}
+		if !seen[k] {
+			seen[k] = true
+			order = append(order, k)
+		}
+
+		isPlayed := true
+		if len(row) >= 10 {
+			switch strings.ToLower(strings.TrimSpace(row[9])) {
+			case "f", "false":
+				isPlayed = false
+			}
+		}
+		if isPlayed {
+			res := 0
+			switch strings.ToLower(strings.TrimSpace(row[7])) {
+			case "t", "true":
+				res = 1
+			case "f", "false":
+				res = -1
+			}
+			played[k] = append(played[k], replayGame{
+				p0:     atoi32(row[3]),
+				p1:     atoi32(row[4]),
+				s0:     atoi(row[5]),
+				s1:     atoi(row[6]),
+				result: res,
+			})
+		} else {
+			unplayed[k] = append(unplayed[k], unfinishedGame{
+				player0ID: atoi32(row[3]),
+				player1ID: atoi32(row[4]),
+			})
+		}
+	}
+	return played, unplayed, order
+}
+
+func replayDivision(rep *replayReport, season, div string, played []replayGame, unplayed []unfinishedGame) {
+	// Distinct players, across played and unplayed games.
+	var players []int32
+	seen := map[int32]bool{}
+	totalGP := map[int32]int{}
+	add := func(p int32) {
+		if !seen[p] {
+			seen[p] = true
+			players = append(players, p)
+		}
+		totalGP[p]++
+	}
+	for _, g := range played {
+		add(g.p0)
+		add(g.p1)
+	}
+	for _, u := range unplayed {
+		add(u.player0ID)
+		add(u.player1ID)
+	}
+	n := len(players)
+
+	// Skip malformed / partially-dumped divisions: a valid full schedule has
+	// every player at exactly the expected game count (played + unplayed).
+	expected := CalculateExpectedGamesPerPlayer(n)
+	for _, p := range players {
+		if totalGP[p] != expected {
+			rep.skipped++
+			return
+		}
+	}
+	rep.divisions++
+
+	// A division has a "timeout-sign" anomaly if any completed game's winner
+	// scored less than the loser (e.g. a leading player who timed out).
+	hasAnomaly := false
+	for _, g := range played {
+		if (g.result == 1 && g.s0 < g.s1) || (g.result == -1 && g.s1 < g.s0) {
+			hasAnomaly = true
+			break
+		}
+	}
+	if hasAnomaly {
+		rep.anomalyDivs++
+	} else {
+		rep.cleanDivs++
+	}
+
+	type acc struct{ wins, draws, spread int }
+	st := make(map[int32]*acc, n)
+	playedCnt := make(map[int32]int, n)
+	for _, p := range players {
+		st[p] = &acc{}
+	}
+
+	prevBest := map[int32]int{}
+	prevWorst := map[int32]int{}
+
+	for k := 0; k <= len(played); k++ {
+		// Standings reflect played[0:k]; remaining = unplayed ∪ played[k:].
+		standings := make([]standingInfo, 0, n)
+		for _, p := range players {
+			a := st[p]
+			standings = append(standings, standingInfo{
+				userID:         p,
+				points:         a.wins*2 + a.draws,
+				spread:         a.spread,
+				gamesRemaining: totalGP[p] - playedCnt[p],
+			})
+		}
+		sort.SliceStable(standings, func(i, j int) bool {
+			if standings[i].points != standings[j].points {
+				return standings[i].points > standings[j].points
+			}
+			if standings[i].spread != standings[j].spread {
+				return standings[i].spread > standings[j].spread
+			}
+			return standings[i].userID < standings[j].userID
+		})
+
+		unf := make([]unfinishedGame, 0, len(unplayed)+len(played)-k)
+		unf = append(unf, unplayed...)
+		for _, g := range played[k:] {
+			unf = append(unf, unfinishedGame{player0ID: g.p0, player1ID: g.p1})
+		}
+		remCount := len(unf)
+
+		bounds := CalculatePossibleRanks(standings, unf)
+		rep.snapshots++
+		inMaxflow := remCount > bruteForceThreshold
+
+		for i := range standings {
+			id := standings[i].userID
+			b := bounds[i]
+			if k > 0 && (b.BestRank < prevBest[id] || b.WorstRank > prevWorst[id]) {
+				rep.monoViol++
+				switch {
+				case remCount > bruteForceThreshold:
+					rep.viaMM++
+				case remCount == bruteForceThreshold:
+					rep.viaMB++
+				default:
+					rep.viaBB++
+				}
+				if hasAnomaly {
+					rep.anomalyViol++
+				} else {
+					rep.cleanViol++
+				}
+				if len(rep.monoSamples) < 50 {
+					clusters := buildBruteForceClusters(standings, toGamePairs(standings, unf))
+					mc := maxClusterGames(clusters)
+					pc := playerClusterGames(clusters, i) // wobbling player's OWN cluster
+					rep.monoSamples = append(rep.monoSamples, fmt.Sprintf(
+						"season=%s div=%s snap=%d/%d player=%d best %d->%d worst %d->%d (pcluster=%d maxcluster=%d rem=%d n=%d gr=%d %s)",
+						season, div, k, len(played), id,
+						prevBest[id], b.BestRank, prevWorst[id], b.WorstRank,
+						pc, mc, remCount, n, standings[i].gamesRemaining,
+						regimeLabel(inMaxflow)))
+				}
+			}
+			prevBest[id] = b.BestRank
+			prevWorst[id] = b.WorstRank
+		}
+
+		// Terminal snapshot of a fully-completed division: bounds must equal the
+		// real final standings. (In-progress divisions still have unplayed games
+		// here, so skip.)
+		if k == len(played) && len(unplayed) == 0 {
+			checkFinalResult(rep, season, div, standings, bounds)
+		}
+
+		// Apply played game k to advance to k+1.
+		if k < len(played) {
+			g := played[k]
+			playedCnt[g.p0]++
+			playedCnt[g.p1]++
+			st[g.p0].spread += g.s0 - g.s1
+			st[g.p1].spread += g.s1 - g.s0
+			switch g.result {
+			case 1:
+				st[g.p0].wins++
+			case -1:
+				st[g.p1].wins++
+			default:
+				st[g.p0].draws++
+				st[g.p1].draws++
+			}
+		}
+	}
+}
+
+// checkFinalResult verifies that, with no games remaining, each player's bounds
+// equal their actual competition rank range: best = 1 + (players strictly
+// above), worst = best + (players tied on exactly points and spread).
+func checkFinalResult(rep *replayReport, season, div string, standings []standingInfo, bounds []RankBounds) {
+	firstPlace := 0
+	for i := range standings {
+		si := standings[i]
+		strictlyAbove, tied := 0, 0
+		for j := range standings {
+			if i == j {
+				continue
+			}
+			sj := standings[j]
+			switch {
+			case sj.points > si.points, sj.points == si.points && sj.spread > si.spread:
+				strictlyAbove++
+			case sj.points == si.points && sj.spread == si.spread:
+				tied++
+			}
+		}
+		if strictlyAbove == 0 {
+			firstPlace++
+		}
+		expBest := 1 + strictlyAbove
+		expWorst := expBest + tied
+		if bounds[i].BestRank != expBest || bounds[i].WorstRank != expWorst {
+			rep.finalMiss++
+			if len(rep.finalSamples) < 50 {
+				rep.finalSamples = append(rep.finalSamples, fmt.Sprintf(
+					"season=%s div=%s player=%d got %d-%d want %d-%d (pts=%d spread=%d)",
+					season, div, si.userID, bounds[i].BestRank, bounds[i].WorstRank,
+					expBest, expWorst, si.points, si.spread))
+			}
+		}
+	}
+	if firstPlace > 1 && len(rep.jointWinner) < 50 {
+		rep.jointWinner = append(rep.jointWinner,
+			fmt.Sprintf("season=%s div=%s: %d-way tie for 1st", season, div, firstPlace))
+	}
+}
+
+func readCSV(t *testing.T, path string) [][]string {
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+// playerClusterGames returns the number of unfinished games in the cluster
+// containing the given standings index, or -1 if the player is in no cluster
+// (rank already fixed).
+func playerClusterGames(clusters []bfCluster, playerIdx int) int {
+	for _, c := range clusters {
+		for _, m := range c.members {
+			if m == playerIdx {
+				return len(c.games)
+			}
+		}
+	}
+	return -1
+}
+
+func regimeLabel(maxflow bool) string {
+	if maxflow {
+		return "maxflow"
+	}
+	return "brute"
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(strings.TrimSpace(s))
+	return n
+}
+
+func atoi32(s string) int32 {
+	return int32(atoi(s))
+}

--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -344,17 +344,16 @@ func worstCandidateCountLocal(p int, standings []standingInfo, gi playerGameInfo
 // the range; the gate, not the budget, is what keeps the search cheap.)
 const bnbBudget = 64
 
-// reachWCut builds the "every candidate gains its deficit of points from non-P
+// reachW builds the "every candidate gains its deficit of points from non-P
 // games" max-flow and reports feasibility. A candidate's deficit is first reduced
 // by 2 per game it plays against a non-candidate (an outright win it can always
 // take); the remainder must come from within-set games, each of which supplies 2
 // points to its two endpoints. The set is feasible iff the flow saturates every
-// game edge. On infeasibility it returns the source-side player nodes of the min
-// cut -- the candidates implicated in the bottleneck.
-func reachWCut(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx []int) (bool, []int) {
+// game edge.
+func reachW(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx []int) bool {
 	k := len(candidates)
 	if k == 0 {
-		return true, nil
+		return true
 	}
 	for ci, c := range candidates {
 		candIdx[c.idx] = ci
@@ -388,7 +387,7 @@ func reachWCut(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx [
 		totalNeeded += adj
 	}
 	if totalNeeded == 0 {
-		return true, nil
+		return true
 	}
 
 	numGameNodes := len(withinGames)
@@ -409,23 +408,7 @@ func reachWCut(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx [
 			fg.addEdge(playerNode(ci), sink, adjustedDeficit[ci])
 		}
 	}
-	if fg.maxflow(source, sink) >= totalNeeded {
-		return true, nil
-	}
-	// Min cut: player nodes still reachable from the source in the residual graph
-	// (level >= 0 after the final BFS) are on the source side of the bottleneck.
-	var cut []int
-	for ci := range k {
-		if fg.level[playerNode(ci)] >= 0 {
-			cut = append(cut, ci)
-		}
-	}
-	if len(cut) == 0 {
-		for ci := range k {
-			cut = append(cut, ci)
-		}
-	}
-	return false, cut
+	return fg.maxflow(source, sink) >= totalNeeded
 }
 
 // minimalInfeasibleAbove shrinks an infeasible subset of candidates (indices into
@@ -441,7 +424,7 @@ func minimalInfeasibleAbove(candidates []cand, idxs []int, nonPGames []gamePair,
 		for j, ci := range trial {
 			sub[j] = candidates[ci]
 		}
-		if feasible, _ := reachWCut(sub, nonPGames, fg, candIdx); !feasible {
+		if !reachW(sub, nonPGames, fg, candIdx) {
 			keep = trial
 		} else {
 			i++
@@ -452,14 +435,13 @@ func minimalInfeasibleAbove(candidates []cand, idxs []int, nonPGames []gamePair,
 
 // minEvictAbove returns the exact minimum number of candidates that must be
 // dropped (finish at/below P) so the rest can all simultaneously reach W. It
-// tests feasibility with reachWCut; if infeasible, it branches on a minimal
+// tests feasibility with reachW; if infeasible, it branches on a minimal
 // infeasible subset, evicting each member in turn and recursing. Branching on a
 // minimal infeasible subset (not the whole set, nor the min cut, which is not a
 // reliable infeasible subset for this flow) is exact and keeps the branch factor
 // small. budget bounds the recursion depth (see bnbBudget).
 func minEvictAbove(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx []int, budget int) int {
-	feasible, _ := reachWCut(candidates, nonPGames, fg, candIdx)
-	if feasible {
+	if reachW(candidates, nonPGames, fg, candIdx) {
 		return 0
 	}
 	if budget <= 0 {

--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -242,34 +242,39 @@ func worstRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *
 		return candidates[i].deficit < candidates[j].deficit
 	})
 
-	// Iteratively check feasibility via max-flow and remove infeasible candidates.
-	for {
-		feasible, infeasibleIdx := checkFeasibility(candidates, gi.nonPGames, fg, candIdx)
-		if feasible {
-			break
-		}
-		if infeasibleIdx >= 0 {
-			candidates = append(candidates[:infeasibleIdx], candidates[infeasibleIdx+1:]...)
-		}
-		if len(candidates) == 0 {
-			break
-		}
-	}
-
-	return 1 + len(candidates)
+	// The worst rank is 1 + (players guaranteed above P) + (minimum candidates
+	// that can be forced above P). The minimum forced-above count is the size of
+	// the candidate set minus the most that can simultaneously stay at/below P;
+	// finding that maximum is a minimum-eviction problem, solved exactly by
+	// branch-and-bound below. (A greedy eviction is faster but sub-optimal, and
+	// its error is not monotone in cluster size, so it can produce a widening
+	// bound. The exact search is kept cheap by the cluster-local-k gate in
+	// CalculatePossibleRanks, which never routes a large candidate set here.)
+	initial := len(candidates)
+	minEvict := minEvictAbove(candidates, gi.nonPGames, fg, candIdx, bnbBudget)
+	return 1 + (initial - minEvict)
 }
 
-// checkFeasibility uses max-flow to determine whether all candidates in the set
-// can simultaneously reach W points from non-P games.
-//
-// Returns (true, -1) if feasible, or (false, idxToRemove) if not.
-func checkFeasibility(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx []int) (bool, int) {
+// bnbBudget caps the branch-and-bound recursion depth (the eviction count). It
+// is a finite-termination backstop only: the cluster-local-k gate already bounds
+// the candidate set so the true minimum eviction never approaches this, so the
+// budget never binds in production. (A depth cap is monotone -- under-counting
+// evictions only loosens the bound -- so even if it did bind it could not widen
+// the range; the gate, not the budget, is what keeps the search cheap.)
+const bnbBudget = 64
+
+// reachWCut builds the "every candidate gains its deficit of points from non-P
+// games" max-flow and reports feasibility. A candidate's deficit is first reduced
+// by 2 per game it plays against a non-candidate (an outright win it can always
+// take); the remainder must come from within-set games, each of which supplies 2
+// points to its two endpoints. The set is feasible iff the flow saturates every
+// game edge. On infeasibility it returns the source-side player nodes of the min
+// cut -- the candidates implicated in the bottleneck.
+func reachWCut(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx []int) (bool, []int) {
 	k := len(candidates)
 	if k == 0 {
-		return true, -1
+		return true, nil
 	}
-
-	// Map candidate player indices → 0..k-1 via candIdx slice.
 	for ci, c := range candidates {
 		candIdx[c.idx] = ci
 	}
@@ -279,13 +284,9 @@ func checkFeasibility(candidates []cand, nonPGames []gamePair, fg *flowGraph, ca
 		}
 	}()
 
-	// Identify within-set games and external games for each candidate.
-	type withinGame struct {
-		ci, cj int // indices into candidates slice
-	}
+	type withinGame struct{ ci, cj int }
 	var withinGames []withinGame
 	externalCnt := make([]int, k)
-
 	for _, g := range nonPGames {
 		ciA, ciB := candIdx[g.a], candIdx[g.b]
 		aIn, bIn := ciA >= 0, ciB >= 0
@@ -298,7 +299,6 @@ func checkFeasibility(candidates []cand, nonPGames []gamePair, fg *flowGraph, ca
 		}
 	}
 
-	// Compute adjusted deficit (what each candidate needs from within-set games).
 	adjustedDeficit := make([]int, k)
 	totalNeeded := 0
 	for ci, c := range candidates {
@@ -306,29 +306,10 @@ func checkFeasibility(candidates []cand, nonPGames []gamePair, fg *flowGraph, ca
 		adjustedDeficit[ci] = adj
 		totalNeeded += adj
 	}
-
 	if totalNeeded == 0 {
-		return true, -1
+		return true, nil
 	}
 
-	// Quick check: total points from within-set games
-	if len(withinGames)*2 < totalNeeded {
-		worst := -1
-		worstDef := -1
-		for ci := range candidates {
-			if adjustedDeficit[ci] > worstDef {
-				worstDef = adjustedDeficit[ci]
-				worst = ci
-			}
-		}
-		return false, worst
-	}
-
-	// Build max-flow network:
-	//   0: source
-	//   1: sink
-	//   2 .. 2+numWithinGames-1: game nodes
-	//   2+numWithinGames .. 2+numWithinGames+k-1: player nodes
 	numGameNodes := len(withinGames)
 	numNodes := 2 + numGameNodes + k
 	source, sink := 0, 1
@@ -342,39 +323,86 @@ func checkFeasibility(candidates []cand, nonPGames []gamePair, fg *flowGraph, ca
 		fg.addEdge(gn, playerNode(wg.ci), 2)
 		fg.addEdge(gn, playerNode(wg.cj), 2)
 	}
-	for ci := 0; ci < k; ci++ {
+	for ci := range k {
 		if adjustedDeficit[ci] > 0 {
 			fg.addEdge(playerNode(ci), sink, adjustedDeficit[ci])
 		}
 	}
-
-	flow := fg.maxflow(source, sink)
-	if flow >= totalNeeded {
-		return true, -1
+	if fg.maxflow(source, sink) >= totalNeeded {
+		return true, nil
 	}
+	// Min cut: player nodes still reachable from the source in the residual graph
+	// (level >= 0 after the final BFS) are on the source side of the bottleneck.
+	var cut []int
+	for ci := range k {
+		if fg.level[playerNode(ci)] >= 0 {
+			cut = append(cut, ci)
+		}
+	}
+	if len(cut) == 0 {
+		for ci := range k {
+			cut = append(cut, ci)
+		}
+	}
+	return false, cut
+}
 
-	// Not feasible. Find the candidate with the largest remaining deficit.
-	playerFlow := make([]int, k)
-	for ci := 0; ci < k; ci++ {
-		pn := playerNode(ci)
-		for _, e := range fg.adj[pn] {
-			if e.to == sink {
-				playerFlow[ci] = adjustedDeficit[ci] - e.cap
+// minimalInfeasibleAbove shrinks an infeasible subset of candidates (indices into
+// candidates) to a minimal one: a subset that is still infeasible but becomes
+// feasible if any single member is removed. The minimum eviction set must contain
+// at least one member of every minimal infeasible subset, so branching on a small
+// one keeps the branch factor low.
+func minimalInfeasibleAbove(candidates []cand, idxs []int, nonPGames []gamePair, fg *flowGraph, candIdx []int) []int {
+	keep := append([]int(nil), idxs...)
+	for i := 0; i < len(keep); {
+		trial := append(append([]int{}, keep[:i]...), keep[i+1:]...)
+		sub := make([]cand, len(trial))
+		for j, ci := range trial {
+			sub[j] = candidates[ci]
+		}
+		if feasible, _ := reachWCut(sub, nonPGames, fg, candIdx); !feasible {
+			keep = trial
+		} else {
+			i++
+		}
+	}
+	return keep
+}
+
+// minEvictAbove returns the exact minimum number of candidates that must be
+// dropped (finish at/below P) so the rest can all simultaneously reach W. It
+// tests feasibility with reachWCut; if infeasible, it branches on a minimal
+// infeasible subset, evicting each member in turn and recursing. Branching on a
+// minimal infeasible subset (not the whole set, nor the min cut, which is not a
+// reliable infeasible subset for this flow) is exact and keeps the branch factor
+// small. budget bounds the recursion depth (see bnbBudget).
+func minEvictAbove(candidates []cand, nonPGames []gamePair, fg *flowGraph, candIdx []int, budget int) int {
+	feasible, _ := reachWCut(candidates, nonPGames, fg, candIdx)
+	if feasible {
+		return 0
+	}
+	if budget <= 0 {
+		return 1
+	}
+	all := make([]int, len(candidates))
+	for i := range all {
+		all[i] = i
+	}
+	branch := minimalInfeasibleAbove(candidates, all, nonPGames, fg, candIdx)
+	best := budget + 1
+	sub := make([]cand, 0, len(candidates)-1)
+	for _, ci := range branch {
+		sub = sub[:0]
+		sub = append(sub, candidates[:ci]...)
+		sub = append(sub, candidates[ci+1:]...)
+		if r := 1 + minEvictAbove(sub, nonPGames, fg, candIdx, best-2); r < best {
+			best = r
+			if best == 1 {
 				break
 			}
 		}
 	}
-
-	worst := -1
-	worstGap := -1
-	for ci := range candidates {
-		gap := adjustedDeficit[ci] - playerFlow[ci]
-		if gap > worstGap {
-			worstGap = gap
-			worst = ci
-		}
-	}
-	return false, worst
+	return best
 }
 
 type cand struct {

--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -63,51 +63,118 @@ func CalculatePossibleRanks(
 		return bruteForceRanksFromClusters(clusters, standings, games)
 	}
 
-	// Precompute for per-player fast path: players with remaining games
-	// whose point range clearly spans [1, n] can skip max-flow.
-	maxFloor := 0 // highest current points (worst case for leader)
-	// Two smallest ceilings so we can get min-excluding-P in O(1).
-	minCeil1, minCeil2 := math.MaxInt, math.MaxInt
-	for _, s := range standings {
-		if s.points > maxFloor {
-			maxFloor = s.points
-		}
-		ceil := s.points + s.gamesRemaining*2
-		if ceil <= minCeil1 {
-			minCeil2 = minCeil1
-			minCeil1 = ceil
-		} else if ceil < minCeil2 {
-			minCeil2 = ceil
+	// Otherwise dispatch each cluster by its size. A cluster only ever shrinks as
+	// games complete (components split, point ranges tighten), so it crosses each
+	// threshold below at most once and only in the tightening direction -- which
+	// is what makes the displayed range provably monotone (never widens).
+	//
+	//   unfinished games <= bruteForceThreshold: enumerate every outcome (exact,
+	//     tightest). Per cluster, so a small cluster beside a large one still gets
+	//     exact bounds.
+	//   else, cluster-local candidate count k <= localCandidateGate: the exact
+	//     max-flow branch-and-bound (worst rank directly, best rank via the
+	//     loss-score inversion). k bounds the B&B cost, and the flow runs on the
+	//     cluster's own games only -- other clusters are rank-disjoint and add no
+	//     flow, so this equals a division-wide flow on a smaller graph.
+	//   else (large, dense cluster): the pairing-agnostic frontend bound. Loose,
+	//     but sound and monotone, and always at least as loose as the B&B bound,
+	//     so the loose->tight flip as the cluster shrinks past the gate only ever
+	//     tightens the range.
+	crossAbove := make([]int, len(clusters))
+	for i := range clusters {
+		for j := range clusters {
+			if i != j && clusters[j].minPts > clusters[i].maxPts {
+				crossAbove[i] += len(clusters[j].members)
+			}
 		}
 	}
 
-	// Reusable state: flow graph (adj slices grow and stabilize) and
-	// candIdx (avoids map allocation in inner loops).
+	// Reusable state for the (sequential) max-flow tier: flow graph (adj slices
+	// grow and stabilize) and candIdx (avoids map allocation in inner loops).
 	fg := newFlowGraph(2 + len(games) + n)
 	candIdx := initSlice(n, -1)
 	mir := mirrorForBest(standings) // best rank = worst rank on this mirror
-
 	results := make([]RankBounds, n)
-	for p := 0; p < n; p++ {
-		if standings[p].gamesRemaining > 0 {
-			bestPts := standings[p].points + standings[p].gamesRemaining*2
-			pCeil := bestPts
-			minCeilExP := minCeil1
-			if pCeil == minCeil1 {
-				minCeilExP = minCeil2
-			}
-			if bestPts >= maxFloor && minCeilExP >= standings[p].points {
-				results[p] = RankBounds{1, n}
-				continue
-			}
+	inCluster := make([]bool, n)
+	var wg sync.WaitGroup
+	for ci := range clusters {
+		c := &clusters[ci]
+		if len(c.games) <= bruteForceThreshold {
+			// Brute clusters are independent (disjoint members), so enumerate
+			// them in parallel; the max-flow tier below stays on this goroutine.
+			wg.Add(1)
+			go func(ci int) {
+				defer wg.Done()
+				enumerateBruteForceCluster(&clusters[ci], standings, games, results, crossAbove[ci])
+			}(ci)
+			continue
 		}
-		gi := decomposeGames(p, n, games)
-		results[p] = RankBounds{
-			BestRank:  bestViaInversion(p, mir, gi, fg, candIdx),
-			WorstRank: worstRankForPlayer(p, standings, gi, fg, candIdx),
+
+		clusterGames := make([]gamePair, len(c.games))
+		for j, gidx := range c.games {
+			clusterGames[j] = games[gidx]
+		}
+		for i := range inCluster {
+			inCluster[i] = false
+		}
+		for _, m := range c.members {
+			inCluster[m] = true
+		}
+		for _, m := range c.members {
+			gi := decomposeGames(m, n, clusterGames)
+			kReal := worstCandidateCountLocal(m, standings, gi, inCluster)
+			kMirror := worstCandidateCountLocal(m, mir, gi, inCluster)
+			if max(kReal, kMirror) <= localCandidateGate {
+				results[m] = RankBounds{
+					BestRank:  bestViaInversion(m, mir, gi, fg, candIdx),
+					WorstRank: worstRankForPlayer(m, standings, gi, fg, candIdx),
+				}
+			} else {
+				results[m] = frontendBound(m, standings)
+			}
 		}
 	}
+	wg.Wait()
 	return results
+}
+
+// localCandidateGate is the largest cluster-local candidate count for which the
+// exact max-flow branch-and-bound runs; above it a cluster's members fall back
+// to the frontend bound. It is a performance budget, not a correctness constant:
+// the threshold is chosen so the worst single division-snapshot stays about as
+// fast as the brute-force worst case (machine-independent via the ratio of
+// B&B-worst to brute-worst). Lowering it only loosens results -- still sound and
+// monotone -- never produces a wrong bound. Empirically, k <= 13 keeps the worst
+// snapshot brute-bound; k = 14 hits a single-player B&B blow-up.
+const localCandidateGate = 13
+
+// frontendBound is the pairing-agnostic possible-rank range for player p: for
+// the best rank P wins all its games (others hold their points), for the worst
+// rank P loses all (others win all). It ignores who plays whom, so it is loose,
+// but it is sound (best <= achievable best, worst >= achievable worst) and
+// monotone -- the above/below counts only grow as games complete (a counted
+// player's points pass P's ceiling, or its ceiling drops below P's points, and
+// neither reverts). It is also always at least as loose as the max-flow bound,
+// so swapping a member to the max-flow tier as its cluster shrinks past the gate
+// can only tighten, never widen. It is exactly the bound the web frontend can
+// compute itself from points and games-remaining, hence the name.
+func frontendBound(p int, standings []standingInfo) RankBounds {
+	n := len(standings)
+	pMax := standings[p].points + standings[p].gamesRemaining*2 // P wins all
+	pMin := standings[p].points                                 // P loses all
+	above, below := 0, 0
+	for i := range standings {
+		if i == p {
+			continue
+		}
+		if standings[i].points > pMax {
+			above++ // above P even if P wins out and this player stalls
+		}
+		if standings[i].points+standings[i].gamesRemaining*2 < pMin {
+			below++ // below P even if this player wins out and P stalls
+		}
+	}
+	return RankBounds{BestRank: 1 + above, WorstRank: n - below}
 }
 
 // standingInfo is the subset of standing data needed for rank calculation.
@@ -170,66 +237,58 @@ func decomposeGames(p int, n int, allGames []gamePair) playerGameInfo {
 // worst rank: maximize the number of players finishing above P
 // ---------------------------------------------------------------------------
 
+// worstCandidateDeficit classifies opponent i for P's worst rank: the points i
+// still needs from non-P games to finish at or above P, and whether it can reach
+// that at all (a candidate). P is assumed to lose all its remaining games, so
+// each opponent of P gains +2 per game vs P.
+//
+// When i would tie P on points, spread decides. How i can accumulate points
+// matters: a win gives 2 points and improves spread (potentially a lot), a draw
+// gives 1 point with no spread change. An odd deficit forces at least one draw,
+// but with deficit >= 2 (or more than one game) i can include wins for arbitrary
+// spread; the only forced-pure-draw case is deficit 1 with exactly 1 game.
+func worstCandidateDeficit(p, i int, standings []standingInfo, gi playerGameInfo) (deficit int, isCandidate bool) {
+	tieDeficit := standings[p].points - (standings[i].points + gi.gamesVsP[i]*2)
+	switch {
+	case standings[p].gamesRemaining > 0:
+		// P has -inf worst spread, so any opponent at P's points is above P.
+		deficit = max(0, tieDeficit)
+	case gi.nonPGamesCnt[i] == 0:
+		// i has no remaining games; its spread is fixed. Equal spread means
+		// either order (arbitrary tiebreak), so a tie still makes i a candidate.
+		if standings[i].spread >= standings[p].spread {
+			deficit = max(0, tieDeficit)
+		} else {
+			deficit = max(0, tieDeficit+1) // worse spread: needs strict points lead
+		}
+	case standings[i].spread >= standings[p].spread:
+		// Spread >= P's: draws preserve it, wins improve it. A tie suffices.
+		deficit = max(0, tieDeficit)
+	case tieDeficit == 1 && gi.nonPGamesCnt[i] == 1:
+		// Exactly 1 game, needs 1 point -> must draw (no spread change); with
+		// spread < P's it cannot win the tiebreak, so it must exceed P on points.
+		deficit = max(0, tieDeficit+1)
+	default:
+		// Spread < P's but deficit >= 2 or multiple games: i can include wins for
+		// arbitrary spread improvement, so a tie on points suffices.
+		deficit = max(0, tieDeficit)
+	}
+	return deficit, deficit <= gi.nonPGamesCnt[i]*2
+}
+
 func worstRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *flowGraph, candIdx []int) int {
 	n := len(standings)
-	W := standings[p].points // P loses all remaining → keeps current points
 
-	// After P loses all, each opponent of P gets +2 per game vs P.
-	effectivePts := make([]int, n)
-	for i := range standings {
-		effectivePts[i] = standings[i].points + gi.gamesVsP[i]*2
-	}
-
-	// Build candidate list: players that can individually surpass P.
-	//
-	// When Q ties P on points, spread decides. Whether Q can beat P on
-	// spread depends on how Q accumulates points:
-	//   - A win gives Q 2 points AND improves spread (potentially a lot).
-	//   - A draw gives Q 1 point with 0 spread change.
-	//
-	// An odd deficit requires at least one draw. But as long as the deficit
-	// is ≥ 3, Q can include wins alongside the draw(s), giving Q arbitrary
-	// spread improvement. The only case where Q is forced into a pure draw
-	// (no spread change) is deficit = 1 with exactly 1 remaining game.
-	pHasGames := standings[p].gamesRemaining > 0
+	// Candidates: opponents that can individually finish at or above P (so could
+	// be forced above P). The per-opponent classification lives in
+	// worstCandidateDeficit, shared with the gate's cluster-local count so the
+	// two never drift.
 	var candidates []cand
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i == p {
 			continue
 		}
-
-		tieDeficit := W - effectivePts[i] // points needed to match P
-		deficit := 0
-
-		if pHasGames {
-			// P has −∞ worst spread → any Q at W points is above P
-			deficit = max(0, tieDeficit)
-		} else if gi.nonPGamesCnt[i] == 0 {
-			// Q has no remaining games. Spread is fixed.
-			// Equal spread: Q could be ranked either side of P (username
-			// tiebreak is arbitrary), so Q is a valid candidate.
-			if standings[i].spread >= standings[p].spread {
-				deficit = max(0, tieDeficit) // tie suffices
-			} else {
-				deficit = max(0, tieDeficit+1) // need strict points advantage
-			}
-		} else if standings[i].spread >= standings[p].spread {
-			// Q has remaining games and spread ≥ P's. Draws preserve it,
-			// wins improve it. Tie on points suffices.
-			deficit = max(0, tieDeficit)
-		} else if tieDeficit == 1 && gi.nonPGamesCnt[i] == 1 {
-			// Q has exactly 1 remaining game and needs 1 point → must draw.
-			// Draw doesn't change spread. Q.spread < P.spread → can't beat
-			// P on spread. Must exceed P on points.
-			deficit = max(0, tieDeficit+1)
-		} else {
-			// Q has remaining games and spread < P's, but with deficit ≥ 2
-			// or multiple games, Q can include wins that give arbitrary
-			// spread improvement. Tie on points suffices.
-			deficit = max(0, tieDeficit)
-		}
-
-		if deficit <= gi.nonPGamesCnt[i]*2 {
+		if deficit, ok := worstCandidateDeficit(p, i, standings, gi); ok {
 			candidates = append(candidates, cand{i, deficit})
 		}
 	}
@@ -254,6 +313,27 @@ func worstRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *
 	initial := len(candidates)
 	minEvict := minEvictAbove(candidates, gi.nonPGames, fg, candIdx, bnbBudget)
 	return 1 + (initial - minEvict)
+}
+
+// worstCandidateCountLocal counts P's worst-rank candidates restricted to P's
+// own cluster (the inCluster mask). It is the branch-and-bound gate metric: the
+// candidate set drives the eviction search, so its size governs B&B cost.
+// Cross-cluster players are rank-disjoint -- they enter worstRankForPlayer's set
+// as trivial deficit-0 candidates that are never evicted and add ~no cost -- so
+// counting only in-cluster candidates gates on the true cost driver. Applied to
+// the real standings it bounds worst-rank cost; applied to the loss-score mirror
+// it bounds best-rank (inversion) cost, so one metric covers both directions.
+func worstCandidateCountLocal(p int, standings []standingInfo, gi playerGameInfo, inCluster []bool) int {
+	k := 0
+	for i := range standings {
+		if i == p || !inCluster[i] {
+			continue
+		}
+		if _, ok := worstCandidateDeficit(p, i, standings, gi); ok {
+			k++
+		}
+	}
+	return k
 }
 
 // bnbBudget caps the branch-and-bound recursion depth (the eviction count). It

--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -85,6 +85,7 @@ func CalculatePossibleRanks(
 	// candIdx (avoids map allocation in inner loops).
 	fg := newFlowGraph(2 + len(games) + n)
 	candIdx := initSlice(n, -1)
+	mir := mirrorForBest(standings) // best rank = worst rank on this mirror
 
 	results := make([]RankBounds, n)
 	for p := 0; p < n; p++ {
@@ -102,7 +103,7 @@ func CalculatePossibleRanks(
 		}
 		gi := decomposeGames(p, n, games)
 		results[p] = RankBounds{
-			BestRank:  bestRankForPlayer(p, standings, gi, fg, candIdx),
+			BestRank:  bestViaInversion(p, mir, gi, fg, candIdx),
 			WorstRank: worstRankForPlayer(p, standings, gi, fg, candIdx),
 		}
 	}
@@ -410,321 +411,52 @@ type cand struct {
 	deficit int // points still needed from non-P games
 }
 
-type stayBelow struct {
-	idx        int
-	absorb     int // max additional points Q can receive without exceeding B
-	maxPerGame int // max points from a single game (1 = draws only, 2 = any outcome)
-}
-
 // ---------------------------------------------------------------------------
-// best rank: minimize the number of players forced above P
+// best rank via loss-score inversion
 //
-// Only reached when len(games) > bruteForceThreshold. For smaller divisions
-// CalculatePossibleRanks dispatches to bruteForceRanks, which enumerates
-// outcomes and returns tight bounds covering every spread interaction.
+// Best-rank is the mirror of worst-rank. Computing it directly would need its
+// own candidate set (players who could be forced BELOW P), whose count keys off
+// P's point ceiling pts+2*remaining -- which FALLS as P's games resolve, so the
+// count can rise. A rising candidate count is non-monotone: a gate on it could
+// flip tight->loose and widen the range. So instead we invert. With loss-score
+// 2L+D we have points = 2W+D = 2G-(2L+D) exactly (G = W+D+L, constant per player
+// at season end, draws included), so ranking by points descending is identical
+// to ranking by loss-score ascending. Hence
 //
-// Algorithm:
-//   1. Compute B = P's maximum possible score (P wins all remaining games).
-//   2. Classify each non-P player as guaranteedAbove, guaranteedBelow, or
-//      an open candidate.
-//   3. Precompute externalCnt[i] = open candidate Q's non-P games vs a
-//      guaranteedBelow opponent.
-//   4. Build belowCandidates with per-player absorb caps and per-game caps,
-//      tightened for spread (see below).
-//   5. Use max-flow to check if all belowCandidates can simultaneously absorb
-//      their within-set game points without exceeding B.
+//	bestRank(P) = n + 1 - worstRank(P on the loss-score mirror)
 //
-// Flow network:
-//
-//   Source ──2──> [game] ──cap──> [player] ──absorb──> Sink
-//
-//   - Each game node receives 2 points from the source.
-//   - Game-to-player edge capacity = maxPerGame (1 or 2, see below).
-//   - Player-to-sink edge capacity = absorb limit.
-//   - Feasible iff max_flow == total within-set game points.
-//
-// Spread treatment when Q can reach B:
-//
-//   Q.spread < P.spread, draws-only path (maxPerGame=1):
-//     Q reaches B via draws (1 pt each, 0 spread change), preserving
-//     Q.spread < P.spread so Q sits below P on tiebreak.
-//
-//   Q.spread >= P.spread, externalCnt[Q] >= 1:
-//     Q plays at least one guaranteedBelow opponent. Routing that game as
-//     Q's loss (opponent takes both pts, still capped below B) lets Q
-//     concede an arbitrary margin, dropping Q.finalSpread below P.spread
-//     even when Q hits B via wins elsewhere. Full absorb=maxBelow.
-//
-//   Q.spread >= P.spread, no external:
-//     Q at B ties P on points and beats P on spread (wins raise it, draws
-//     preserve it). Decrement maxBelow so Q stays strictly below B on points.
-//     This can still be pessimistic when Q's within-set opponents have
-//     maxPerGame=2 (Q could realize 1W+1L with a huge loss margin, reaching
-//     B at a dropped spread). For division sizes where this matters the
-//     brute-force path handles the case; the heuristic leaves it loose.
-//
-// Guarantees:
-//   - bestRank is achievable (flow outcomes map to real game outcomes, with
-//     realizable margins for the external-loss case).
-//   - bestRank-1 can be wrongly reported as impossible in the pessimistic
-//     case above (Q.spread >= P's, no external, opponents maxPerGame=2).
-//     Brute force covers small divisions; large divisions where this triggers
-//     are very rare in practice.
-//   - worstRank+1 is always impossible (sound upper bound).
-//   - worstRank can be pessimistic when the candidate set is a closed
-//     round-robin whose initial spread sum is too small for every member to
-//     strictly beat P on tiebreak. Brute force covers small divisions.
+// reusing the single monotone worst-rank routine. On the mirror, best-rank keys
+// off P's loss FLOOR, which rises over the season -- so its candidate count is
+// monotone, and one gate metric covers both directions. (See
+// rank_bounds_design.md for the full rationale.)
 // ---------------------------------------------------------------------------
 
-func bestRankForPlayer(p int, standings []standingInfo, gi playerGameInfo, fg *flowGraph, candIdx []int) int {
+// mirrorForBest returns the loss-score mirror of a full division: each player's
+// points become its loss-score 2L+D and its spread is negated, so worst-rank on
+// the mirror equals best-rank on the original. Requires a full division
+// (constant total games per player) so expected = CalculateExpectedGamesPerPlayer
+// is each player's total games; then played = expected - remaining and
+// 2L+D = 2*expected - points - 2*remaining.
+func mirrorForBest(standings []standingInfo) []standingInfo {
 	n := len(standings)
-	B := standings[p].points + standings[p].gamesRemaining*2 // P wins all remaining
-
-	// When P wins all, P's opponents each LOSE their game vs P (get 0 from it).
-	// Q's effective points = Q.currentPoints (unchanged; the loss to P adds 0).
-	// Q can absorb at most B - Q.currentPoints points at or below B.
-
-	pHasGames := standings[p].gamesRemaining > 0
-
-	// First pass: classify each non-P player as guaranteedAbove, guaranteedBelow,
-	// or an open candidate. Stored as bool slices so externalCnt can reference them.
-	isGuaranteedAbove := make([]bool, n)
-	isGuaranteedBelow := make([]bool, n)
-	guaranteedAbove := 0
-	guaranteedBelow := 0
-	for i := 0; i < n; i++ {
-		if i == p {
-			continue
-		}
-		qWorst := standings[i].points
-		if qWorst > B {
-			isGuaranteedAbove[i] = true
-			guaranteedAbove++
-			continue
-		}
-		if qWorst == B && !pHasGames && gi.nonPGamesCnt[i] == 0 &&
-			standings[i].spread > standings[p].spread {
-			isGuaranteedAbove[i] = true
-			guaranteedAbove++
-			continue
-		}
-
-		// Q's ceiling when P wins all: games vs P yield 0, non-P games up to 2.
-		maxPts := standings[i].points + gi.nonPGamesCnt[i]*2
-		if maxPts < B {
-			isGuaranteedBelow[i] = true
-			guaranteedBelow++
-			continue // Q cannot reach B on points
-		}
-		if maxPts == B {
-			if pHasGames {
-				// P's best spread is unbounded (wins by huge margins).
-				// Q at B loses the spread tiebreak to P.
-				isGuaranteedBelow[i] = true
-				guaranteedBelow++
-				continue
-			}
-			if gi.nonPGamesCnt[i] == 0 && standings[i].spread < standings[p].spread {
-				// Q finished at B with worse spread. Loses tiebreak to P.
-				isGuaranteedBelow[i] = true
-				guaranteedBelow++
-				continue
-			}
+	expected := CalculateExpectedGamesPerPlayer(n)
+	m := make([]standingInfo, n)
+	for i, s := range standings {
+		m[i] = standingInfo{
+			userID:         s.userID,
+			points:         2*expected - s.points - 2*s.gamesRemaining,
+			spread:         -s.spread,
+			gamesRemaining: s.gamesRemaining,
 		}
 	}
-
-	// externalCnt[i] = non-P games Q plays against a guaranteedBelow opponent.
-	// These opponents cannot reach B, so we route all 2 game pts to them
-	// (Q loses the game → +0 pts, arbitrary loss margin). A Q with spread
-	// >= P's can still end at B below P on spread by taking this external
-	// loss with a huge margin.
-	externalCnt := make([]int, n)
-	for _, g := range gi.nonPGames {
-		if isGuaranteedBelow[g.a] && !isGuaranteedBelow[g.b] {
-			externalCnt[g.b]++
-		} else if isGuaranteedBelow[g.b] && !isGuaranteedBelow[g.a] {
-			externalCnt[g.a]++
-		}
-	}
-
-	// Build the "stay below P" set with per-player constraints:
-	//
-	//   Q.spread < P.spread, can reach B via draws (maxBelow ≤ games):
-	//     maxPerGame=1 (draws preserve spread → Q below P at B)
-	//
-	//   Q.spread >= P.spread, externalCnt[i] >= 1:
-	//     full maxBelow (external loss drops spread arbitrarily → Q at B below P)
-	//
-	//   Q.spread >= P.spread, no external:
-	//     maxBelow-- (Q must stay strictly below B; a win lifts spread and
-	//     draws-only preserves it above P)
-	//
-	//   P has games (unbounded best spread):
-	//     no restriction (P always beats Q on spread at equal points)
-	//
-	//   both finished (no games):
-	//     fixed spread comparison, maxBelow-- if Q.spread >= P.spread
-	var belowCandidates []stayBelow
-	for i := 0; i < n; i++ {
-		if i == p || isGuaranteedAbove[i] || isGuaranteedBelow[i] {
-			continue
-		}
-
-		// Determine whether Q at exactly B points could be above P.
-		// If so, Q must stay strictly below B (maxBelow--) or use
-		// draws only (maxPerGame=1) to guarantee being below P.
-		maxBelow := B - standings[i].points
-		maxPerGame := 2
-
-		if pHasGames {
-			// P has unbounded best spread (wins by huge margins) → Q can
-			// never beat P on spread at equal points. No restriction needed.
-		} else if gi.nonPGamesCnt[i] == 0 {
-			// Both finished. Spread is fixed. Equal spread: Q could be
-			// ranked either side of P, so treat as potentially above.
-			if standings[i].spread >= standings[p].spread && maxBelow > 0 {
-				maxBelow--
-			}
-		} else if standings[i].spread < standings[p].spread &&
-			maxBelow <= gi.nonPGamesCnt[i] {
-			// Q has remaining games but worse spread than P. Q can reach B
-			// via draws only (each draw gives 1 point, preserves spread).
-			// Restrict per-game capacity to 1 so the flow only allows draws.
-			maxPerGame = 1
-		} else if externalCnt[i] >= 1 {
-			// Q has at least one game vs a guaranteedBelow opponent. We route
-			// that game as a Q-loss (opponent takes both pts, still capped
-			// below B). A sufficiently large loss margin drops Q's spread
-			// below P's even when Q reaches B via wins on other games. No
-			// decrement needed; Q can stay at B below P.
-		} else {
-			// Q at B could beat P on spread (spread >= P's, no external loss
-			// to absorb margin). Stay strictly below B.
-			if maxBelow > 0 {
-				maxBelow--
-			}
-		}
-
-		if maxBelow < 0 {
-			continue // Q is at B and beats P on spread → guaranteed above
-		}
-
-		absorb := maxBelow
-		if absorb >= gi.nonPGamesCnt[i]*2 {
-			absorb = gi.nonPGamesCnt[i] * 2
-		}
-		belowCandidates = append(belowCandidates, stayBelow{i, absorb, maxPerGame})
-	}
-
-	// Sort by absorb capacity ascending (tightest constraint first).
-	sort.Slice(belowCandidates, func(i, j int) bool {
-		return belowCandidates[i].absorb < belowCandidates[j].absorb
-	})
-
-	// Iteratively check if all belowCandidates can stay below P via max-flow.
-	for {
-		feasible, removeIdx := checkBestFeasibility(belowCandidates, gi.nonPGames, fg, candIdx)
-		if feasible {
-			break
-		}
-		if removeIdx >= 0 {
-			belowCandidates = append(belowCandidates[:removeIdx], belowCandidates[removeIdx+1:]...)
-		}
-		if len(belowCandidates) == 0 {
-			break
-		}
-	}
-
-	minForcedAbove := guaranteedAbove + ((n - 1 - guaranteedAbove - guaranteedBelow) - len(belowCandidates))
-	return max(1, 1+minForcedAbove)
+	return m
 }
 
-// checkBestFeasibility checks whether all players in the set can absorb the
-// points from within-set games without anyone exceeding their absorb limit.
-//
-// Uses max-flow: source → game nodes → player nodes → sink.
-// Each game produces 2 points. Each player can absorb at most their limit.
-// Feasible if max_flow = total within-set game points.
-func checkBestFeasibility(candidates []stayBelow, nonPGames []gamePair, fg *flowGraph, candIdx []int) (bool, int) {
-	k := len(candidates)
-	if k == 0 {
-		return true, -1
-	}
-
-	for ci, c := range candidates {
-		candIdx[c.idx] = ci
-	}
-	defer func() {
-		for _, c := range candidates {
-			candIdx[c.idx] = -1
-		}
-	}()
-
-	// Find within-set games
-	type withinGame struct{ ci, cj int }
-	var withinGames []withinGame
-	for _, g := range nonPGames {
-		ciA, ciB := candIdx[g.a], candIdx[g.b]
-		if ciA >= 0 && ciB >= 0 {
-			withinGames = append(withinGames, withinGame{ciA, ciB})
-		}
-	}
-
-	totalGamePoints := len(withinGames) * 2
-	if totalGamePoints == 0 {
-		return true, -1
-	}
-
-	// Quick check: if total absorb capacity can't cover all game points,
-	// definitely infeasible — skip building the flow graph.
-	totalAbsorb := 0
-	for _, c := range candidates {
-		totalAbsorb += c.absorb
-	}
-	if totalAbsorb < totalGamePoints {
-		worst := -1
-		worstAbsorb := math.MaxInt
-		for ci := range candidates {
-			if candidates[ci].absorb < worstAbsorb {
-				worstAbsorb = candidates[ci].absorb
-				worst = ci
-			}
-		}
-		return false, worst
-	}
-
-	numGameNodes := len(withinGames)
-	numNodes := 2 + numGameNodes + k
-	source, sink := 0, 1
-	playerNode := func(ci int) int { return 2 + numGameNodes + ci }
-	gameNode := func(gi int) int { return 2 + gi }
-
-	fg.reset(numNodes)
-	for gi, wg := range withinGames {
-		gn := gameNode(gi)
-		fg.addEdge(source, gn, 2)
-		fg.addEdge(gn, playerNode(wg.ci), candidates[wg.ci].maxPerGame)
-		fg.addEdge(gn, playerNode(wg.cj), candidates[wg.cj].maxPerGame)
-	}
-	for ci := 0; ci < k; ci++ {
-		fg.addEdge(playerNode(ci), sink, candidates[ci].absorb)
-	}
-
-	flow := fg.maxflow(source, sink)
-	if flow >= totalGamePoints {
-		return true, -1
-	}
-
-	// Not feasible. Remove the player with the smallest absorb capacity.
-	worst := -1
-	worstAbsorb := math.MaxInt
-	for ci := range candidates {
-		if candidates[ci].absorb < worstAbsorb {
-			worstAbsorb = candidates[ci].absorb
-			worst = ci
-		}
-	}
-	return false, worst
+// bestViaInversion computes P's best rank as n+1 minus P's worst rank on the
+// loss-score mirror. mir must be mirrorForBest(standings); gi is index-based, so
+// it is valid unchanged on the mirror (the unfinished games are the same).
+func bestViaInversion(p int, mir []standingInfo, gi playerGameInfo, fg *flowGraph, candIdx []int) int {
+	return len(mir) + 1 - worstRankForPlayer(p, mir, gi, fg, candIdx)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -930,6 +930,12 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 	winsCnt := make([]int, m)
 	lossCnt := make([]int, m)
 	coupledVal := make([]bool, maxPts+2*g+1)
+	// order + valOffset implement a per-leaf counting sort of members by points,
+	// so strictly-above and tied-on-points are read off contiguous groups in
+	// O(m + pointsRange) rather than rescanned per player in O(m^2). Sized by the
+	// points range and cluster size, never by a fixed division size.
+	order := make([]int, m)
+	valOffset := make([]int, maxPts+2*g+1)
 
 	total := 1
 	for i := 0; i < g; i++ {
@@ -944,11 +950,8 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 		}
 		x := k
 		for localGi := 0; localGi < g; localGi++ {
-			gm := allGames[c.games[localGi]]
-			// Both endpoints are guaranteed cluster members because games are
-			// assigned to clusters by the union-find root.
-			a := memberIdx[gm.a]
-			b := memberIdx[gm.b]
+			// localGames already holds both endpoints' local member indices.
+			a, b := localGames[localGi][0], localGames[localGi][1]
 			bit := uint64(1) << localGi
 			switch x % 3 {
 			case 0:
@@ -981,47 +984,75 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 			}
 		}
 
-		for p := range m {
-			strictAbove := 0
-			tied = tied[:0]
-			for q := range m {
-				if q == p {
-					continue
-				}
-				switch {
-				case points[q] > points[p]:
-					strictAbove++
-				case points[q] == points[p]:
-					tied = append(tied, q)
-				}
+		// Counting sort members by points into `order` (ascending), so each
+		// points value is a contiguous group. Then strictly-above is the suffix
+		// past the group and the group itself is the tied-on-points set -- read
+		// off in O(m + pointsRange) instead of an O(m^2) per-player rescan.
+		clear(valOffset)
+		for i := range m {
+			valOffset[points[i]]++
+		}
+		acc := 0
+		for v := range valOffset {
+			cnt := valOffset[v]
+			valOffset[v] = acc
+			acc += cnt
+		}
+		for i := range m {
+			v := points[i]
+			order[valOffset[v]] = i
+			valOffset[v]++
+		}
+
+		for lo := 0; lo < m; {
+			v := points[order[lo]]
+			hi := lo + 1
+			for hi < m && points[order[hi]] == v {
+				hi++
 			}
-			var minAbove, maxGE int
-			if standings[c.members[p]].gamesRemaining > 0 {
-				// Free P: per-pair is exact in aggregate (the lose-all and
-				// win-all leaves give P's true rank extremes). Fast path.
-				for _, q := range tied {
-					forced, possible := spreadOrdering(
-						winMask[p], loseMask[p], winMask[q], loseMask[q],
-						baseSpread[p], baseSpread[q],
-					)
-					if forced {
-						minAbove++
+			strictAbove := m - hi // members past this group have strictly higher points
+			coupled := coupledVal[v]
+			for gi := lo; gi < hi; gi++ {
+				p := order[gi]
+				var minAbove, maxGE int
+				if standings[c.members[p]].gamesRemaining > 0 {
+					// Free P: per-pair is exact in aggregate (the lose-all and
+					// win-all leaves give P's true rank extremes). Fast path.
+					for ti := lo; ti < hi; ti++ {
+						if ti == gi {
+							continue
+						}
+						q := order[ti]
+						forced, possible := spreadOrdering(
+							winMask[p], loseMask[p], winMask[q], loseMask[q],
+							baseSpread[p], baseSpread[q],
+						)
+						if forced {
+							minAbove++
+						}
+						if possible {
+							maxGE++
+						}
 					}
-					if possible {
-						maxGE++
+				} else if coupled {
+					// Fixed P tied with a coupled set: the per-pair view over-counts,
+					// so use the joint closed-form. tied = this group minus P.
+					tied = tied[:0]
+					for ti := lo; ti < hi; ti++ {
+						if ti != gi {
+							tied = append(tied, order[ti])
+						}
 					}
-				}
-			} else {
-				// Fixed P: the per-pair view over-counts coupled tied players.
-				// If no two of P's tied opponents are coupled (no decided game
-				// this leaf between two players both at P's points), each is
-				// independent and a per-member reachable-spread box is exact;
-				// only genuine coupling needs the joint closed-form.
-				if coupledVal[points[p]] {
 					minAbove, maxGE = jointFixedTied(p, tied, winMask, baseSpread, localGames, js)
 				} else {
+					// Fixed P, no coupling: each tied opponent's reachable-spread
+					// box is independent and exact.
 					sprP := baseSpread[p]
-					for _, q := range tied {
+					for ti := lo; ti < hi; ti++ {
+						if ti == gi {
+							continue
+						}
+						q := order[ti]
 						hiq := baseSpread[q] - lossCnt[q] // max spread: no win -> lose minimally
 						if winsCnt[q] > 0 {
 							hiq = 1 << 30 // a win runs spread to +inf
@@ -1038,15 +1069,16 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 						}
 					}
 				}
+				bestRank := 1 + fixedAbove + strictAbove + minAbove
+				worstRank := 1 + fixedAbove + strictAbove + maxGE
+				if bestRank < best[p] {
+					best[p] = bestRank
+				}
+				if worstRank > worst[p] {
+					worst[p] = worstRank
+				}
 			}
-			bestRank := 1 + fixedAbove + strictAbove + minAbove
-			worstRank := 1 + fixedAbove + strictAbove + maxGE
-			if bestRank < best[p] {
-				best[p] = bestRank
-			}
-			if worstRank > worst[p] {
-				worst[p] = worstRank
-			}
+			lo = hi
 		}
 	}
 
@@ -1055,9 +1087,10 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 	}
 }
 
-// spreadInf is a sentinel for an unbounded (+/-inf) reachable spread. It is far
-// larger than any real spread sum (a cluster has <= ~26 players), so finite
-// values never reach it and sums of a handful of sentinels do not overflow.
+// spreadInf is a sentinel for an unbounded (+/-inf) reachable spread. At 1<<50
+// it dwarfs any real spread sum yet leaves int64 headroom for summing one per
+// cluster member (a sum stays safe up to thousands of members, far beyond any
+// division), so finite values never reach it and the sums never overflow.
 const spreadInf = int64(1) << 50
 
 // spreadOrdering decides, for one brute leaf, whether a points-tied opponent Q

--- a/pkg/league/rank_bounds.go
+++ b/pkg/league/rank_bounds.go
@@ -2,6 +2,8 @@ package league
 
 import (
 	"math"
+	"math/bits"
+	"slices"
 	"sort"
 	"sync"
 
@@ -1068,6 +1070,27 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 	winMask := make([]uint64, m)
 	loseMask := make([]uint64, m)
 
+	// baseSpread is constant across leaves; tied is reset per player.
+	// localGames holds each cluster game's two members in local indices.
+	baseSpread := make([]int, m)
+	maxPts := 0
+	for i := range m {
+		baseSpread[i] = standings[c.members[i]].spread
+		if pts := standings[c.members[i]].points; pts > maxPts {
+			maxPts = pts
+		}
+	}
+	tied := make([]int, 0, m)
+	localGames := make([][2]int, g)
+	for gi := range g {
+		gm := allGames[c.games[gi]]
+		localGames[gi] = [2]int{memberIdx[gm.a], memberIdx[gm.b]}
+	}
+	js := newJointScratch(m)
+	winsCnt := make([]int, m)
+	lossCnt := make([]int, m)
+	coupledVal := make([]bool, maxPts+2*g+1)
+
 	total := 1
 	for i := 0; i < g; i++ {
 		total *= 3
@@ -1103,35 +1126,81 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 			x /= 3
 		}
 
-		for p := 0; p < m; p++ {
+		for mi := range m {
+			winsCnt[mi] = bits.OnesCount64(winMask[mi])
+			lossCnt[mi] = bits.OnesCount64(loseMask[mi])
+		}
+		// Mark each points value with a decided game between two players both at
+		// that value -- the only values where a fixed P needs the joint
+		// closed-form rather than independent per-member spread boxes.
+		clear(coupledVal)
+		for gi, gp := range localGames {
+			a, b := gp[0], gp[1]
+			if points[a] == points[b] && (winMask[a]|winMask[b])&(uint64(1)<<gi) != 0 {
+				coupledVal[points[a]] = true
+			}
+		}
+
+		for p := range m {
 			strictAbove := 0
-			forcedAboveTied := 0
-			possiblyAboveTied := 0
-			pSpread := standings[c.members[p]].spread
-			for q := 0; q < m; q++ {
+			tied = tied[:0]
+			for q := range m {
 				if q == p {
 					continue
 				}
-				if points[q] > points[p] {
+				switch {
+				case points[q] > points[p]:
 					strictAbove++
-					continue
-				}
-				if points[q] < points[p] {
-					continue
-				}
-				forced, possible := spreadOrdering(
-					winMask[p], loseMask[p], winMask[q], loseMask[q],
-					pSpread, standings[c.members[q]].spread,
-				)
-				if forced {
-					forcedAboveTied++
-				}
-				if possible {
-					possiblyAboveTied++
+				case points[q] == points[p]:
+					tied = append(tied, q)
 				}
 			}
-			bestRank := 1 + fixedAbove + strictAbove + forcedAboveTied
-			worstRank := 1 + fixedAbove + strictAbove + possiblyAboveTied
+			var minAbove, maxGE int
+			if standings[c.members[p]].gamesRemaining > 0 {
+				// Free P: per-pair is exact in aggregate (the lose-all and
+				// win-all leaves give P's true rank extremes). Fast path.
+				for _, q := range tied {
+					forced, possible := spreadOrdering(
+						winMask[p], loseMask[p], winMask[q], loseMask[q],
+						baseSpread[p], baseSpread[q],
+					)
+					if forced {
+						minAbove++
+					}
+					if possible {
+						maxGE++
+					}
+				}
+			} else {
+				// Fixed P: the per-pair view over-counts coupled tied players.
+				// If no two of P's tied opponents are coupled (no decided game
+				// this leaf between two players both at P's points), each is
+				// independent and a per-member reachable-spread box is exact;
+				// only genuine coupling needs the joint closed-form.
+				if coupledVal[points[p]] {
+					minAbove, maxGE = jointFixedTied(p, tied, winMask, baseSpread, localGames, js)
+				} else {
+					sprP := baseSpread[p]
+					for _, q := range tied {
+						hiq := baseSpread[q] - lossCnt[q] // max spread: no win -> lose minimally
+						if winsCnt[q] > 0 {
+							hiq = 1 << 30 // a win runs spread to +inf
+						}
+						loq := baseSpread[q] + winsCnt[q] // min spread: no loss -> win minimally
+						if lossCnt[q] > 0 {
+							loq = -(1 << 30)
+						}
+						if hiq >= sprP {
+							maxGE++
+						}
+						if loq > sprP {
+							minAbove++
+						}
+					}
+				}
+			}
+			bestRank := 1 + fixedAbove + strictAbove + minAbove
+			worstRank := 1 + fixedAbove + strictAbove + maxGE
 			if bestRank < best[p] {
 				best[p] = bestRank
 			}
@@ -1146,34 +1215,25 @@ func enumerateBruteForceCluster(c *bfCluster, standings []standingInfo, allGames
 	}
 }
 
-// spreadOrdering decides, for a fixed outcome, two things about a pair (q, p)
-// tied on final points, using precomputed win/loss bitmasks:
-//   - forced: Q.spread > P.spread in every margin assignment.
-//   - possible: Q.spread >= P.spread in at least one margin assignment
-//     (equal spread counts as possibly-above via username tiebreak).
+// spreadInf is a sentinel for an unbounded (+/-inf) reachable spread. It is far
+// larger than any real spread sum (a cluster has <= ~26 players), so finite
+// values never reach it and sums of a handful of sentinels do not overflow.
+const spreadInf = int64(1) << 50
+
+// spreadOrdering decides, for one brute leaf, whether a points-tied opponent Q
+// sits above a FREE player P (P has remaining games) on spread. Across all
+// leaves the lose-all and win-all leaves give P its true rank extremes, and
+// there this per-pair test is exact -- so for a free P it yields the correct
+// brute bound even though it ignores the joint coupling in intermediate leaves.
+// (A FIXED P has no such extreme leaf; see jointFixedTied.)
+//   - possible: Q can reach spread >= P (counts toward P's worst rank).
+//   - forced:   Q must exceed P on spread (counts toward P's best rank).
 //
-// Derivation (see bruteForceRanks header for the Δ_g definition):
-//
-// For a non-draw game g, Δ_g = sign_Q(g) - sign_P(g) ∈ {±1, ±2} and is
-//   - > 0 iff q wins g OR p loses g (the only cases with sign_Q > sign_P)
-//   - < 0 iff q loses g OR p wins g (mirror)
-//
-// max Σ Δ_g · m_g is +∞ iff any Δ_g > 0 (push m_g → ∞):
-//
-//	maxUnbounded = (winMask[q] | loseMask[p]) != 0
-//
-// Similarly minUnbounded = (winMask[p] | loseMask[q]) != 0.
-//
-// When neither is unbounded, no non-draw game has p or q in it, so every
-// Δ_g = 0; the finite sums are 0 and the spread comparison falls to the
-// initial diff.
+// A non-draw game Q wins, or P loses, lets the margin run to +inf
+// (maxUnbounded); P winning or Q losing lets it run to -inf (minUnbounded).
 func spreadOrdering(pWins, pLosses, qWins, qLosses uint64, pSpread, qSpread int) (forced, possible bool) {
 	maxUnbounded := (qWins | pLosses) != 0
 	minUnbounded := (pWins | qLosses) != 0
-
-	// Q.final > P.final (strict):  forced   = min Σ > P.init - Q.init
-	// Q.final >= P.final (allow =): possible = max Σ >= P.init - Q.init
-	// When the relevant direction is bounded, Σ == 0.
 	if maxUnbounded {
 		possible = true
 	} else {
@@ -1185,4 +1245,214 @@ func spreadOrdering(pWins, pLosses, qWins, qLosses uint64, pSpread, qSpread int)
 		forced = qSpread > pSpread
 	}
 	return forced, possible
+}
+
+// jointScratch holds reusable buffers for jointFixedTied so the brute's inner
+// loop allocates nothing. One per enumerateBruteForceCluster goroutine.
+type jointScratch struct {
+	parent, wins, losses []int
+	isTied, external     []bool
+	comp                 []int
+	lo, hi, costs        []int64
+}
+
+func newJointScratch(m int) *jointScratch {
+	return &jointScratch{
+		parent:   make([]int, m),
+		wins:     make([]int, m),
+		losses:   make([]int, m),
+		isTied:   make([]bool, m),
+		external: make([]bool, m),
+		comp:     make([]int, 0, m),
+		lo:       make([]int64, 0, m),
+		hi:       make([]int64, 0, m),
+		costs:    make([]int64, 0, m),
+	}
+}
+
+func findUF(parent []int, x int) int {
+	for parent[x] != x {
+		parent[x] = parent[parent[x]]
+		x = parent[x]
+	}
+	return x
+}
+
+// jointFixedTied computes, for a FIXED player P (no remaining games, so P's
+// spread is the constant baseSpread[p]) in one brute leaf, the min number of
+// points-tied players that MUST finish strictly above P (best rank) and the max
+// that CAN finish at-or-above P (worst rank), accounting for the joint zero-sum
+// coupling of shared games that the per-pair view misses.
+//
+// Tied players are grouped into components by their internal (tied-vs-tied)
+// non-draw games. A component is OPEN if any member also has a non-draw game to
+// a non-tied player: that game leaks spread out of the component, and the leak
+// propagates through the internal edges, so every member can independently
+// reach its own spread box -- count each member by its box. A CLOSED component
+// has no such leak, so its total spread is conserved; the count is then a
+// box-constrained sum-feasibility (maxAtOrAbove / maxAtOrBelow).
+func jointFixedTied(p int, tied []int, winMask []uint64, baseSpread []int, localGames [][2]int, js *jointScratch) (minAbove, maxGE int) {
+	if len(tied) == 0 {
+		return 0, 0
+	}
+	sprP := int64(baseSpread[p])
+	parent, wins, losses := js.parent, js.wins, js.losses
+	isTied, external := js.isTied, js.external
+	for _, q := range tied {
+		parent[q] = q
+		wins[q] = 0
+		losses[q] = 0
+		isTied[q] = true
+		external[q] = false
+	}
+	defer func() {
+		for _, q := range tied {
+			isTied[q] = false
+		}
+	}()
+
+	for gi, gp := range localGames {
+		bit := uint64(1) << gi
+		a, b := gp[0], gp[1]
+		var w, l int
+		switch {
+		case winMask[a]&bit != 0:
+			w, l = a, b
+		case winMask[b]&bit != 0:
+			w, l = b, a
+		default:
+			continue // draw: no spread coupling
+		}
+		if isTied[w] {
+			wins[w]++
+		}
+		if isTied[l] {
+			losses[l]++
+		}
+		switch {
+		case isTied[w] && isTied[l]:
+			if rw, rl := findUF(parent, w), findUF(parent, l); rw != rl {
+				parent[rw] = rl
+			}
+		case isTied[w]:
+			external[w] = true
+		case isTied[l]:
+			external[l] = true
+		}
+	}
+
+	// Group tied players into coupled components (by union-find root). Sorting
+	// by root makes same-component members contiguous, so each component is
+	// handled once in O(|tied| log |tied|) -- no per-root rescan of the set.
+	comp := append(js.comp[:0], tied...)
+	js.comp = comp
+	slices.SortFunc(comp, func(a, b int) int { return findUF(parent, a) - findUF(parent, b) })
+	for i := 0; i < len(comp); {
+		r := findUF(parent, comp[i])
+		lo, hi := js.lo[:0], js.hi[:0]
+		closed := true
+		var sumC int64
+		j := i
+		for j < len(comp) && findUF(parent, comp[j]) == r {
+			t := comp[j]
+			if external[t] {
+				closed = false
+			}
+			var loq, hiq int64
+			if wins[t] > 0 {
+				hiq = spreadInf
+			} else {
+				hiq = int64(baseSpread[t] - losses[t])
+			}
+			if losses[t] > 0 {
+				loq = -spreadInf
+			} else {
+				loq = int64(baseSpread[t] + wins[t])
+			}
+			lo = append(lo, loq)
+			hi = append(hi, hiq)
+			sumC += int64(baseSpread[t])
+			j++
+		}
+		js.lo, js.hi = lo, hi
+		if closed {
+			maxGE += maxAtOrAbove(lo, hi, sumC, sprP, js.costs)
+			minAbove += len(lo) - maxAtOrBelow(lo, hi, sumC, sprP, js.costs)
+		} else {
+			for k := range lo {
+				if hi[k] >= sprP {
+					maxGE++
+				}
+				if lo[k] > sprP {
+					minAbove++
+				}
+			}
+		}
+		i = j
+	}
+	return minAbove, maxGE
+}
+
+// maxAtOrAbove returns the largest count of members that can have spread >= c
+// given each spread is in [lo_i, hi_i] and they sum to the conserved S. Placing
+// a member at-or-above c costs max(c,lo_i)-lo_i over its floor; greedily admit
+// the cheapest while the minimum achievable sum stays <= S. costs is scratch.
+func maxAtOrAbove(lo, hi []int64, s, c int64, costs []int64) int {
+	var base int64
+	for _, l := range lo {
+		base += l
+	}
+	costs = costs[:0]
+	for i := range lo {
+		if hi[i] >= c {
+			floor := lo[i]
+			if c > floor {
+				floor = c
+			}
+			costs = append(costs, floor-lo[i])
+		}
+	}
+	slices.Sort(costs)
+	cnt := 0
+	cur := base
+	for _, ct := range costs {
+		cur += ct
+		if cur <= s {
+			cnt++
+		} else {
+			break
+		}
+	}
+	return cnt
+}
+
+// maxAtOrBelow is the mirror of maxAtOrAbove: the largest count of members that
+// can have spread <= c, given the boxes and the conserved sum S.
+func maxAtOrBelow(lo, hi []int64, s, c int64, costs []int64) int {
+	var base int64
+	for _, h := range hi {
+		base += h
+	}
+	costs = costs[:0]
+	for i := range hi {
+		if lo[i] <= c {
+			ceil := hi[i]
+			if c < ceil {
+				ceil = c
+			}
+			costs = append(costs, hi[i]-ceil)
+		}
+	}
+	slices.Sort(costs)
+	cnt := 0
+	cur := base
+	for _, ct := range costs {
+		cur -= ct
+		if cur >= s {
+			cnt++
+		} else {
+			break
+		}
+	}
+	return cnt
 }

--- a/pkg/league/rank_bounds_bench_test.go
+++ b/pkg/league/rank_bounds_bench_test.go
@@ -1,0 +1,27 @@
+package league
+
+import "testing"
+
+// BenchmarkBruteWorst measures the brute-force tier's worst case: a large
+// division bunched into a single cluster sitting at the brute-force game
+// threshold, so 3^bruteForceThreshold leaves each rank every member. This is the
+// hot path that sets the per-snapshot budget; the benchmark guards against perf
+// regressions in enumerateBruteForceCluster. (26 members is a representative
+// large division, not an assumed maximum.)
+func BenchmarkBruteWorst(b *testing.B) {
+	const n = 26
+	st := make([]standingInfo, n)
+	for i := range st {
+		st[i] = standingInfo{userID: int32(i + 1), points: 20, spread: 0, gamesRemaining: 0}
+	}
+	var unf []unfinishedGame
+	for i := range bruteForceThreshold { // a path of threshold games keeps it one cluster
+		unf = append(unf, unfinishedGame{player0ID: int32(i + 1), player1ID: int32(i + 2)})
+		st[i].gamesRemaining++
+		st[i+1].gamesRemaining++
+	}
+	sortStandings(st)
+	for b.Loop() {
+		CalculatePossibleRanks(st, unf)
+	}
+}

--- a/pkg/league/rank_bounds_design.md
+++ b/pkg/league/rank_bounds_design.md
@@ -210,13 +210,14 @@ sound+monotone); it never makes a wrong answer.
 
 The thresholds are measured: brute runs at `<= 10` unfinished games per cluster
 (`bruteForceThreshold`), and the B&B at cluster-local `k <= 13`
-(`localCandidateGate`). At those gates the worst single division-snapshot over
-the full game-history replay is ~65ms and lands on a *brute* cluster -- the gated
-B&B never exceeds the brute worst case, so the budget is brute-bound. `k = 14`
-hits a single-player B&B blow-up (a fully-bunched division), which is why the
-gate sits at 13. Replaying every completed division-season in completion order,
-the monotonicity violations drop from 1220 (the reported bug) to 0, with zero
-final-result mismatches.
+(`localCandidateGate`). Over the full game-history replay the worst single
+division-snapshot is ~29ms and lands on a *B&B* cluster; the brute worst case (a
+bunched `m=26`, `g=10` cluster) is ~24ms after its per-leaf counting sort, so the
+budget is B&B-bound, not brute-bound. `k = 14` hits a single-player B&B blow-up
+(a fully-bunched division), which is why the gate sits at 13; the brute stays at
+`<= 10` because `3^11` leaves explode regardless of the per-leaf speed. Replaying
+every completed division-season in completion order, the monotonicity violations
+drop from 1220 (the reported bug) to 0, with zero final-result mismatches.
 
 ### What `k` is (the B&B gate metric)
 

--- a/pkg/league/rank_bounds_design.md
+++ b/pkg/league/rank_bounds_design.md
@@ -208,9 +208,15 @@ about as fast as today's brute worst case (machine-independent via the ratio of
 B&B-worst to brute-worst). Lowering a gate only loosens the result (still
 sound+monotone); it never makes a wrong answer.
 
-> Measured constants (gate thresholds, coverage, speedups) are finalized in the
-> last commit of this work and filled in here then; treat the `<= 10` / `k <= 13`
-> figures above as the intended design values until then.
+The thresholds are measured: brute runs at `<= 10` unfinished games per cluster
+(`bruteForceThreshold`), and the B&B at cluster-local `k <= 13`
+(`localCandidateGate`). At those gates the worst single division-snapshot over
+the full game-history replay is ~65ms and lands on a *brute* cluster -- the gated
+B&B never exceeds the brute worst case, so the budget is brute-bound. `k = 14`
+hits a single-player B&B blow-up (a fully-bunched division), which is why the
+gate sits at 13. Replaying every completed division-season in completion order,
+the monotonicity violations drop from 1220 (the reported bug) to 0, with zero
+final-result mismatches.
 
 ### What `k` is (the B&B gate metric)
 

--- a/pkg/league/rank_bounds_design.md
+++ b/pkg/league/rank_bounds_design.md
@@ -1,0 +1,429 @@
+# Possible-rank bounds: design rationale
+
+`CalculatePossibleRanks` shows each league player a "possible final rank" range,
+`bestRank..worstRank`. This file documents the guarantees, the algorithm, the
+deliberate tradeoffs, and -- importantly -- the approaches that were tried and
+rejected, so a future maintainer does not re-walk the dead ends.
+
+## Reader's guide
+
+This section is the whole story in plain language; the rest of the file is the
+precise reference.
+
+**The problem.** Each player in a league division sees a "possible final rank"
+range, like "you can still finish anywhere from 3rd to 7th". Some games in the
+division are still unplayed, so the final order is not yet fixed; the range says
+which finishing positions are still reachable for that player. Users treat the
+range as a *promise*, which forces two non-negotiable properties:
+
+- **Soundness:** the player's actual final rank must always be inside the shown
+  range. We may show a range that is too wide, but never one that excludes a rank
+  they could really finish in.
+- **Monotonicity:** as games finish, the range may only *narrow*. Showing "3rd to
+  7th" today and "2nd to 7th" tomorrow is forbidden -- a range that grows reads as
+  the promise being broken. (Showing "1st to last" is always safe but tells the
+  user nothing; the job is to be tight *and* never break the two rules.)
+
+Everything else in this file exists to make the range as tight as possible
+without ever breaking those two rules.
+
+**The exact-but-slow method (brute force).** The honest way to compute the range
+is to consider every way the unplayed games could turn out and keep the player's
+best and worst rank across all of them. Each unplayed game has three outcomes --
+win, draw, or loss -- giving `3^(unplayed games)` combinations: fine for a handful
+of games, hopeless past about ten, so brute force is used only for small
+situations. But win/draw/loss is not the whole story -- players who tie on points
+are separated by score spread, and spread depends on the *margins* of the
+remaining games, both relative to the spread each player already has and to each
+other (a game's margin helps the winner exactly as much as it hurts the loser, so
+shared games couple players). We do **not** enumerate margin sizes on top of the
+`3^g` outcomes -- that is unbounded, and sampling a few sizes is unreliable (see
+the joint-margin section). Instead, for each of the `3^g` outcomes we check which
+spread orderings among the tied players are actually *achievable*. So the cost is
+`3^g` outcomes each times a cheap feasibility check -- not `3^g` times a number of
+margins.
+
+**Cheaper safe methods for bigger situations.** When there are too many unplayed
+games to enumerate, we fall back to cheaper methods that are still *safe* (never
+exclude a reachable rank, never widen later), even if they sometimes report a
+range slightly wider than the true one:
+
+- **The "frontend" bound** is the simplest possible safe answer: assume the
+  player wins all their remaining games while everyone else loses all of theirs
+  (for the best rank), and the reverse (for the worst rank), ignoring who
+  actually plays whom. It is called the *frontend* bound because it is exactly
+  what the web frontend could compute on its own, knowing only each player's
+  points and games remaining -- no pairing data. It is the loosest of the three,
+  but trivially safe and only ever tightens.
+- **The middle tier (max-flow / branch-and-bound)** is smarter but still cheap.
+  The key sub-question for the worst rank is "what is the fewest rivals who could
+  still leapfrog this player?" That turns out to be a network-flow feasibility
+  question, and solving it *exactly* is a branch-and-bound search. This tier is
+  tighter than the frontend bound and almost as good as brute force, used in the
+  medium range where brute force is too slow.
+
+**Why this stays monotone.** We pick which method to use from the size of the
+player's *cluster* -- the group of players whose order relative to one another is
+still in doubt. A cluster can only *shrink* as games finish, never grow, so we
+only ever switch from a looser method to a tighter one, exactly once, and never
+back. That is what guarantees the range never widens.
+
+**What was tried and rejected, and why:**
+
+- **A greedy shortcut for the leapfrog count** (a fast approximation instead of
+  the exact branch-and-bound). Rejected: it is sometimes wrong in a direction
+  that makes the range *grow* in a later snapshot, which breaks monotonicity. The
+  exact search is used instead, kept cheap by only running it on small-enough
+  clusters.
+- **Remembering the last range and refusing to widen.** Would give monotonicity
+  trivially, but needs new database columns to store prior ranges -- a schema
+  migration and downtime. Rejected; the cluster-shrink argument gives
+  monotonicity for free, with no stored state.
+- **A permutation ("Hall") post-pass:** a clever extra tightening -- across the
+  whole division, if a rank can belong to only one player, pin it to that player,
+  and repeat. It is correct, cheap, and safe, but when measured on real league
+  data it recovered *nothing* (the other tiers already capture that tightness in
+  practice), so it would be pure dead code. Rejected.
+- **Capping the exact search by work or time.** Stopping branch-and-bound after a
+  fixed number of steps, or when a timer trips, bounds the cost but is either
+  non-monotone (the cap is not tied to cluster size) or non-deterministic (the
+  same situation could get the tight answer on one page load and the loose one on
+  the next). Rejected; the size-based gate is the deterministic, monotone way to
+  cap cost.
+
+**One subtlety even brute force got wrong.** The exact brute force originally
+reasoned about score spread one pair of players at a time, which misses that two
+players sharing a game cannot both swing its margin their own way. That made even
+the "exact" method occasionally too wide. The fix (the joint-margin section
+below) reasons about the shared spread jointly.
+
+**If you change anything here,** re-run the verification harness (last section).
+It checks both hard guarantees mechanically against real game histories and an
+independent oracle -- the safety net, since the algorithm is intricate enough
+that code review alone will not catch a subtle break.
+
+## Guarantees
+
+- **Soundness (HARD).** `displayed_best <= actual_best <= actual_worst <=
+  displayed_worst` at all times. Whatever results the unfinished games take
+  (under the spread model below), the player's real final rank is always inside
+  the displayed `[best, worst]`. Both ends are correct; we never exclude an
+  achievable rank.
+- **Monotonicity (HARD).** As games complete, the range may only *tighten*. It
+  must never widen (e.g. show `worst=7` then later `worst=8`). This is the
+  feature's promise -- users read the range as a guarantee, so widening it is a
+  broken promise, not a cosmetic glitch. (The trivial `1..n` is always sound but
+  useless; the point is to be tight *and* monotone.)
+- **Tightest-feasible (SOFT).** Subject to the two hard guarantees, the range
+  should be as narrow as possible. A too-wide but sound+monotone range is
+  acceptable; a tighter range that is ever unsound or non-monotone is not. When
+  the two conflict, tightness yields.
+
+## Normal-termination spread model (deliberate)
+
+A decided game contributes a **margin of at least 1, strictly**: the winner
+gains strictly positive spread, the loser strictly negative; only a draw is
+zero. The bounds reason about spread under this model.
+
+We deliberately do **not** model the timeout edge case where a leading player
+times out and loses *with positive spread* (a negative-spread "win" for the
+opponent). Timeouts are rare and discouraged; in that rare case the displayed
+range may be slightly too tight. Do not "fix" the spread logic to cover it
+without revisiting this decision -- it is a choice, not an oversight.
+
+- A cheater penalty that adjusts scores so the cheater loses by some margin is
+  consistent with this model (the winner keeps positive spread).
+- A planned time-bank-auto-pass mechanic (a timed-out player auto-passes on a
+  fresh turn; forced adjudication after two weeks uses the current spread, so the
+  leader wins) would make normal play exact -- no negative-spread wins.
+
+## The bounds as extremal achievable ranks
+
+Define `achievable(P, r)` = "there is some completion of the unfinished games
+(results and margins, under the spread model) in which player P finishes in rank
+`r`". Then:
+
+    bestRank(P)  = smallest r with achievable(P, r)
+    worstRank(P) = largest  r with achievable(P, r)
+
+Conceptually you could compute either end by scanning from the extreme:
+`while !achievable(P, best) { best++ }` and
+`while !achievable(P, worst) { worst-- }`. Two independent verification oracles
+evaluate `achievable` exactly: an exhaustive enumeration (the indisputable
+ground truth, tiny cases only) and a Fourier-Motzkin feasibility test (which
+scales to the whole brute regime). Production does **not** scan rank-by-rank:
+each tier computes the extremal achievable rank in one shot (brute by
+enumeration, B&B by minimum eviction), which is cheaper. Every tier and oracle
+is a different way to decide the same `achievable`, so they cross-check each
+other.
+
+## Clusters: the monotonicity linchpin
+
+Partition players into **clusters** -- maximal groups whose relative order is
+still undetermined (`buildBruteForceClusters`). A cluster occupies a *consecutive
+rank band* `[1+crossAbove, n-crossBelow]`; players outside it are rank-disjoint
+(guaranteed all-above or all-below by points alone). Members share the band but
+have different individual sub-ranges, so a cluster is **not** "everyone is
+`1..size`".
+
+A cluster's size -- its member count and its unfinished-game count -- only ever
+*shrinks* as games complete: components can only split, and the point ranges
+`[pts, pts + 2*remaining]` only tighten, so non-overlapping stays
+non-overlapping. This is what makes a size-based gate monotone: it flips from the
+looser tier to the tighter tier exactly once and never back.
+
+## Three-tier dispatch (per cluster)
+
+Each cluster is handled by one of three algorithms, chosen by size:
+
+| tier     | when (per cluster)            | soundness | tightness                        |
+|----------|-------------------------------|-----------|----------------------------------|
+| brute    | unfinished games <= 10        | exact     | exact in both directions         |
+| B&B      | local candidate count k <= 13 | sound     | exact eviction; flow-model loose |
+| frontend | otherwise (large clusters)    | sound     | loosest (pairing-agnostic)       |
+
+- **brute** enumerates the `3^games` win/draw/loss outcomes; within each it does
+  *not* enumerate score margins (unbounded, and sampling is unreliable) but checks
+  which spread orderings of the tied players are achievable (the joint-margin
+  reasoning below) -- so it is `3^games` leaves times a cheap per-leaf feasibility
+  check. Exact: it captures spread coupling *and* the cross-player permutation
+  constraints the per-player heuristics miss. Affordable only while `3^games` is
+  small, hence the `<= 10` cap.
+- **B&B** (branch-and-bound, primer below) models the bound as a minimum eviction
+  over P's candidate set and solves it exactly. Polynomial per node but
+  exponential in the worst case, so gated by `k`. Sound; looser than brute only
+  because the underlying flow model cannot represent every joint-margin
+  realization and ignores permutation constraints -- never unsound in the
+  achievable direction.
+- **frontend** is the pairing-agnostic bound (named for the bound the web
+  frontend can compute on its own, from points and games-remaining only):
+  `best = 1 + |{Q: pts_Q > P_ceiling}|`, `worst = n - |{Q: Q_ceiling < P_pts}|`
+  (a ceiling is `pts + 2*remaining`). Loose but sound, monotone (the counts only
+  grow), and provably wider than the B&B range in both directions -- so the
+  loose->tight flip as a cluster shrinks past the gate only ever tightens.
+
+The brute/B&B/frontend gates are a **performance budget**, not correctness
+constants: the thresholds are chosen so the worst single division-snapshot stays
+about as fast as today's brute worst case (machine-independent via the ratio of
+B&B-worst to brute-worst). Lowering a gate only loosens the result (still
+sound+monotone); it never makes a wrong answer.
+
+> Measured constants (gate thresholds, coverage, speedups) are finalized in the
+> last commit of this work and filled in here then; treat the `<= 10` / `k <= 13`
+> figures above as the intended design values until then.
+
+### What `k` is (the B&B gate metric)
+
+`k` is P's **candidate count**: the number of *other* players whose final order
+relative to P is still genuinely undetermined -- they could finish above or below
+P depending on the unfinished results. (Guaranteed-above and guaranteed-below
+players are not candidates.) For worst-rank, candidates are the players who could
+be *forced above* P; that count drives the eviction search, so the B&B cost is
+governed by `k`, which is why the gate is on `k`.
+
+- **local k:** counted within P's own cluster only. Cross-cluster players are
+  rank-disjoint, so they would inflate `k` while adding ~zero eviction cost;
+  excluding them gates on the true cost driver.
+- **unified across both ends:** via the inversion below, best-rank uses the same
+  candidate count on a transformed view, so one metric
+  `k = max(k_above_real, k_above_mirror)` gates both directions. It is monotone
+  both ways (shown below), so the gate stays monotone.
+- `k` is bounded by the cluster size, which only shrinks over the season. There
+  is no assumed maximum division size; the gate copes with any `k` (above the
+  threshold falls back to frontend).
+
+### Primer: branch-and-bound (B&B) minimum eviction
+
+The worst rank P can reach is `(players guaranteed above P) + (minimum number of
+candidates that can be forced above P) + 1`. "Forced above" means a feasible
+assignment of the unfinished results exists in which those candidates all end up
+above P. Finding the *minimum* such set is the hard part:
+
+- It is a minimum-vertex-cover-like problem (each unfinished game between two
+  candidates is a constraint coupling them), which is **NP-hard** in general.
+- A **greedy** approximation (repeatedly evict the highest-gain candidate) is
+  fast but sub-optimal, and -- critically -- its error is **not monotone** in
+  cluster size, so greedy bounds can *widen* between page loads. Rejected (see
+  below).
+- **Branch-and-bound** solves it exactly: test feasibility with a max-flow; if
+  infeasible, find a *minimal infeasible subset* of candidates and branch on
+  evicting each member of just that subset (a small branch factor), recursing.
+  Exact, and bounded to the gated regime (`k <= 13`) so the exponential worst
+  case never runs in production.
+
+The feasibility test is a max-flow; B&B wraps it; the rank routine wraps the B&B.
+
+### Primer: the max-flow feasibility test (what the graph is, why it works)
+
+Max-flow is used in exactly **one** place: the B&B (medium) tier. Brute uses
+enumeration plus the closed-form conservation rule, the frontend tier is pure
+counting, and the verification oracle is an LP -- none of them use max-flow.
+
+The question the flow answers (worst-rank case) is: *can this set of candidates
+all stay at or below P on points?* Model it as routing the points that the
+unfinished games will award:
+
+- a **source** and a **sink**;
+- one **game node** per unfinished game between two candidates, fed from the
+  source by an edge of capacity 2 (the two league points at stake in a game);
+- each game node feeds its **two player nodes** (the candidates playing it),
+  capacity = the points that player could take from the game (a win is 2, a draw
+  1);
+- each player node drains to the sink with capacity = that player's **slack**:
+  how many more points it can gain and still stay at or below P. (This is where
+  the per-candidate spread tiebreak is folded in: a candidate that would tie P on
+  points is kept below or not according to current spread.)
+
+The candidates can all stay below P iff the **max-flow saturates every game
+edge** (total flow = `2 * games`): every game's points find a home without
+pushing any candidate past P. If the flow falls short, the **min-cut** names a
+set of games whose points cannot all be absorbed -- so at least one of those
+candidates is forced above P. That cut yields the minimal infeasible subset the
+B&B branches on. (It is the standard max-flow/min-cut, i.e. transportation /
+Hall, argument: infeasibility = an over-subscribed candidate set.)
+
+**The flow models points, not joint spread.** It uses each candidate's current
+spread only for the per-candidate tiebreak (the slack above), not the joint
+zero-sum coupling of shared-game margins that brute handles. That coupling only
+bites when P is *fixed* (no games left) and tied inside a *closed* group, which
+in a medium/large cluster is rare (P usually still has games to move its own
+spread) and is exactly what the brute tier (`<= 10`) covers exactly. So the B&B
+bound is sound and, in practice, tight on spread; any residual looseness is
+measured against the oracle and revisited only if material. Modeling joint spread
+in the flow does not fit cleanly anyway -- spread matters only among players tied
+on points, and this tier deliberately does not fix the points outcome -- so it is
+left to brute.
+
+### Why invert for best-rank instead of computing it directly
+
+Best-rank is the mirror of worst-rank, and we compute it *as* one rather than
+writing a second eviction routine -- for a concrete monotonicity reason, not just
+code reuse:
+
+- Computing best-rank *directly* needs its own candidate set (players who could
+  be forced *below* P). That count keys off P's point **ceiling**
+  (`pts + 2*remaining`), which *falls* over the season as P's games resolve -- so
+  previously-guaranteed-below players can re-enter candidacy and the count can
+  **rise**. A rising candidate count is non-monotone: a `k`-gate on it could flip
+  tight->loose = widen = break the hard guarantee.
+- The fix is the **win/loss inversion**. With **loss-score = 2L + D** (not just
+  L), `points = 2W + D = 2G - (2L + D)` exactly (`G = W + D + L`, constant per
+  player at season end; draws included). So ranking by points descending is
+  identical to ranking by loss-score ascending. Best-rank-by-points therefore
+  equals worst-rank-by-loss-score on a mirrored view (points -> loss-score,
+  spread negated, rank flipped):
+
+      bestRank(P) = n + 1 - worstRankExact(P, mirror)
+
+  where the mirror sends `points -> 2*expected - points - 2*remaining` and
+  `spread -> -spread`. On the mirror, best-rank keys off P's loss **floor**,
+  which *rises* over time -- so its candidate count is **monotone**. One routine,
+  monotone in both directions.
+
+## Tightness by tier (when the sound bounds are also exact)
+
+The bounds are always sound and monotone. They are *additionally* exact (as
+tight as reality allows) depending on which tier the player's cluster falls in:
+
+- **brute (cluster <= 10 games): exact in both directions.** After the
+  joint-margin fix below, the enumeration realizes every legal outcome including
+  the joint spread coupling of shared games and the cross-player permutation
+  constraints.
+- **B&B (local k <= 13): sound, exact eviction, but the flow model can be
+  slightly loose.** The flow cannot represent every joint-margin realization and
+  ignores permutation constraints, so the bound may be a little wider than
+  reality -- never narrower (never unsound). The one direction where the flow
+  model *can* be unsound (an over-tight best-rank in a tiny cluster) is covered
+  by the brute tier (`<= 10`), which always wins there.
+- **frontend (large clusters): loosest, but still sound + monotone.** Early in a
+  season, when everyone is bunched in one big cluster, players land here and the
+  range is close to the whole cluster band. As games finish and the cluster
+  shrinks past the gates, each player's range tightens monotonically
+  (frontend -> B&B -> brute), never widening.
+
+So tightness improves over the course of a season, monotonically, as clusters
+shrink -- which is exactly when users care about a precise range (near the end).
+
+## Exact-brute joint-margin fix
+
+The brute is the exact ground truth, but the original `spreadOrdering` reasons
+about spread **per pair** of players -- effectively giving each player an
+independent spread range -- which **misses the joint zero-sum coupling of shared
+games**. Two players who share a game cannot both push that game's margin their
+own way, so the per-pair brute is sound but can be too *wide*.
+
+The fix reasons about spread **jointly** within a tied group:
+
+- A player's reachable spread is a box `[lo, hi]` around the spread it already has
+  (`start`): any win makes `hi = +inf`, any loss makes `lo = -inf`; otherwise
+  `lo = start + wins`, `hi = start - losses`. We test *feasibility* of the needed
+  spread ordering within these boxes -- we never enumerate concrete margin sizes.
+- Within a **closed** component (every game of every member is internal to the
+  tied group) the total spread is **conserved**, so not all members can sit at
+  their extreme at once: the number that can stay `<= P` is limited by the
+  conserved sum subject to the per-player boxes. (Example: a closed tied
+  round-robin whose spread sum forces at least one member above P -- invisible to
+  the per-pair view.)
+
+This only bites when P itself is **fixed** on the relevant side (no remaining
+game to push its own spread to the extreme) and is tied with a closed coupled
+set; otherwise the per-pair view is already tight. It is verified against the
+independent oracle below.
+
+## Approaches considered and REJECTED
+
+- **Clamp against stored prior bounds** (persist each player's last range, never
+  widen vs it): needs new DB columns = a migration = downtime. Rejected; the
+  cluster-shrink monotonicity argument needs no storage.
+- **Greedy eviction (no exact solve):** sub-optimal, and its error is not
+  monotone in cluster size, so it produces widening (non-monotone) bounds.
+  Empirically matched the exact bound only up to ~19 unfinished games and first
+  wobbled at 20. Dominated by gated B&B; dropped entirely.
+- **Brute force above ~10 games:** `3^games` explodes (`3^19 ~ 1.2e9`).
+- **B&B with a work-cap** (stop after N nodes): bounds time but BREAKS
+  monotonicity -- the node budget is not monotone in cluster size, so the bound
+  can widen.
+- **B&B with a depth-cap:** monotone, but does not tame the blow-up -- the branch
+  factor is unbounded, so `depth^branch` still explodes.
+- **Dynamic time-budget gate** (run B&B, fall back when a timer trips):
+  non-deterministic, hence non-monotone -- the same cluster could get the tight
+  tier on one page load and the loose fallback on the next (server load),
+  widening the range between loads.
+- **Naive candidate-count gate:** the best-rank candidate count is non-monotone
+  (see inversion above). Fixed by the loss-score inversion, which makes it
+  monotone; only then is candidate-gating sound.
+- **Hall / alldifferent post-pass:** a cheap, sound, monotone division-wide
+  fixpoint that recovers cross-player permutation tightness the per-player tiers
+  miss (if only one player's range contains rank `r`, force it; generalizes to
+  size-w Hall intervals). Correct and fully implemented, but **measured zero
+  reclaim** on the real corpus -- the per-player B&B/frontend bounds already
+  capture all the permutation tightness that actually occurs -- so it would be
+  dead code. Dropped. (The brute tier still gets permutation tightness for free
+  via real enumeration.)
+- **Finite-magnitude "brute of brute" oracle:** enumerating concrete margin
+  magnitudes from a fixed set is unreliable -- too coarse a set is silently
+  too-tight, and you can never prove the set is rich enough. Replaced by the
+  exact Fourier-Motzkin oracle below.
+
+## Verification
+
+All env-gated (`LEAGUE_REPLAY_CSV`), skipped in CI; CI keeps synthetic regression
+tests with no data file.
+
+- **Exhaustive oracle:** for tiny divisions, enumerate every win/draw/loss
+  outcome and every integer margin in `[1..B]` and read off the rank range --
+  the indisputable ground truth.
+- **Fourier-Motzkin oracle:** an independent exact `achievable(P, r)` via
+  Fourier-Motzkin feasibility over the game margins (exact integer arithmetic;
+  boolean feasibility, no witness). It scales past the exhaustive limit, is
+  validated to match the exhaustive ground truth, and in turn validates the
+  production brute on random small divisions.
+- **Replay harness** (`monotonic_replay_test.go`): replays real completed
+  division-seasons in game-completion order and asserts per-player monotonicity
+  (best non-decreasing, worst non-increasing) plus a tie-aware final-result
+  check.
+- **Pinpoint** (`rank_bounds_pinpoint_test.go`): isolates a single over-tight
+  state for debugging.
+- **Per-commit metric deltas:** each change in this work is measured to *reduce*
+  at least one of {monotonicity violations, soundness violations vs the oracle,
+  range width} without regressing the two hard guarantees.

--- a/pkg/league/rank_bounds_oracle_test.go
+++ b/pkg/league/rank_bounds_oracle_test.go
@@ -525,6 +525,106 @@ func TestRankBoundsBestInversionSoundVsBrute(t *testing.T) {
 	t.Logf("best-rank inversion vs brute over %d cases: 0 unsound, %d loose", cases, loose)
 }
 
+// TestRankBoundsSyntheticMonotonicReplay exercises the full per-cluster dispatch
+// -- the frontend, branch-and-bound, and brute tiers and the gate flips between
+// them -- with no data file (the real-data replay is env-gated, skipped in CI).
+// It simulates a round-robin season, and at every prefix asserts the two hard
+// guarantees: as games complete each player's range only tightens (best
+// non-decreasing, worst non-increasing), and once every game is played the range
+// collapses to that player's actual block-tie finishing rank. n=15 starts in the
+// frontend tier (candidate count 14 > gate 13); n=6 and n=12 start in the B&B
+// tier; all pass through the brute tier as their cluster shrinks below 10 games.
+func TestRankBoundsSyntheticMonotonicReplay(t *testing.T) {
+	rng := rand.New(rand.NewSource(2026))
+	for _, n := range []int{6, 12, 15} {
+		type game struct{ a, b int }
+		var schedule []game
+		for i := range n {
+			for j := i + 1; j < n; j++ {
+				schedule = append(schedule, game{i, j})
+			}
+		}
+		rng.Shuffle(len(schedule), func(i, j int) { schedule[i], schedule[j] = schedule[j], schedule[i] })
+		winner := make([]int, len(schedule)) // 0 = a wins, 1 = b wins, 2 = draw
+		margin := make([]int, len(schedule))
+		for i := range schedule {
+			winner[i] = rng.Intn(3)
+			margin[i] = 1 + rng.Intn(50)
+		}
+
+		// accumulate points/spread/played for the first `upto` completed games.
+		tally := func(upto int) (pts, spr, played []int) {
+			pts, spr, played = make([]int, n), make([]int, n), make([]int, n)
+			for gi := range upto {
+				g := schedule[gi]
+				switch winner[gi] {
+				case 0:
+					pts[g.a] += 2
+					spr[g.a] += margin[gi]
+					spr[g.b] -= margin[gi]
+				case 1:
+					pts[g.b] += 2
+					spr[g.b] += margin[gi]
+					spr[g.a] -= margin[gi]
+				default:
+					pts[g.a]++
+					pts[g.b]++
+				}
+				played[g.a]++
+				played[g.b]++
+			}
+			return
+		}
+
+		prevBest := make([]int, n) // indexed by userID-1
+		prevWorst := make([]int, n)
+		for i := range prevBest {
+			prevBest[i], prevWorst[i] = 1, n
+		}
+		for done := 0; done <= len(schedule); done++ {
+			pts, spr, played := tally(done)
+			st := make([]standingInfo, n)
+			for i := range st {
+				st[i] = standingInfo{userID: int32(i + 1), points: pts[i], spread: spr[i], gamesRemaining: (n - 1) - played[i]}
+			}
+			var unf []unfinishedGame
+			for gi := done; gi < len(schedule); gi++ {
+				unf = append(unf, unfinishedGame{player0ID: int32(schedule[gi].a + 1), player1ID: int32(schedule[gi].b + 1)})
+			}
+			sortStandings(st)
+			bounds := CalculatePossibleRanks(st, unf)
+			for i, s := range st {
+				uid := int(s.userID) - 1
+				b := bounds[i]
+				if b.BestRank < 1 || b.WorstRank > n || b.BestRank > b.WorstRank {
+					t.Fatalf("n=%d done=%d uid=%d: invalid bounds %v", n, done, uid, b)
+				}
+				if b.BestRank < prevBest[uid] || b.WorstRank > prevWorst[uid] {
+					t.Fatalf("n=%d uid=%d widened at done=%d: [%d,%d] -> [%d,%d]",
+						n, uid, done, prevBest[uid], prevWorst[uid], b.BestRank, b.WorstRank)
+				}
+				prevBest[uid], prevWorst[uid] = b.BestRank, b.WorstRank
+			}
+		}
+		// All games played: each player's range must equal its exact finishing
+		// rank (block-tie convention), since nothing remains undecided.
+		pts, spr, _ := tally(len(schedule))
+		st := make([]standingInfo, n)
+		for i := range st {
+			st[i] = standingInfo{userID: int32(i + 1), points: pts[i], spread: spr[i]}
+		}
+		sortStandings(st)
+		bounds := CalculatePossibleRanks(st, nil)
+		for i, s := range st {
+			uid := int(s.userID) - 1
+			lo, hi := rankRange(pts, spr, uid)
+			if bounds[i].BestRank != lo || bounds[i].WorstRank != hi {
+				t.Errorf("n=%d uid=%d: final bounds %v != actual rank [%d,%d]", n, uid, bounds[i], lo, hi)
+			}
+		}
+	}
+}
+
 // --- Fourier-Motzkin feasibility (the oracle's joint-margin engine) ---
 //
 // oracleRanks asks, per leaf, whether a subset of points-tied players can be

--- a/pkg/league/rank_bounds_oracle_test.go
+++ b/pkg/league/rank_bounds_oracle_test.go
@@ -1,0 +1,497 @@
+package league
+
+// Independent exact rank-bounds oracle, for validating the production brute's
+// joint-margin reasoning. TEST ONLY -- never used by production code.
+//
+// Two independent computations of the exact best/worst rank for SMALL
+// divisions:
+//
+//   - exhaustiveRanks: the indisputable ground truth. Enumerates every
+//     win/draw/loss outcome AND every concrete integer margin in [1..B] for
+//     each unfinished game, computes concrete final points+spread, and reads
+//     off the rank range. Exact for tiny games once B exceeds the spread gaps;
+//     too slow past ~3-4 games.
+//
+//   - oracleRanks: enumerates the 3^g win/draw/loss leaves and, per leaf, finds
+//     the max/min number of points-tied players that can be ordered at/above P
+//     by a feasible joint margin assignment, via Fourier-Motzkin feasibility
+//     over the game margins (no magnitude enumeration). Scales to the whole
+//     brute regime (g <= 10).
+//
+// oracleRanks is validated to agree with exhaustiveRanks on random tiny
+// divisions (TestOracleVsExhaustive) -- that agreement, not code inspection, is
+// what makes the Fourier-Motzkin path trustworthy. It is then used as the exact
+// reference for the production joint-margin brute fix.
+
+import (
+	"math/bits"
+	"math/rand"
+	"testing"
+)
+
+// rankRange returns the [best, worst] rank of player p given concrete final
+// points and spread for every player, using the block tie convention: best
+// excludes players tied on exactly (points, spread); worst includes them.
+func rankRange(pts, spr []int, p int) (int, int) {
+	strictAbove, tied := 0, 0
+	for q := range pts {
+		if q == p {
+			continue
+		}
+		switch {
+		case pts[q] > pts[p] || (pts[q] == pts[p] && spr[q] > spr[p]):
+			strictAbove++
+		case pts[q] == pts[p] && spr[q] == spr[p]:
+			tied++
+		}
+	}
+	return strictAbove + 1, strictAbove + tied + 1
+}
+
+// exhaustiveRanks is the ground truth for tiny divisions: it enumerates every
+// outcome and every integer margin in [1..b] for each unfinished game.
+func exhaustiveRanks(st []standingInfo, unf []unfinishedGame, b int) []RankBounds {
+	pairs := toGamePairs(st, unf)
+	n := len(st)
+	g := len(pairs)
+	pts := make([]int, n)
+	spr := make([]int, n)
+	for i := range st {
+		pts[i] = st[i].points
+		spr[i] = st[i].spread
+	}
+	best := make([]int, n)
+	worst := make([]int, n)
+	for i := range best {
+		best[i] = n + 1
+		worst[i] = 0
+	}
+	var rec func(gi int)
+	rec = func(gi int) {
+		if gi == g {
+			for p := range n {
+				lo, hi := rankRange(pts, spr, p)
+				if lo < best[p] {
+					best[p] = lo
+				}
+				if hi > worst[p] {
+					worst[p] = hi
+				}
+			}
+			return
+		}
+		a, bb := pairs[gi].a, pairs[gi].b
+		// draw
+		pts[a]++
+		pts[bb]++
+		rec(gi + 1)
+		pts[a]--
+		pts[bb]--
+		for m := 1; m <= b; m++ {
+			// a wins by m
+			pts[a] += 2
+			spr[a] += m
+			spr[bb] -= m
+			rec(gi + 1)
+			pts[a] -= 2
+			spr[a] -= m
+			spr[bb] += m
+			// b wins by m
+			pts[bb] += 2
+			spr[bb] += m
+			spr[a] -= m
+			rec(gi + 1)
+			pts[bb] -= 2
+			spr[bb] -= m
+			spr[a] += m
+		}
+	}
+	rec(0)
+	res := make([]RankBounds, n)
+	for i := range res {
+		res[i] = RankBounds{BestRank: best[i], WorstRank: worst[i]}
+	}
+	return res
+}
+
+// oracleRanks is the scalable exact oracle (Fourier-Motzkin per leaf).
+func oracleRanks(st []standingInfo, unf []unfinishedGame) []RankBounds {
+	pairs := toGamePairs(st, unf)
+	n := len(st)
+	g := len(pairs)
+	best := make([]int, n)
+	worst := make([]int, n)
+	for i := range best {
+		best[i] = n + 1
+		worst[i] = 0
+	}
+	pts := make([]int, n)
+	for i := range st {
+		pts[i] = st[i].points
+	}
+	// spcoef[i][j] = coefficient of margin variable j in player i's spread.
+	spcoef := make([][]int64, n)
+	for i := range spcoef {
+		spcoef[i] = make([]int64, g)
+	}
+	var rec func(gi int)
+	rec = func(gi int) {
+		if gi == g {
+			oracleLeaf(st, pts, spcoef, g, best, worst)
+			return
+		}
+		a, bb := pairs[gi].a, pairs[gi].b
+		// draw: no margin variable contribution
+		pts[a]++
+		pts[bb]++
+		rec(gi + 1)
+		pts[a]--
+		pts[bb]--
+		// a wins
+		pts[a] += 2
+		spcoef[a][gi] = 1
+		spcoef[bb][gi] = -1
+		rec(gi + 1)
+		pts[a] -= 2
+		spcoef[a][gi] = 0
+		spcoef[bb][gi] = 0
+		// b wins
+		pts[bb] += 2
+		spcoef[bb][gi] = 1
+		spcoef[a][gi] = -1
+		rec(gi + 1)
+		pts[bb] -= 2
+		spcoef[bb][gi] = 0
+		spcoef[a][gi] = 0
+	}
+	rec(0)
+	res := make([]RankBounds, n)
+	for i := range res {
+		res[i] = RankBounds{BestRank: best[i], WorstRank: worst[i]}
+	}
+	return res
+}
+
+func oracleLeaf(st []standingInfo, pts []int, spcoef [][]int64, g int, best, worst []int) {
+	n := len(st)
+	for p := range n {
+		above := 0
+		var tied []int
+		for q := range n {
+			if q == p {
+				continue
+			}
+			switch {
+			case pts[q] > pts[p]:
+				above++
+			case pts[q] == pts[p]:
+				tied = append(tied, q)
+			}
+		}
+		// maxGE: most tied players that can simultaneously be at-or-above P on
+		// spread (spr_q - spr_p >= 0); maxLE: most that can be at-or-below.
+		maxGE := maxFeasibleSubset(st, spcoef, g, tied, p, true)
+		maxLE := maxFeasibleSubset(st, spcoef, g, tied, p, false)
+		lo := 1 + above + (len(tied) - maxLE) // min strictly-above
+		hi := 1 + above + maxGE               // max at-or-above (block worst)
+		if lo < best[p] {
+			best[p] = lo
+		}
+		if hi > worst[p] {
+			worst[p] = hi
+		}
+	}
+}
+
+// maxFeasibleSubset returns the size of the largest subset S of tied such that
+// "spr_q >= spr_p for all q in S" (ge) or "spr_q <= spr_p for all q in S" (!ge)
+// is jointly feasible over the game margins. Feasibility is downward-closed, so
+// any feasible S of a given size means all smaller subsets are feasible too.
+func maxFeasibleSubset(st []standingInfo, spcoef [][]int64, g int, tied []int, p int, ge bool) int {
+	k := len(tied)
+	best := 0
+	for mask := range 1 << k {
+		size := bits.OnesCount(uint(mask))
+		if size <= best {
+			continue
+		}
+		ineqs := make([]fmIneq, 0, size)
+		for bi := range k {
+			if mask&(1<<bi) == 0 {
+				continue
+			}
+			q := tied[bi]
+			coef := make([]int64, g)
+			var c int64
+			if ge {
+				for j := range g {
+					coef[j] = spcoef[q][j] - spcoef[p][j]
+				}
+				c = int64(st[q].spread - st[p].spread)
+			} else {
+				for j := range g {
+					coef[j] = spcoef[p][j] - spcoef[q][j]
+				}
+				c = int64(st[p].spread - st[q].spread)
+			}
+			ineqs = append(ineqs, fmIneq{coef: coef, c: c})
+		}
+		if fmFeasible(ineqs, g) {
+			best = size
+		}
+	}
+	return best
+}
+
+// fmIneq is the linear inequality sum_i coef[i]*x[i] + c >= 0.
+type fmIneq struct {
+	coef []int64
+	c    int64
+}
+
+// fmFeasible reports whether {ineqs, x_i >= 1 for all i} has a real solution,
+// via Fourier-Motzkin elimination with exact integer arithmetic.
+func fmFeasible(ineqs []fmIneq, nv int) bool {
+	sys := make([]fmIneq, 0, len(ineqs)+nv)
+	for _, q := range ineqs {
+		cf := make([]int64, nv)
+		copy(cf, q.coef)
+		sys = append(sys, fmIneq{coef: cf, c: q.c})
+	}
+	for i := range nv {
+		cf := make([]int64, nv)
+		cf[i] = 1
+		sys = append(sys, fmIneq{coef: cf, c: -1}) // x_i >= 1
+	}
+	for j := nv - 1; j >= 0; j-- {
+		var pos, neg, next []fmIneq
+		for _, q := range sys {
+			switch {
+			case q.coef[j] > 0:
+				pos = append(pos, q)
+			case q.coef[j] < 0:
+				neg = append(neg, q)
+			default:
+				next = append(next, q)
+			}
+		}
+		for _, p := range pos {
+			for _, q := range neg {
+				a := p.coef[j]
+				b := -q.coef[j] // both > 0; combo a*q + b*p cancels x_j
+				cf := make([]int64, nv)
+				for i := range nv {
+					cf[i] = a*q.coef[i] + b*p.coef[i]
+				}
+				ni := fmIneq{coef: cf, c: a*q.c + b*p.c}
+				reduceIneq(&ni)
+				if ni.allZero() {
+					if ni.c < 0 {
+						return false
+					}
+					continue
+				}
+				next = append(next, ni)
+			}
+		}
+		sys = next
+	}
+	for _, q := range sys {
+		if q.c < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (q fmIneq) allZero() bool {
+	for _, v := range q.coef {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func reduceIneq(q *fmIneq) {
+	var g int64
+	for _, v := range q.coef {
+		g = gcd64(g, abs64(v))
+	}
+	g = gcd64(g, abs64(q.c))
+	if g > 1 {
+		for i := range q.coef {
+			q.coef[i] /= g
+		}
+		q.c /= g
+	}
+}
+
+func gcd64(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func abs64(a int64) int64 {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+// --- test helpers ---
+
+// makeDivision builds a sorted division from per-player points/spread and a
+// list of unfinished games given as index pairs into the (pre-sort) arrays.
+func makeDivision(points, spreads []int, gamePairs [][2]int) ([]standingInfo, []unfinishedGame) {
+	n := len(points)
+	gr := make([]int, n)
+	for _, gp := range gamePairs {
+		gr[gp[0]]++
+		gr[gp[1]]++
+	}
+	st := make([]standingInfo, n)
+	for i := range n {
+		st[i] = standingInfo{
+			userID:         int32(i + 1),
+			points:         points[i],
+			spread:         spreads[i],
+			gamesRemaining: gr[i],
+		}
+	}
+	var unf []unfinishedGame
+	for _, gp := range gamePairs {
+		unf = append(unf, unfinishedGame{player0ID: int32(gp[0] + 1), player1ID: int32(gp[1] + 1)})
+	}
+	sortStandings(st)
+	return st, unf
+}
+
+func eqBounds(a, b []RankBounds) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestOracleVsExhaustive(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260611))
+	const cases = 400
+	const b = 16
+	mismatch := 0
+	for c := range cases {
+		n := 3 + rng.Intn(2) // 3 or 4 players
+		points := make([]int, n)
+		spreads := make([]int, n)
+		for i := range n {
+			points[i] = rng.Intn(4)
+			spreads[i] = rng.Intn(9) - 4
+		}
+		g := rng.Intn(4) // 0..3 games
+		var pairs [][2]int
+		for range g {
+			x := rng.Intn(n)
+			y := rng.Intn(n)
+			if x == y {
+				continue
+			}
+			pairs = append(pairs, [2]int{x, y})
+		}
+		st, unf := makeDivision(points, spreads, pairs)
+		got := oracleRanks(st, unf)
+		want := exhaustiveRanks(st, unf, b)
+		if !eqBounds(got, want) {
+			mismatch++
+			if mismatch <= 5 {
+				t.Errorf("case %d: oracle=%v exhaustive=%v\n  st=%+v\n  unf=%+v", c, got, want, st, unf)
+			}
+		}
+	}
+	if mismatch > 0 {
+		t.Fatalf("%d/%d oracle vs exhaustive mismatches", mismatch, cases)
+	}
+}
+
+// TestOracleClosedRRLooseness builds a closed tied round-robin (the joint-margin
+// looseness the production brute will be fixed for) and confirms the oracle
+// matches exhaustive truth and is strictly tighter than the current production
+// brute on at least one player.
+func TestOracleClosedRRLooseness(t *testing.T) {
+	// A is fixed (no games), tied on points with B,C,D who play a closed
+	// round-robin among themselves. Their conserved spread sum constrains how
+	// many can finish above A.
+	// points: A=2 (fixed), B=C=D=0 with 2 games each -> reach 2 via a 1-1 cycle.
+	// spreads: A=0; B,C,D start with a small conserved sum.
+	points := []int{2, 0, 0, 0}
+	spreads := []int{0, 1, 1, 1}
+	pairs := [][2]int{{1, 2}, {1, 3}, {2, 3}} // B-C, B-D, C-D
+	st, unf := makeDivision(points, spreads, pairs)
+	oracle := oracleRanks(st, unf)
+	truth := exhaustiveRanks(st, unf, 16)
+	if !eqBounds(oracle, truth) {
+		t.Fatalf("oracle %v != exhaustive %v", oracle, truth)
+	}
+	brute := CalculatePossibleRanks(st, unf)
+	// The oracle must be sound vs the production brute (contained within it)
+	// and tighter somewhere (that is the looseness commit 4 removes).
+	tighter := false
+	for i := range oracle {
+		if oracle[i].BestRank < brute[i].BestRank || oracle[i].WorstRank > brute[i].WorstRank {
+			t.Fatalf("oracle wider than brute at %d: oracle=%v brute=%v", i, oracle[i], brute[i])
+		}
+		if oracle[i].BestRank > brute[i].BestRank || oracle[i].WorstRank < brute[i].WorstRank {
+			tighter = true
+		}
+	}
+	t.Logf("closed-RR: oracle=%v brute=%v tighter=%v", oracle, brute, tighter)
+}
+
+// TestOracleVsBruteSanity checks basic validity on random small divisions and
+// reports where the oracle differs from the production brute (tighter = the
+// joint-margin fix's target; wider = a brute unsoundness the oracle catches).
+func TestOracleVsBruteSanity(t *testing.T) {
+	rng := rand.New(rand.NewSource(424242))
+	const cases = 300
+	tighter, wider := 0, 0
+	for c := range cases {
+		n := 3 + rng.Intn(4) // 3..6
+		points := make([]int, n)
+		spreads := make([]int, n)
+		for i := range n {
+			points[i] = rng.Intn(6)
+			spreads[i] = rng.Intn(13) - 6
+		}
+		g := rng.Intn(6) // 0..5 games
+		var pairs [][2]int
+		for range g {
+			x := rng.Intn(n)
+			y := rng.Intn(n)
+			if x != y {
+				pairs = append(pairs, [2]int{x, y})
+			}
+		}
+		st, unf := makeDivision(points, spreads, pairs)
+		oracle := oracleRanks(st, unf)
+		brute := CalculatePossibleRanks(st, unf)
+		for i := range oracle {
+			o, br := oracle[i], brute[i]
+			if o.BestRank < 1 || o.WorstRank > n || o.BestRank > o.WorstRank {
+				t.Fatalf("case %d player %d: invalid oracle bounds %v (n=%d)", c, i, o, n)
+			}
+			if o.BestRank > br.BestRank || o.WorstRank < br.WorstRank {
+				tighter++
+			}
+			if o.BestRank < br.BestRank || o.WorstRank > br.WorstRank {
+				wider++
+			}
+		}
+	}
+	t.Logf("oracle vs brute over %d cases: tighter=%d (joint-margin target), wider=%d (brute unsoundness)", cases, tighter, wider)
+}

--- a/pkg/league/rank_bounds_oracle_test.go
+++ b/pkg/league/rank_bounds_oracle_test.go
@@ -418,6 +418,59 @@ func TestBruteJointVsExhaustive(t *testing.T) {
 	}
 }
 
+// TestRankBoundsWorstBnBSoundVsBrute validates the worst-rank branch-and-bound
+// eviction (the max-flow tier) against the exact brute on random small divisions.
+// The B&B bound must be SOUND -- never tighter than the exact worst rank
+// (worstRankForPlayer >= brute.worst) -- because the flow model can only lose
+// tightness, never claim an unreachable rank. It is exercised here on the same
+// small divisions the brute solves exactly; in production the B&B runs on larger
+// clusters where the brute is infeasible. Reports how often it is merely loose.
+func TestRankBoundsWorstBnBSoundVsBrute(t *testing.T) {
+	rng := rand.New(rand.NewSource(13579))
+	const cases = 3000
+	unsound, loose := 0, 0
+	for c := range cases {
+		n := 3 + rng.Intn(5) // 3..7
+		points := make([]int, n)
+		spreads := make([]int, n)
+		for i := range n {
+			points[i] = rng.Intn(7)
+			spreads[i] = rng.Intn(15) - 7
+		}
+		g := rng.Intn(8) // 0..7 games -> brute path, exact ground truth
+		var pairs [][2]int
+		for range g {
+			x, y := rng.Intn(n), rng.Intn(n)
+			if x != y {
+				pairs = append(pairs, [2]int{x, y})
+			}
+		}
+		st, unf := makeDivision(points, spreads, pairs)
+		brute := CalculatePossibleRanks(st, unf) // small division => exact brute
+		games := toGamePairs(st, unf)
+		fg := newFlowGraph(2 + len(games) + n)
+		candIdx := initSlice(n, -1)
+		for p := range n {
+			gi := decomposeGames(p, n, games)
+			w := worstRankForPlayer(p, st, gi, fg, candIdx)
+			switch {
+			case w < brute[p].WorstRank:
+				unsound++
+				if unsound <= 5 {
+					t.Errorf("case %d player %d: B&B worst %d < brute worst %d (UNSOUND)\n st=%+v\n unf=%+v",
+						c, p, w, brute[p].WorstRank, st, unf)
+				}
+			case w > brute[p].WorstRank:
+				loose++
+			}
+		}
+	}
+	if unsound > 0 {
+		t.Fatalf("%d unsound worst-rank B&B bounds vs brute", unsound)
+	}
+	t.Logf("worst-rank B&B vs brute over %d cases: 0 unsound, %d loose", cases, loose)
+}
+
 // --- Fourier-Motzkin feasibility (the oracle's joint-margin engine) ---
 //
 // oracleRanks asks, per leaf, whether a subset of points-tied players can be

--- a/pkg/league/rank_bounds_oracle_test.go
+++ b/pkg/league/rank_bounds_oracle_test.go
@@ -174,6 +174,10 @@ func oracleRanks(st []standingInfo, unf []unfinishedGame) []RankBounds {
 
 func oracleLeaf(st []standingInfo, pts []int, spcoef [][]int64, g int, best, worst []int) {
 	n := len(st)
+	baseSpread := make([]int, n)
+	for i := range st {
+		baseSpread[i] = st[i].spread
+	}
 	for p := range n {
 		above := 0
 		var tied []int
@@ -190,8 +194,8 @@ func oracleLeaf(st []standingInfo, pts []int, spcoef [][]int64, g int, best, wor
 		}
 		// maxGE: most tied players that can simultaneously be at-or-above P on
 		// spread (spr_q - spr_p >= 0); maxLE: most that can be at-or-below.
-		maxGE := maxFeasibleSubset(st, spcoef, g, tied, p, true)
-		maxLE := maxFeasibleSubset(st, spcoef, g, tied, p, false)
+		maxGE := maxFeasibleSubset(baseSpread, spcoef, g, tied, p, true)
+		maxLE := maxFeasibleSubset(baseSpread, spcoef, g, tied, p, false)
 		lo := 1 + above + (len(tied) - maxLE) // min strictly-above
 		hi := 1 + above + maxGE               // max at-or-above (block worst)
 		if lo < best[p] {
@@ -201,144 +205,6 @@ func oracleLeaf(st []standingInfo, pts []int, spcoef [][]int64, g int, best, wor
 			worst[p] = hi
 		}
 	}
-}
-
-// maxFeasibleSubset returns the size of the largest subset S of tied such that
-// "spr_q >= spr_p for all q in S" (ge) or "spr_q <= spr_p for all q in S" (!ge)
-// is jointly feasible over the game margins. Feasibility is downward-closed, so
-// any feasible S of a given size means all smaller subsets are feasible too.
-func maxFeasibleSubset(st []standingInfo, spcoef [][]int64, g int, tied []int, p int, ge bool) int {
-	k := len(tied)
-	best := 0
-	for mask := range 1 << k {
-		size := bits.OnesCount(uint(mask))
-		if size <= best {
-			continue
-		}
-		ineqs := make([]fmIneq, 0, size)
-		for bi := range k {
-			if mask&(1<<bi) == 0 {
-				continue
-			}
-			q := tied[bi]
-			coef := make([]int64, g)
-			var c int64
-			if ge {
-				for j := range g {
-					coef[j] = spcoef[q][j] - spcoef[p][j]
-				}
-				c = int64(st[q].spread - st[p].spread)
-			} else {
-				for j := range g {
-					coef[j] = spcoef[p][j] - spcoef[q][j]
-				}
-				c = int64(st[p].spread - st[q].spread)
-			}
-			ineqs = append(ineqs, fmIneq{coef: coef, c: c})
-		}
-		if fmFeasible(ineqs, g) {
-			best = size
-		}
-	}
-	return best
-}
-
-// fmIneq is the linear inequality sum_i coef[i]*x[i] + c >= 0.
-type fmIneq struct {
-	coef []int64
-	c    int64
-}
-
-// fmFeasible reports whether {ineqs, x_i >= 1 for all i} has a real solution,
-// via Fourier-Motzkin elimination with exact integer arithmetic.
-func fmFeasible(ineqs []fmIneq, nv int) bool {
-	sys := make([]fmIneq, 0, len(ineqs)+nv)
-	for _, q := range ineqs {
-		cf := make([]int64, nv)
-		copy(cf, q.coef)
-		sys = append(sys, fmIneq{coef: cf, c: q.c})
-	}
-	for i := range nv {
-		cf := make([]int64, nv)
-		cf[i] = 1
-		sys = append(sys, fmIneq{coef: cf, c: -1}) // x_i >= 1
-	}
-	for j := nv - 1; j >= 0; j-- {
-		var pos, neg, next []fmIneq
-		for _, q := range sys {
-			switch {
-			case q.coef[j] > 0:
-				pos = append(pos, q)
-			case q.coef[j] < 0:
-				neg = append(neg, q)
-			default:
-				next = append(next, q)
-			}
-		}
-		for _, p := range pos {
-			for _, q := range neg {
-				a := p.coef[j]
-				b := -q.coef[j] // both > 0; combo a*q + b*p cancels x_j
-				cf := make([]int64, nv)
-				for i := range nv {
-					cf[i] = a*q.coef[i] + b*p.coef[i]
-				}
-				ni := fmIneq{coef: cf, c: a*q.c + b*p.c}
-				reduceIneq(&ni)
-				if ni.allZero() {
-					if ni.c < 0 {
-						return false
-					}
-					continue
-				}
-				next = append(next, ni)
-			}
-		}
-		sys = next
-	}
-	for _, q := range sys {
-		if q.c < 0 {
-			return false
-		}
-	}
-	return true
-}
-
-func (q fmIneq) allZero() bool {
-	for _, v := range q.coef {
-		if v != 0 {
-			return false
-		}
-	}
-	return true
-}
-
-func reduceIneq(q *fmIneq) {
-	var g int64
-	for _, v := range q.coef {
-		g = gcd64(g, abs64(v))
-	}
-	g = gcd64(g, abs64(q.c))
-	if g > 1 {
-		for i := range q.coef {
-			q.coef[i] /= g
-		}
-		q.c /= g
-	}
-}
-
-func gcd64(a, b int64) int64 {
-	for b != 0 {
-		a, b = b, a%b
-	}
-	return a
-}
-
-func abs64(a int64) int64 {
-	if a < 0 {
-		return -a
-	}
-	return a
 }
 
 // --- test helpers ---
@@ -494,4 +360,211 @@ func TestOracleVsBruteSanity(t *testing.T) {
 		}
 	}
 	t.Logf("oracle vs brute over %d cases: tighter=%d (joint-margin target), wider=%d (brute unsoundness)", cases, tighter, wider)
+}
+
+// TestBruteJointExact confirms the production brute (after the joint-margin fix)
+// now matches the exact oracle on random small divisions -- the per-pair
+// looseness is gone.
+func TestBruteJointExact(t *testing.T) {
+	rng := rand.New(rand.NewSource(77777))
+	const cases = 500
+	for c := range cases {
+		n := 3 + rng.Intn(4) // 3..6
+		points := make([]int, n)
+		spreads := make([]int, n)
+		for i := range n {
+			points[i] = rng.Intn(5)
+			spreads[i] = rng.Intn(11) - 5
+		}
+		g := rng.Intn(5) // 0..4 games -> brute path (cluster <= bruteForceThreshold)
+		var pairs [][2]int
+		for range g {
+			x, y := rng.Intn(n), rng.Intn(n)
+			if x != y {
+				pairs = append(pairs, [2]int{x, y})
+			}
+		}
+		st, unf := makeDivision(points, spreads, pairs)
+		if got, want := CalculatePossibleRanks(st, unf), oracleRanks(st, unf); !eqBounds(got, want) {
+			t.Fatalf("case %d: brute=%v oracle=%v\n  st=%+v\n  unf=%+v", c, got, want, st, unf)
+		}
+	}
+}
+
+// TestBruteJointVsExhaustive confirms the production brute matches the
+// indisputable exhaustive integer-margin truth on random tiny divisions.
+func TestBruteJointVsExhaustive(t *testing.T) {
+	rng := rand.New(rand.NewSource(88888))
+	for c := range 250 {
+		n := 3 + rng.Intn(2) // 3 or 4
+		points := make([]int, n)
+		spreads := make([]int, n)
+		for i := range n {
+			points[i] = rng.Intn(4)
+			spreads[i] = rng.Intn(9) - 4
+		}
+		g := rng.Intn(4) // 0..3
+		var pairs [][2]int
+		for range g {
+			x, y := rng.Intn(n), rng.Intn(n)
+			if x != y {
+				pairs = append(pairs, [2]int{x, y})
+			}
+		}
+		st, unf := makeDivision(points, spreads, pairs)
+		if got, want := CalculatePossibleRanks(st, unf), exhaustiveRanks(st, unf, 16); !eqBounds(got, want) {
+			t.Fatalf("case %d: brute=%v exhaustive=%v\n  st=%+v\n  unf=%+v", c, got, want, st, unf)
+		}
+	}
+}
+
+// --- Fourier-Motzkin feasibility (the oracle's joint-margin engine) ---
+//
+// oracleRanks asks, per leaf, whether a subset of points-tied players can be
+// jointly ordered at/above (or at/below) P on spread. That is exact linear
+// feasibility over the game margins; we solve it by Fourier-Motzkin elimination
+// with integer arithmetic. This is the INDEPENDENT method that validates the
+// production closed-form (jointFixedTied) -- kept in the test, not production.
+
+// fmIneq is the linear inequality sum_i coef[i]*x[i] + c >= 0.
+type fmIneq struct {
+	coef []int64
+	c    int64
+}
+
+func (q fmIneq) allZero() bool {
+	for _, v := range q.coef {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// fmFeasible reports whether {ineqs, x_i >= 1 for all i} has a real solution,
+// via Fourier-Motzkin elimination with exact integer arithmetic. Margins are
+// integers >= 1; the systems arising here are integral, so real feasibility
+// coincides with integer feasibility (validated against exhaustive enumeration
+// in TestOracleVsExhaustive).
+func fmFeasible(ineqs []fmIneq, nv int) bool {
+	sys := make([]fmIneq, 0, len(ineqs)+nv)
+	for _, q := range ineqs {
+		cf := make([]int64, nv)
+		copy(cf, q.coef)
+		sys = append(sys, fmIneq{coef: cf, c: q.c})
+	}
+	for i := range nv {
+		cf := make([]int64, nv)
+		cf[i] = 1
+		sys = append(sys, fmIneq{coef: cf, c: -1}) // x_i >= 1
+	}
+	for j := nv - 1; j >= 0; j-- {
+		var pos, neg, next []fmIneq
+		for _, q := range sys {
+			switch {
+			case q.coef[j] > 0:
+				pos = append(pos, q)
+			case q.coef[j] < 0:
+				neg = append(neg, q)
+			default:
+				next = append(next, q)
+			}
+		}
+		for _, p := range pos {
+			for _, q := range neg {
+				a := p.coef[j]
+				b := -q.coef[j] // both > 0; combo a*q + b*p cancels x_j
+				cf := make([]int64, nv)
+				for i := range nv {
+					cf[i] = a*q.coef[i] + b*p.coef[i]
+				}
+				ni := fmIneq{coef: cf, c: a*q.c + b*p.c}
+				reduceIneq(&ni)
+				if ni.allZero() {
+					if ni.c < 0 {
+						return false
+					}
+					continue
+				}
+				next = append(next, ni)
+			}
+		}
+		sys = next
+	}
+	for _, q := range sys {
+		if q.c < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func reduceIneq(q *fmIneq) {
+	var g int64
+	for _, v := range q.coef {
+		g = gcd64(g, abs64(v))
+	}
+	g = gcd64(g, abs64(q.c))
+	if g > 1 {
+		for i := range q.coef {
+			q.coef[i] /= g
+		}
+		q.c /= g
+	}
+}
+
+func gcd64(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func abs64(a int64) int64 {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+// maxFeasibleSubset returns the size of the largest subset S of tied such that
+// "spr_q >= spr_p for all q in S" (ge) or "spr_q <= spr_p for all q in S"
+// (!ge) is jointly feasible over the game margins. baseSpread[i] is player i's
+// current spread; spcoef[i][j] is the coefficient of margin variable j in i's
+// final spread for the current leaf. Feasibility is downward-closed in S, so
+// the largest feasible subset bounds the count.
+func maxFeasibleSubset(baseSpread []int, spcoef [][]int64, g int, tied []int, p int, ge bool) int {
+	k := len(tied)
+	best := 0
+	for mask := range 1 << k {
+		size := bits.OnesCount(uint(mask))
+		if size <= best {
+			continue
+		}
+		ineqs := make([]fmIneq, 0, size)
+		for bi := range k {
+			if mask&(1<<bi) == 0 {
+				continue
+			}
+			q := tied[bi]
+			coef := make([]int64, g)
+			var c int64
+			if ge {
+				for j := range g {
+					coef[j] = spcoef[q][j] - spcoef[p][j]
+				}
+				c = int64(baseSpread[q] - baseSpread[p])
+			} else {
+				for j := range g {
+					coef[j] = spcoef[p][j] - spcoef[q][j]
+				}
+				c = int64(baseSpread[p] - baseSpread[q])
+			}
+			ineqs = append(ineqs, fmIneq{coef: coef, c: c})
+		}
+		if fmFeasible(ineqs, g) {
+			best = size
+		}
+	}
+	return best
 }

--- a/pkg/league/rank_bounds_oracle_test.go
+++ b/pkg/league/rank_bounds_oracle_test.go
@@ -471,6 +471,60 @@ func TestRankBoundsWorstBnBSoundVsBrute(t *testing.T) {
 	t.Logf("worst-rank B&B vs brute over %d cases: 0 unsound, %d loose", cases, loose)
 }
 
+// TestRankBoundsBestInversionSoundVsBrute validates best-rank via the loss-score
+// inversion (best = n+1 - worst on the mirror) against the exact brute on random
+// small divisions. The inverted bound must be SOUND -- never tighter than the
+// exact best rank (bestViaInversion <= brute.best). The mirror's constant offset
+// CalculateExpectedGamesPerPlayer cancels in every pairwise comparison, and the
+// win/draw/loss dynamics map to +0/+1/+2 loss-score, so the inversion is exact
+// regardless of that constant. Reports how often it is merely loose.
+func TestRankBoundsBestInversionSoundVsBrute(t *testing.T) {
+	rng := rand.New(rand.NewSource(24680))
+	const cases = 3000
+	unsound, loose := 0, 0
+	for c := range cases {
+		n := 3 + rng.Intn(5) // 3..7
+		points := make([]int, n)
+		spreads := make([]int, n)
+		for i := range n {
+			points[i] = rng.Intn(7)
+			spreads[i] = rng.Intn(15) - 7
+		}
+		g := rng.Intn(8) // 0..7 games -> brute path, exact ground truth
+		var pairs [][2]int
+		for range g {
+			x, y := rng.Intn(n), rng.Intn(n)
+			if x != y {
+				pairs = append(pairs, [2]int{x, y})
+			}
+		}
+		st, unf := makeDivision(points, spreads, pairs)
+		brute := CalculatePossibleRanks(st, unf) // small division => exact brute
+		games := toGamePairs(st, unf)
+		mir := mirrorForBest(st)
+		fg := newFlowGraph(2 + len(games) + n)
+		candIdx := initSlice(n, -1)
+		for p := range n {
+			gi := decomposeGames(p, n, games)
+			b := bestViaInversion(p, mir, gi, fg, candIdx)
+			switch {
+			case b > brute[p].BestRank:
+				unsound++
+				if unsound <= 5 {
+					t.Errorf("case %d player %d: inversion best %d > brute best %d (UNSOUND)\n st=%+v\n unf=%+v",
+						c, p, b, brute[p].BestRank, st, unf)
+				}
+			case b < brute[p].BestRank:
+				loose++
+			}
+		}
+	}
+	if unsound > 0 {
+		t.Fatalf("%d unsound best-rank inversion bounds vs brute", unsound)
+	}
+	t.Logf("best-rank inversion vs brute over %d cases: 0 unsound, %d loose", cases, loose)
+}
+
 // --- Fourier-Motzkin feasibility (the oracle's joint-margin engine) ---
 //
 // oracleRanks asks, per leaf, whether a subset of points-tied players can be

--- a/pkg/league/rank_bounds_pinpoint_test.go
+++ b/pkg/league/rank_bounds_pinpoint_test.go
@@ -1,0 +1,272 @@
+package league
+
+// Phase-3 pinpoint: from the replay data, find one state where the maxflow
+// heuristic (CalculatePossibleRanks, used when a cluster has >bruteForceThreshold
+// games) returns an OVER-TIGHT bound versus the exact brute-force oracle, then
+// delta-debug-minimize it to the smallest standings+games that still fail. The
+// printed case becomes a synthetic, data-free unit test for the fix.
+//
+// Env-gated like the replay test; never runs on CI.
+
+import (
+	"os"
+	"sort"
+	"testing"
+)
+
+func sortStandings(s []standingInfo) {
+	sort.SliceStable(s, func(i, j int) bool {
+		if s[i].points != s[j].points {
+			return s[i].points > s[j].points
+		}
+		if s[i].spread != s[j].spread {
+			return s[i].spread > s[j].spread
+		}
+		return s[i].userID < s[j].userID
+	})
+}
+
+// feasLimit caps the oracle's 3^games enumeration. The starting state must have
+// its largest cluster in (bruteForceThreshold, feasLimit], i.e. maxflow is used
+// yet exact brute is still cheap.
+const pinpointFeasLimit = 12
+
+func toGamePairs(st []standingInfo, unf []unfinishedGame) []gamePair {
+	idx := make(map[int32]int, len(st))
+	for i, s := range st {
+		idx[s.userID] = i
+	}
+	var g []gamePair
+	for _, u := range unf {
+		a, okA := idx[u.player0ID]
+		b, okB := idx[u.player1ID]
+		if okA && okB {
+			g = append(g, gamePair{a, b})
+		}
+	}
+	return g
+}
+
+// overTightPlayer returns the index of a player whose maxflow bound is tighter
+// than the exact bound (best too high or worst too low), or -1. Requires the
+// largest cluster in (bruteForceThreshold, feasLimit] so maxflow is exercised
+// and the oracle is affordable.
+func overTightPlayer(st []standingInfo, unf []unfinishedGame) int {
+	games := toGamePairs(st, unf)
+	clusters := buildBruteForceClusters(st, games)
+	mc := maxClusterGames(clusters)
+	if mc <= bruteForceThreshold || mc > pinpointFeasLimit {
+		return -1
+	}
+	exact := bruteForceRanksFromClusters(clusters, st, games)
+	maxf := CalculatePossibleRanks(st, unf)
+	for i := range st {
+		if maxf[i].BestRank > exact[i].BestRank || maxf[i].WorstRank < exact[i].WorstRank {
+			return i
+		}
+	}
+	return -1
+}
+
+func countGamesOf(id int32, unf []unfinishedGame) int {
+	c := 0
+	for _, u := range unf {
+		if u.player0ID == id || u.player1ID == id {
+			c++
+		}
+	}
+	return c
+}
+
+func withoutGame(st []standingInfo, unf []unfinishedGame, gi int) ([]standingInfo, []unfinishedGame) {
+	g := unf[gi]
+	newUnf := make([]unfinishedGame, 0, len(unf)-1)
+	newUnf = append(newUnf, unf[:gi]...)
+	newUnf = append(newUnf, unf[gi+1:]...)
+	newSt := make([]standingInfo, len(st))
+	copy(newSt, st)
+	for i := range newSt {
+		if newSt[i].userID == g.player0ID || newSt[i].userID == g.player1ID {
+			newSt[i].gamesRemaining--
+		}
+	}
+	return newSt, newUnf
+}
+
+func withoutPlayer(st []standingInfo, pi int) []standingInfo {
+	newSt := make([]standingInfo, 0, len(st)-1)
+	newSt = append(newSt, st[:pi]...)
+	newSt = append(newSt, st[pi+1:]...)
+	return newSt
+}
+
+// minimizeCase greedily removes games (decrementing gamesRemaining) and
+// zero-game players while an over-tight player still exists.
+func minimizeCase(st []standingInfo, unf []unfinishedGame) ([]standingInfo, []unfinishedGame) {
+	for changed := true; changed; {
+		changed = false
+		for i := range unf {
+			cst, cunf := withoutGame(st, unf, i)
+			if overTightPlayer(cst, cunf) >= 0 {
+				st, unf = cst, cunf
+				changed = true
+				break
+			}
+		}
+		if changed {
+			continue
+		}
+		for i := range st {
+			if countGamesOf(st[i].userID, unf) != 0 {
+				continue
+			}
+			cst := withoutPlayer(st, i)
+			if overTightPlayer(cst, unf) >= 0 {
+				st = cst
+				changed = true
+				break
+			}
+		}
+	}
+	return st, unf
+}
+
+func TestRankBoundsPinpoint(t *testing.T) {
+	path := os.Getenv("LEAGUE_REPLAY_CSV")
+	if path == "" {
+		t.Skip("set LEAGUE_REPLAY_CSV to the exported league-all.csv to run")
+	}
+	played, unplayed, order := loadSchedule(t, path)
+
+	// Scan for the first over-tight maxflow state.
+	var foundSt []standingInfo
+	var foundUnf []unfinishedGame
+	found := false
+	for _, k := range order {
+		if found {
+			break
+		}
+		scanDivision(played[k], unplayed[k], func(st []standingInfo, unf []unfinishedGame) bool {
+			if overTightPlayer(st, unf) >= 0 {
+				foundSt, foundUnf = st, unf
+				found = true
+				return true // stop
+			}
+			return false
+		})
+	}
+	if !found {
+		t.Skip("no over-tight maxflow state found within feasLimit; raise pinpointFeasLimit")
+	}
+
+	t.Logf("starting case: n=%d games=%d", len(foundSt), len(foundUnf))
+	st, unf := minimizeCase(foundSt, foundUnf)
+	printCase(t, st, unf)
+	t.Fatalf("minimal over-tight maxflow case: n=%d games=%d (see log above)", len(st), len(unf))
+}
+
+// scanDivision walks a division's played prefix, invoking visit with the
+// (sorted standings, remaining games) at each snapshot; stops early if visit
+// returns true. Mirrors replayDivision's state construction.
+func scanDivision(played []replayGame, unplayed []unfinishedGame, visit func([]standingInfo, []unfinishedGame) bool) {
+	var players []int32
+	seen := map[int32]bool{}
+	totalGP := map[int32]int{}
+	add := func(p int32) {
+		if !seen[p] {
+			seen[p] = true
+			players = append(players, p)
+		}
+		totalGP[p]++
+	}
+	for _, g := range played {
+		add(g.p0)
+		add(g.p1)
+	}
+	for _, u := range unplayed {
+		add(u.player0ID)
+		add(u.player1ID)
+	}
+	n := len(players)
+	expected := CalculateExpectedGamesPerPlayer(n)
+	for _, p := range players {
+		if totalGP[p] != expected {
+			return
+		}
+	}
+
+	type acc struct{ wins, draws, spread int }
+	st := make(map[int32]*acc, n)
+	playedCnt := make(map[int32]int, n)
+	for _, p := range players {
+		st[p] = &acc{}
+	}
+	for k := 0; k <= len(played); k++ {
+		standings := make([]standingInfo, 0, n)
+		for _, p := range players {
+			a := st[p]
+			standings = append(standings, standingInfo{
+				userID:         p,
+				points:         a.wins*2 + a.draws,
+				spread:         a.spread,
+				gamesRemaining: totalGP[p] - playedCnt[p],
+			})
+		}
+		sortStandings(standings)
+		unf := make([]unfinishedGame, 0, len(unplayed)+len(played)-k)
+		unf = append(unf, unplayed...)
+		for _, g := range played[k:] {
+			unf = append(unf, unfinishedGame{player0ID: g.p0, player1ID: g.p1})
+		}
+		if visit(standings, unf) {
+			return
+		}
+		if k < len(played) {
+			g := played[k]
+			playedCnt[g.p0]++
+			playedCnt[g.p1]++
+			st[g.p0].spread += g.s0 - g.s1
+			st[g.p1].spread += g.s1 - g.s0
+			switch g.result {
+			case 1:
+				st[g.p0].wins++
+			case -1:
+				st[g.p1].wins++
+			default:
+				st[g.p0].draws++
+				st[g.p1].draws++
+			}
+		}
+	}
+}
+
+func printCase(t *testing.T, st []standingInfo, unf []unfinishedGame) {
+	remap := make(map[int32]int32, len(st))
+	for i, s := range st {
+		remap[s.userID] = int32(i + 1)
+	}
+	t.Log("standings := []standingInfo{")
+	for _, s := range st {
+		t.Logf("\tsi(%d, %d, %d, %d),", remap[s.userID], s.points, s.spread, s.gamesRemaining)
+	}
+	t.Log("}")
+	t.Log("games := []unfinishedGame{")
+	for _, u := range unf {
+		t.Logf("\tuf(%d, %d),", remap[u.player0ID], remap[u.player1ID])
+	}
+	t.Log("}")
+
+	games := toGamePairs(st, unf)
+	clusters := buildBruteForceClusters(st, games)
+	exact := bruteForceRanksFromClusters(clusters, st, games)
+	maxf := CalculatePossibleRanks(st, unf)
+	for i := range st {
+		tag := ""
+		if maxf[i].BestRank > exact[i].BestRank || maxf[i].WorstRank < exact[i].WorstRank {
+			tag = "  <-- OVER-TIGHT"
+		}
+		t.Logf("player %d (pts=%d spread=%d gr=%d): maxflow %d-%d  exact %d-%d%s",
+			remap[st[i].userID], st[i].points, st[i].spread, st[i].gamesRemaining,
+			maxf[i].BestRank, maxf[i].WorstRank, exact[i].BestRank, exact[i].WorstRank, tag)
+	}
+}


### PR DESCRIPTION
## Summary
Rewrites the league possible-rank bounds (the "can finish between rank X and Y" range in standings) to be exact, fixing a monotonicity bug where the range could widen as more games completed. Fix-only; 6 files, all rank-bounds.

## Bug
The prior bounds used a per-pair / greedy-eviction approximation. As games finished, the computed worst rank could get *looser* -- the possible-rank range widened instead of narrowing, which a correct bound can never do. The monotonicity-replay harness surfaced 1220 such violations under the old approximation.

## Approach (tiered, exact)
- joint-margin **exact** brute for small clusters (`bruteForceThreshold` 10), replacing the per-pair approximation
- exact **branch-and-bound** worst-rank eviction (replaces greedy)
- best rank by **loss-score inversion** of the worst-rank computation
- max-flow tier **gated per cluster** on a local candidate count
- per-leaf counting-sort speedup for the brute tier

## Guarantees
Bounds are now sound and monotonic (the range only narrows as games complete). Validated by an independent exact **oracle**, exhaustive small-field block enumeration, and a **monotonicity-replay** harness that replays a division's completed-game history and checks the range only ever tightens: **1220 -> 0** violations, with final bounds matching the actual final standings.

## Test plan
- [x] `go build ./pkg/league/`
- [x] `go test ./pkg/league/` rank-bounds suite (oracle-vs-exhaustive, brute joint exact, worst-B&B sound-vs-brute, best-inversion sound-vs-brute, monotonic replay, pinpoint) -- all pass
- [x] `gofmt -l` clean
- [ ] `go test ./pkg/league/ -race` (CI)

## Notes
Design and tier tradeoffs are documented in `pkg/league/rank_bounds_design.md`.
