### PR TITLE
show unseen tile count to spectators with hidden racks

### DIFF
--- a/liwords-ui/src/gameroom/pool.tsx
+++ b/liwords-ui/src/gameroom/pool.tsx
@@ -69,6 +69,7 @@ function getPoolCount(
 
 type Props = {
   omitCard?: boolean;
+  tilesHidden?: boolean;
   pool: poolType;
   poolFormat: PoolFormatType;
   setPoolFormat: (format: PoolFormatType) => void;
@@ -177,7 +178,16 @@ const ActualPool = React.memo((props: Props & { hidePool: boolean }) => {
   const inbag = Math.max(unseen - 7, 0);
 
   let title: string;
-  if (inbag === 0) {
+  if (props.tilesHidden) {
+    // When tiles are hidden -- a spectator of a censored game (correspondence,
+    // league, or a private-analysis tournament; see pkg/bus/event_sanitizer.go)
+    // receives blanked racks -- the pool is every unseen tile, both players'
+    // racks plus the bag, so it can't be split into "in bag": subtracting one
+    // 7-tile rack is meaningless when the viewer holds no rack of their own.
+    // Report the unseen total, which matches the tiles listed below. A player
+    // always has their own rack, so this branch never applies to them.
+    title = `${singularCount(unseen, "tile", "tiles")} unseen`;
+  } else if (inbag === 0) {
     title = `Opponent has ${singularCount(unseen, "tile", "tiles")}`;
   } else {
     title = `${singularCount(inbag, "tile", "tiles")} in bag`;

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -1368,6 +1368,7 @@ export const Table = React.memo((props: Props) => {
           <Pool
             pool={examinableGameContext?.pool}
             currentRack={sortedRack}
+            tilesHidden={!us && !gameDone && sortedRack.length === 0}
             poolFormat={poolFormat}
             setPoolFormat={setPoolFormat}
             alphabet={alphabet}


### PR DESCRIPTION
## Summary
The pool card labeled the unseen-tile count "Opponent has N" at endgame and "N tiles in bag" otherwise, both assuming the viewer holds one rack (their own). A spectator of a **censored** game -- correspondence, league, or a private-analysis tournament, where the server blanks both racks (`pkg/bus/event_sanitizer.go`) -- holds no rack, so the pool is every unseen tile (both racks + bag) and the "− 7 = bag" split is meaningless: e.g. 15 tiles shown but labeled "8 in bag".

Show "N tiles unseen" (matching the displayed tiles) only when the viewer is not a player, the game is live, and the rack data is blank -- exactly the server's censored-spectator case (`!us && !gameDone && sortedRack.length === 0`). A player always has their own rack, so no player-facing label ever changes.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean
- [ ] observe a censored game (league / correspondence / private-analysis tournament): pool title reads "N tiles unseen", matching the tile list (not "N in bag" / "Opponent has N")
- [ ] as a player (live, went-out, pre-deal): label unchanged
- [ ] observe a non-censored real-time game (racks visible): label unchanged
