### PR TITLE
show correspondence next button only in place of a dead play

### DIFF
--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -654,39 +654,39 @@ const GameControls = React.memo((props: Props) => {
           </Button>
         </div>
         {(() => {
-          // Correspondence-only "Next (x)" affordance. Puzzles never show it.
+          // Correspondence-only: when it is NOT the user's turn, the Play button
+          // is a dead disabled control, so show "Next" in its place to jump to
+          // the user's next on-turn game. This Next targets the exact same game
+          // as the top-bar next-game cycler (props.onNextCorresGame ->
+          // nextCorresGame in table.tsx), so the two always agree. Puzzles never
+          // show it. We never render Next beside a live Play -- doing so led
+          // players to misclick Next instead of Play.
           const showNext = !props.puzzleMode && !!props.hasNextCorresGame;
-          const nextButton = showNext ? (
-            <Button
-              type="primary"
-              className="play next-game"
-              onClick={props.onNextCorresGame}
-            >
-              <RightOutlined /> Next
-              {props.corresGamesWaiting && props.corresGamesWaiting > 1 ? (
-                <span className="next-game-count">
-                  ({props.corresGamesWaiting})
-                </span>
-              ) : null}
-            </Button>
-          ) : null;
-          // When it's not the user's turn, the Play button would be a dead
-          // disabled control. If a next game exists, show "Next" in its place.
           if (!props.myTurn && showNext) {
-            return nextButton;
-          }
-          return (
-            <React.Fragment>
+            return (
               <Button
                 type="primary"
-                className={showNext ? "play play-with-next" : "play"}
-                onClick={props.onCommit}
-                disabled={!props.myTurn || props.finalPassOrChallenge}
+                className="play next-game"
+                onClick={props.onNextCorresGame}
               >
-                {props.puzzleMode ? "Solve" : "Play"}
+                <RightOutlined /> Next
+                {props.corresGamesWaiting && props.corresGamesWaiting > 1 ? (
+                  <span className="next-game-count">
+                    ({props.corresGamesWaiting})
+                  </span>
+                ) : null}
               </Button>
-              {nextButton}
-            </React.Fragment>
+            );
+          }
+          return (
+            <Button
+              type="primary"
+              className="play"
+              onClick={props.onCommit}
+              disabled={!props.myTurn || props.finalPassOrChallenge}
+            >
+              {props.puzzleMode ? "Solve" : "Play"}
+            </Button>
           );
         })()}
       </div>

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -213,7 +213,6 @@ p.streak-loss {
     }
   }
 
-
   .analyzer-card {
     .ant-card-body {
       padding: 0;
@@ -2974,9 +2973,10 @@ p.rune {
       margin: 0 6px;
     }
 
-    // Correspondence-only "Next (x)" jump button. Sits beside Play (or in its
-    // place when it is not the user's turn). Keep it a compact, normal-height
-    // button rather than the big square Play uses on mobile.
+    // Correspondence-only "Next (x)" jump button. Shown only in place of a dead
+    // Play (when it is not the user's turn), never beside a live Play. Keep it a
+    // compact, normal-height button rather than the big square Play uses on
+    // mobile.
     &.play.next-game {
       min-width: auto;
       width: auto;
@@ -2986,14 +2986,6 @@ p.rune {
         margin-left: 4px;
         opacity: 0.7;
       }
-    }
-
-    // When Play is shown alongside Next, shrink it from the big mobile square
-    // to a compact button so both fit on one row.
-    &.play.play-with-next {
-      min-width: auto;
-      width: auto;
-      height: calc(($board-size-mobile / 8) - 9px);
     }
   }
 


### PR DESCRIPTION
## Summary
Stops showing the in-game "Next" button beside a live "Play" button.

## Root cause
#1866 rendered Play and Next side by side on your turn, both primary-blue and similar size; players kept clicking Next instead of Play, and on mobile the dual layout shrank Play to a tiny square.

## Changes
- Render the in-game Next button only when it is **not** the user's turn -- i.e. in place of the otherwise dead, disabled Play.
- On your turn the original single Play button (and its full-size mobile square) is restored unchanged.
- Remove the dual `play-with-next` layout and its now-unused styling.

## Test plan
- [x] `tsc --noEmit` clean
- [x] eslint clean (no new warnings)
- [x] `npx prettier --write`
- [x] `npm run build`

Fixes a regression from #1866. Part of the UI feedback batch (#1877-#1881). Followed up by #1882 (Next styled like Play on mobile).
