### PR TITLE
restore red 'your turn' and condense correspondence game time display

### DIFF
--- a/liwords-ui/src/leagues/league_correspondence_games.tsx
+++ b/liwords-ui/src/leagues/league_correspondence_games.tsx
@@ -1,14 +1,11 @@
 import React, { useMemo } from "react";
 import { Card, Empty, Tooltip } from "antd";
-import { ClockCircleOutlined } from "@ant-design/icons";
 import { useNavigate } from "react-router";
 import { useQuery } from "@connectrpc/connect-query";
+import { CorrespondenceTurnIndicator } from "../shared/corres_turn_indicator";
 import { useLobbyStoreContext } from "../store/store";
 import { useLoginStateStoreContext } from "../store/store";
-import {
-  formatCoarseDuration,
-  onTurnCountdowns,
-} from "../utils/time_bank_calculator";
+import { onTurnCountdowns } from "../utils/time_bank_calculator";
 import { getPlayerLeagueH2H } from "../gen/api/proto/league_service/league_service-LeagueService_connectquery";
 import { H2HRecord } from "../gen/api/proto/league_service/league_service_pb";
 
@@ -139,23 +136,22 @@ export const LeagueCorrespondenceGames: React.FC<
 
           // Bank-aware countdowns for the on-turn player: before-expiry is the
           // hard deadline (per-turn allowance + bank - elapsed), before-bleed
-          // is the free-time window before the bank starts draining. Low-time
-          // and the bleeding warning flag off these rather than the bank-blind
-          // per-turn proxy.
+          // is the free-time window before the bank starts draining. The shared
+          // CorrespondenceTurnIndicator renders these (and the low-time /
+          // time-bank escalations) from the values below.
           const now = Date.now();
-          let isLowTime = false;
           let countdowns: ReturnType<typeof onTurnCountdowns> | undefined;
+          let hasTimeBank = false;
           if (game.playerOnTurn !== undefined && game.lastUpdate) {
             const timeElapsedSecs = (now - game.lastUpdate) / 1000;
             const bankSecs = (game.timeBank?.[game.playerOnTurn] ?? 0) / 1000;
+            hasTimeBank = bankSecs > 0;
             countdowns = onTurnCountdowns(
               game.incrementSecs,
               bankSecs,
               timeElapsedSecs,
             );
-            isLowTime = isUserTurn ? countdowns.beforeExpiry < 86400 : false;
           }
-          const isBleeding = countdowns ? countdowns.beforeBleed <= 0 : false;
 
           // Get opponent name and scores
           const userPlayerIndex = game.players.findIndex(
@@ -237,48 +233,14 @@ export const LeagueCorrespondenceGames: React.FC<
                     </span>
                   )}
                 </div>
-                {isUserTurn ? (
+                {(isUserTurn || countdowns) && (
                   <div className="turn-indicator-compact">
-                    {isLowTime && (
-                      <Tooltip title="Less than 24 hours remaining">
-                        <ClockCircleOutlined
-                          style={{ color: "#ff4d4f", marginRight: 4 }}
-                        />
-                      </Tooltip>
-                    )}
-                    <span className={isLowTime ? "low-time" : ""}>
-                      Your turn
-                    </span>
-                    {countdowns && (
-                      <span style={{ marginLeft: 6, opacity: 0.85 }}>
-                        {isBleeding ? (
-                          <Tooltip title="Per-turn time used; time bank is draining">
-                            bleeding, expires in{" "}
-                            {formatCoarseDuration(countdowns.beforeExpiry)}
-                          </Tooltip>
-                        ) : (
-                          <Tooltip title="Time until you time out (per-turn time + time bank)">
-                            expires in{" "}
-                            {formatCoarseDuration(countdowns.beforeExpiry)},
-                            free for{" "}
-                            {formatCoarseDuration(countdowns.beforeBleed)}
-                          </Tooltip>
-                        )}
-                      </span>
-                    )}
+                    <CorrespondenceTurnIndicator
+                      onTurn={!!isUserTurn}
+                      countdowns={countdowns}
+                      hasTimeBank={hasTimeBank}
+                    />
                   </div>
-                ) : (
-                  countdowns && (
-                    <div
-                      className="turn-indicator-compact"
-                      style={{ opacity: 0.55 }}
-                    >
-                      <Tooltip title="Opponent's clock (not your deadline)">
-                        Their turn (expires in{" "}
-                        {formatCoarseDuration(countdowns.beforeExpiry)})
-                      </Tooltip>
-                    </div>
-                  )
                 )}
               </div>
             </div>

--- a/liwords-ui/src/lobby/correspondence_games.tsx
+++ b/liwords-ui/src/lobby/correspondence_games.tsx
@@ -1,9 +1,5 @@
 import { Table, Tag, Tooltip } from "antd";
-import {
-  FundOutlined,
-  ClockCircleOutlined,
-  TrophyOutlined,
-} from "@ant-design/icons";
+import { FundOutlined, TrophyOutlined } from "@ant-design/icons";
 import React, {
   ReactNode,
   useCallback,
@@ -15,6 +11,7 @@ import { useNavigate } from "react-router";
 import { RatingBadge } from "./rating_badge";
 import { challengeFormat, PlayerDisplay, SoughtGames } from "./sought_games";
 import { ActiveGame, SoughtGame } from "../store/reducers/lobby_reducer";
+import { CorrespondenceTurnIndicator } from "../shared/corres_turn_indicator";
 import { VariantIcon } from "../shared/variant_icons";
 import { lexiconOrder, MatchLexiconDisplay } from "../shared/lexicon_display";
 import { useLoginStateStoreContext } from "../store/store";
@@ -26,7 +23,6 @@ import {
 } from "../gen/api/proto/ipc/omgwords_pb";
 import { useClient } from "../utils/hooks/connect";
 import {
-  formatCoarseDuration,
   OnTurnCountdowns,
   onTurnCountdowns,
 } from "../utils/time_bank_calculator";
@@ -141,25 +137,15 @@ export const CorrespondenceGames = (props: Props) => {
             onTurn = playerIndex === ag.playerOnTurn;
           }
 
-          // Determine turn indicator text
-          let turnIndicator = "";
-          if (ag.playerOnTurn === 0) {
-            turnIndicator =
-              ag.players[0]?.uuid === userID ? "Your turn" : "Opponent";
-          } else if (ag.playerOnTurn === 1) {
-            turnIndicator =
-              ag.players[1]?.uuid === userID ? "Your turn" : "Opponent";
-          }
-
           // Compute the bank-aware countdowns for whoever is on turn. The
-          // before-expiry value is the real time-remaining we sort and flag by
-          // (per-turn allowance + that player's remaining bank - elapsed); the
-          // before-bleed value is the free-time window before the bank starts
-          // draining. This replaces the old bank-blind `incrementSecs -
+          // before-expiry value is the real time-remaining we sort by (per-turn
+          // allowance + that player's remaining bank - elapsed); the shared
+          // CorrespondenceTurnIndicator renders it (and the low-time / time-bank
+          // escalations). This replaces the old bank-blind `incrementSecs -
           // elapsed` proxy, which sorted league games (which have banks) wrong.
           const now = Date.now();
           let timeRemainingSecs = Infinity;
-          let isLowTime = false;
+          let hasTimeBank = false;
           let countdowns: OnTurnCountdowns | undefined;
           if (
             ag.playerOnTurn !== undefined &&
@@ -168,56 +154,26 @@ export const CorrespondenceGames = (props: Props) => {
           ) {
             const timeElapsedSecs = (now - ag.lastUpdate) / 1000;
             const bankSecs = (ag.timeBank?.[ag.playerOnTurn] ?? 0) / 1000;
+            hasTimeBank = bankSecs > 0;
             countdowns = onTurnCountdowns(
               ag.incrementSecs,
               bankSecs,
               timeElapsedSecs,
             );
             timeRemainingSecs = countdowns.beforeExpiry;
-            isLowTime = timeRemainingSecs < 86400; // 24 hours in seconds
           }
-          const isBleeding = countdowns ? countdowns.beforeBleed <= 0 : false;
 
-          // Build the turn / countdown display. For the user's own turn we show
-          // their hard deadline (and a bleeding warning once the bank is being
-          // consumed); for the opponent's turn we show their deadline greyed,
-          // since it is not the user's clock.
-          let turnDisplay: ReactNode = turnIndicator;
-          if (countdowns) {
-            const expiryLabel = formatCoarseDuration(countdowns.beforeExpiry);
-            if (onTurn) {
-              turnDisplay = (
-                <span style={{ color: isLowTime ? "#ff4d4f" : undefined }}>
-                  {isLowTime && (
-                    <Tooltip title="Less than 24 hours remaining">
-                      <ClockCircleOutlined style={{ marginRight: 4 }} />
-                    </Tooltip>
-                  )}
-                  {turnIndicator}
-                  <span style={{ marginLeft: 6, opacity: 0.85 }}>
-                    {isBleeding ? (
-                      <Tooltip title="Per-turn time used; time bank is draining">
-                        bleeding, expires in {expiryLabel}
-                      </Tooltip>
-                    ) : (
-                      <Tooltip title="Time until you time out (per-turn time + time bank)">
-                        expires in {expiryLabel}, free for{" "}
-                        {formatCoarseDuration(countdowns.beforeBleed)}
-                      </Tooltip>
-                    )}
-                  </span>
-                </span>
-              );
-            } else {
-              turnDisplay = (
-                <span style={{ opacity: 0.55 }}>
-                  <Tooltip title="Opponent's clock (not your deadline)">
-                    {turnIndicator} (expires in {expiryLabel})
-                  </Tooltip>
-                </span>
-              );
-            }
-          }
+          // Condensed shared turn / countdown indicator: red "Your turn" with a
+          // coarse time inline and the full "expires in X, free for Y" detail in
+          // the tooltip; the opponent's clock is greyed since it is not the
+          // user's deadline.
+          const turnDisplay: ReactNode = (
+            <CorrespondenceTurnIndicator
+              onTurn={onTurn}
+              countdowns={countdowns}
+              hasTimeBank={hasTimeBank}
+            />
+          );
 
           return {
             gameID: ag.gameID,

--- a/liwords-ui/src/shared/corres_turn_indicator.tsx
+++ b/liwords-ui/src/shared/corres_turn_indicator.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { Tooltip } from "antd";
+import { ClockCircleOutlined, FieldTimeOutlined } from "@ant-design/icons";
+import {
+  OnTurnCountdowns,
+  formatCoarseDuration,
+  formatCoarseDurationShort,
+} from "../utils/time_bank_calculator";
+
+// "Your turn" is always shown in this red so a glance at the list (especially
+// on mobile) tells you which games need a move. The low-time and time-bank
+// escalations ride on icons rather than on toggling the red on and off -- that
+// toggling was the regression: the bank-aware deadline almost never dipped
+// under the 24h flag, so the red (which players relied on) effectively vanished.
+const YOUR_TURN_COLOR = "#ff4d4f";
+// Matches the in-game clock's time-bank color, so "draining your bank" reads
+// the same here as it does on the board.
+const TIME_BANK_COLOR = "#52c41a";
+// Under a day to a forced timeout: surface the urgency with a clock icon.
+const LOW_TIME_SECS = 86400;
+
+type Props = {
+  // Whether it is the logged-in user's turn in this game.
+  onTurn: boolean;
+  // Bank-aware countdowns for whoever is on turn; undefined when unknown.
+  countdowns?: OnTurnCountdowns;
+  // Whether the on-turn player still has time bank left to drain. Non-league
+  // correspondence games typically have no bank, so they never "bleed" -- they
+  // simply time out when the per-turn allowance runs out.
+  hasTimeBank?: boolean;
+};
+
+// Condensed turn / time indicator shared by the lobby correspondence list and
+// the league "My League Games" card. The inline text stays terse -- "Your turn"
+// (red) plus a single coarse time unit -- while the verbose "expires in X, free
+// for Y" detail lives in the tooltip.
+export const CorrespondenceTurnIndicator = (props: Props) => {
+  const { onTurn, countdowns, hasTimeBank } = props;
+
+  if (!onTurn) {
+    // Opponent's clock -- greyed, since it is not the user's deadline.
+    const short = countdowns
+      ? formatCoarseDurationShort(countdowns.beforeExpiry)
+      : null;
+    const tooltip = countdowns
+      ? `Opponent's clock (not your deadline). Times out in ${formatCoarseDuration(
+          countdowns.beforeExpiry,
+        )}.`
+      : "Opponent's turn.";
+    return (
+      <span className="corres-turn their-turn" style={{ opacity: 0.55 }}>
+        <Tooltip title={tooltip}>
+          Their turn
+          {short ? (
+            <span className="corres-turn-time" style={{ marginLeft: 6 }}>
+              {short}
+            </span>
+          ) : null}
+        </Tooltip>
+      </span>
+    );
+  }
+
+  // Only a game with bank still to spend can "bleed"; a no-bank correspondence
+  // game just times out when its per-turn allowance runs out.
+  const isBleeding =
+    !!countdowns && !!hasTimeBank && countdowns.beforeBleed <= 0;
+  const isLowTime = countdowns
+    ? countdowns.beforeExpiry < LOW_TIME_SECS
+    : false;
+  const short = countdowns
+    ? formatCoarseDurationShort(countdowns.beforeExpiry)
+    : null;
+  const tooltip = !countdowns
+    ? "Your turn."
+    : isBleeding
+      ? `Using your time bank -- times out in ${formatCoarseDuration(
+          countdowns.beforeExpiry,
+        )}.`
+      : hasTimeBank
+        ? `Times out in ${formatCoarseDuration(
+            countdowns.beforeExpiry,
+          )} (free for ${formatCoarseDuration(
+            countdowns.beforeBleed,
+          )} before your time bank starts draining).`
+        : `Times out in ${formatCoarseDuration(countdowns.beforeExpiry)}.`;
+
+  return (
+    <span className="corres-turn your-turn">
+      <Tooltip title={tooltip}>
+        {isBleeding ? (
+          <FieldTimeOutlined
+            className="corres-turn-icon"
+            style={{ color: TIME_BANK_COLOR, marginRight: 4 }}
+          />
+        ) : isLowTime ? (
+          <ClockCircleOutlined
+            className="corres-turn-icon"
+            style={{ color: YOUR_TURN_COLOR, marginRight: 4 }}
+          />
+        ) : null}
+        <span style={{ color: YOUR_TURN_COLOR }}>Your turn</span>
+        {short ? (
+          <span
+            className="corres-turn-time"
+            style={{ marginLeft: 6, opacity: 0.7 }}
+          >
+            {short}
+          </span>
+        ) : null}
+      </Tooltip>
+    </span>
+  );
+};

--- a/liwords-ui/src/utils/time_bank_calculator.test.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.test.ts
@@ -1,4 +1,9 @@
-import { formatCoarseDuration, onTurnCountdowns } from "./time_bank_calculator";
+import {
+  formatCoarseDuration,
+  formatCoarseDurationShort,
+  onTurnCountdowns,
+  pickNextCorresGame,
+} from "./time_bank_calculator";
 
 it("onTurnCountdowns: before per-turn allowance is spent, nothing bleeds", () => {
   // 1-day per-turn allowance, 2-day bank, 6h elapsed.
@@ -68,4 +73,72 @@ it("formatCoarseDuration: non-positive and non-finite render as 'now'", () => {
   expect(formatCoarseDuration(-100)).toBe("now");
   expect(formatCoarseDuration(Infinity)).toBe("now");
   expect(formatCoarseDuration(NaN)).toBe("now");
+});
+
+it("formatCoarseDurationShort: renders only the single largest unit", () => {
+  expect(formatCoarseDurationShort(2 * 86400 + 3 * 3600)).toBe("2d");
+  expect(formatCoarseDurationShort(5 * 3600 + 12 * 60)).toBe("5h");
+  expect(formatCoarseDurationShort(47 * 60 + 30)).toBe("47m");
+  expect(formatCoarseDurationShort(30)).toBe("30s");
+  expect(formatCoarseDurationShort(0)).toBe("now");
+  expect(formatCoarseDurationShort(-5)).toBe("now");
+  expect(formatCoarseDurationShort(Infinity)).toBe("now");
+});
+
+it("pickNextCorresGame: clicking Next once per game cycles through all and returns to the first", () => {
+  // Five on-turn games with distinct urgencies, supplied unsorted.
+  const candidates = [
+    { game: "c", gameID: "c", beforeExpiry: 300 },
+    { game: "a", gameID: "a", beforeExpiry: 100 },
+    { game: "e", gameID: "e", beforeExpiry: 500 },
+    { game: "b", gameID: "b", beforeExpiry: 200 },
+    { game: "d", gameID: "d", beforeExpiry: 400 },
+  ];
+  // Most-urgent-first order: a, b, c, d, e.
+  const order = ["a", "b", "c", "d", "e"];
+  let current = order[0];
+  const visited = [current];
+  for (let i = 0; i < order.length - 1; i++) {
+    const { next } = pickNextCorresGame(candidates, current);
+    expect(next).not.toBeNull();
+    current = next as string;
+    visited.push(current);
+  }
+  // Walked every on-turn game exactly once, in urgency order.
+  expect(visited).toEqual(order);
+  // The n-th click wraps back to the first.
+  expect(pickNextCorresGame(candidates, current).next).toBe("a");
+});
+
+it("pickNextCorresGame: waiting excludes the current game only when it is on turn", () => {
+  const candidates = [
+    { game: "a", gameID: "a", beforeExpiry: 100 },
+    { game: "b", gameID: "b", beforeExpiry: 200 },
+    { game: "c", gameID: "c", beforeExpiry: 300 },
+  ];
+  // Current game is itself on turn: it is excluded from the waiting count.
+  expect(pickNextCorresGame(candidates, "a").waiting).toBe(2);
+  // Current game is not on turn (opponent's move / different game): every
+  // on-turn game is waiting, and Next points at the most urgent.
+  const off = pickNextCorresGame(candidates, "not-on-turn");
+  expect(off.waiting).toBe(3);
+  expect(off.next).toBe("a");
+});
+
+it("pickNextCorresGame: a lone on-turn game (or none) has nowhere to cycle", () => {
+  const lone = [{ game: "a", gameID: "a", beforeExpiry: 100 }];
+  expect(pickNextCorresGame(lone, "a")).toEqual({ next: null, waiting: 0 });
+  expect(pickNextCorresGame([], "a")).toEqual({ next: null, waiting: 0 });
+});
+
+it("pickNextCorresGame: equal urgency is broken stably by gameID", () => {
+  const candidates = [
+    { game: "b", gameID: "b", beforeExpiry: 100 },
+    { game: "a", gameID: "a", beforeExpiry: 100 },
+    { game: "c", gameID: "c", beforeExpiry: 100 },
+  ];
+  // Deterministic cycle a -> b -> c -> a regardless of input order.
+  expect(pickNextCorresGame(candidates, "a").next).toBe("b");
+  expect(pickNextCorresGame(candidates, "b").next).toBe("c");
+  expect(pickNextCorresGame(candidates, "c").next).toBe("a");
 });

--- a/liwords-ui/src/utils/time_bank_calculator.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.ts
@@ -135,3 +135,95 @@ export function formatCoarseDuration(seconds: number): string {
   }
   return `${secs}s`;
 }
+
+/**
+ * Like formatCoarseDuration but renders only the single largest unit, for the
+ * compact at-a-glance time shown inline in the correspondence/league game
+ * lists. The full two-unit value (and the free-time window) belong in a
+ * tooltip. Examples: "2d", "5h", "47m", "30s", "now".
+ *
+ * Non-positive inputs render as "now" (the deadline has passed / is imminent).
+ */
+export function formatCoarseDurationShort(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "now";
+  }
+  const totalSeconds = Math.floor(seconds);
+  const days = Math.floor(totalSeconds / 86400);
+  if (days > 0) {
+    return `${days}d`;
+  }
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return `${totalSeconds % 60}s`;
+}
+
+export type NextCorresPick<T> = {
+  // The game to jump to next, or null when there is nowhere to cycle to.
+  next: T | null;
+  // How many OTHER on-turn games are waiting (excludes the current game when it
+  // is itself on turn). Drives the "(x)" count on the Next button.
+  waiting: number;
+};
+
+/**
+ * Pick the next on-turn correspondence game to jump to, cycling.
+ *
+ * The candidates are every game where it is the user's turn (the current game
+ * included if it is on turn). They are sorted by the bank-aware time-until-
+ * expiry (least first, gameID as a stable tiebreak) -- the same "most urgent
+ * first" order the correspondence/league lists use -- so this is the single
+ * source of truth shared by the in-game Next button and the gameroom's top-bar
+ * next-game cycler. Because the order is deterministic, clicking Next once per
+ * game walks every on-turn game exactly once and returns to the first after n
+ * clicks.
+ *
+ * The caller is expected to recompute this whenever the live correspondence-game
+ * set changes (e.g. a notification that another game became the user's turn), so
+ * the cycle stays current "as at last refresh".
+ */
+export function pickNextCorresGame<T>(
+  candidates: ReadonlyArray<{
+    game: T;
+    gameID: string;
+    beforeExpiry: number;
+  }>,
+  currentGameID: string | undefined,
+): NextCorresPick<T> {
+  const sorted = [...candidates].sort((a, b) => {
+    // Do not use a-b even if it should not overflow.
+    if (a.beforeExpiry < b.beforeExpiry) return -1;
+    if (a.beforeExpiry > b.beforeExpiry) return 1;
+    // Stable tiebreak so the cycle order is deterministic.
+    if (a.gameID < b.gameID) return -1;
+    if (a.gameID > b.gameID) return 1;
+    return 0;
+  });
+
+  const currentIndex = sorted.findIndex((c) => c.gameID === currentGameID);
+
+  if (currentIndex >= 0) {
+    // The current game is itself on the user's turn: advance to the next game
+    // in the cycle (null when this is the only on-turn game).
+    return {
+      next:
+        sorted.length > 1
+          ? sorted[(currentIndex + 1) % sorted.length].game
+          : null,
+      waiting: sorted.length - 1,
+    };
+  }
+
+  // The current game is not on the user's turn (opponent's move, a finished
+  // game, or a different game entirely): jump to the most urgent on-turn game.
+  return {
+    next: sorted.length > 0 ? sorted[0].game : null,
+    waiting: sorted.length,
+  };
+}


### PR DESCRIPTION
## Summary
Restores the red "Your turn" indicator and condenses the verbose time line in the lobby correspondence list and the league "My League Games" card, via a shared `CorrespondenceTurnIndicator` component.

## Root cause
The bank-aware deadline (#1860) almost never dips under the 24h low-time flag (a 10h/turn + multi-day bank game stays well above 24h), so "Your turn" stopped turning red. Players relied on that red to spot games needing a move. (The red was previously an accidental side effect of the old bank-blind `increment - elapsed < 24h`, which was effectively always true.)

## Changes
- "Your turn" is now always red on your turn; the clock icon (under 24h) and the green time-bank icon (bleeding) are separate escalations rather than toggling the red on/off.
- Condense the verbose "expires in X, free for Y" / "bleeding" line to a single coarse unit inline, moving the full detail to the tooltip; drop the alarming "bleeding" word for a time-bank icon.
- A no-bank (non-league) game never bleeds, so the time-bank treatment only shows when bank remains. Sorting is unchanged (bank-aware total-expiry).

## Test plan
- [x] `tsc --noEmit` clean
- [x] eslint clean (no new warnings)
- [x] `vitest` full suite passes
- [x] `npx prettier --write`
- [x] `npm run build`

Fixes a regression from #1860. Part of the UI feedback batch (#1877-#1881).
