### PR TITLE
share the next-game picker between the next button and the cycler

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -99,7 +99,10 @@ import { MachineLetter, MachineWord } from "../utils/cwgame/common";
 import { create, toBinary } from "@bufbuild/protobuf";
 import { useTournamentCompetitorState } from "../hooks/use_tournament_competitor_state";
 import { showTurnNotification } from "../utils/notifications";
-import { onTurnCountdowns } from "../utils/time_bank_calculator";
+import {
+  onTurnCountdowns,
+  pickNextCorresGame,
+} from "../utils/time_bank_calculator";
 import { timeCtrlToDisplayName } from "../store/constants";
 
 type Props = {
@@ -1052,18 +1055,13 @@ export const Table = React.memo((props: Props) => {
       return { nextCorresGame: null, corresGamesWaiting: 0 };
     }
 
-    // Get all correspondence games where it's user's turn, including current game
-    const now = Date.now(); // Use the same reference time during iteration
-    // ("now" does not have to be Date.now(), it can be any const picked to minimize overflow)
-    const gamesOnMyTurn = corresGames
+    // Every game where it is the user's turn (current game included). "now"
+    // need not be Date.now(); any const that minimizes overflow works.
+    const now = Date.now();
+    const candidates = corresGames
       .filter((ag) => {
-        // Check if it's user's turn
         const playerIndex = ag.players.findIndex((p) => p.uuid === userID);
-        if (playerIndex === -1) {
-          return false;
-        }
-
-        return playerIndex === ag.playerOnTurn;
+        return playerIndex !== -1 && playerIndex === ag.playerOnTurn;
       })
       .map((ag) => {
         // Real time-until-expiry for the on-turn player (per-turn allowance +
@@ -1077,41 +1075,14 @@ export const Table = React.memo((props: Props) => {
           bankSecs,
           timeElapsedSecs,
         );
+        return { game: ag, gameID: ag.gameID, beforeExpiry };
+      });
 
-        return {
-          game: ag,
-          timeRemaining: beforeExpiry,
-        };
-      })
-      .sort((a, b) => {
-        // Do not use a-b even if it should not overflow
-        if (a.timeRemaining < b.timeRemaining) return -1;
-        if (a.timeRemaining > b.timeRemaining) return 1;
-        // Tiebreak to stabilize order (this may not be the same as the backend)
-        if (a.game.gameID < b.game.gameID) return -1;
-        if (a.game.gameID > b.game.gameID) return 1;
-        return 0;
-      }); // Sort by most urgent first
-
-    // This would exist if current game is on my turn.
-    const currentGameIndex = gamesOnMyTurn.findIndex(
-      (gomt) => gomt.game.gameID === gameID,
-    );
-
-    // If not on my turn (opponent's turn, completed game, others' game),
-    // next game is the first one that is on my turn.
-    return {
-      nextCorresGame:
-        currentGameIndex >= 0
-          ? gamesOnMyTurn.length > 1
-            ? gamesOnMyTurn[(currentGameIndex + 1) % gamesOnMyTurn.length].game
-            : null
-          : gamesOnMyTurn.length > 0
-            ? gamesOnMyTurn[0].game
-            : null,
-      corresGamesWaiting:
-        gamesOnMyTurn.length + (currentGameIndex >= 0 ? -1 : 0),
-    };
+    // Shared "next urgent, cycling" selection -- the same logic the gameroom
+    // top-bar next-game cycler and the in-game Next button both consume, so the
+    // two always point at the same game.
+    const { next, waiting } = pickNextCorresGame(candidates, gameID);
+    return { nextCorresGame: next, corresGamesWaiting: waiting };
   }, [gameInfo.gameRequest?.gameMode, userID, gameID, corresGames]);
 
   const handleNextCorresGame = useCallback(() => {

--- a/liwords-ui/src/utils/time_bank_calculator.test.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.test.ts
@@ -1,4 +1,9 @@
-import { formatCoarseDuration, onTurnCountdowns } from "./time_bank_calculator";
+import {
+  formatCoarseDuration,
+  formatCoarseDurationShort,
+  onTurnCountdowns,
+  pickNextCorresGame,
+} from "./time_bank_calculator";
 
 it("onTurnCountdowns: before per-turn allowance is spent, nothing bleeds", () => {
   // 1-day per-turn allowance, 2-day bank, 6h elapsed.
@@ -68,4 +73,72 @@ it("formatCoarseDuration: non-positive and non-finite render as 'now'", () => {
   expect(formatCoarseDuration(-100)).toBe("now");
   expect(formatCoarseDuration(Infinity)).toBe("now");
   expect(formatCoarseDuration(NaN)).toBe("now");
+});
+
+it("formatCoarseDurationShort: renders only the single largest unit", () => {
+  expect(formatCoarseDurationShort(2 * 86400 + 3 * 3600)).toBe("2d");
+  expect(formatCoarseDurationShort(5 * 3600 + 12 * 60)).toBe("5h");
+  expect(formatCoarseDurationShort(47 * 60 + 30)).toBe("47m");
+  expect(formatCoarseDurationShort(30)).toBe("30s");
+  expect(formatCoarseDurationShort(0)).toBe("now");
+  expect(formatCoarseDurationShort(-5)).toBe("now");
+  expect(formatCoarseDurationShort(Infinity)).toBe("now");
+});
+
+it("pickNextCorresGame: clicking Next once per game cycles through all and returns to the first", () => {
+  // Five on-turn games with distinct urgencies, supplied unsorted.
+  const candidates = [
+    { game: "c", gameID: "c", beforeExpiry: 300 },
+    { game: "a", gameID: "a", beforeExpiry: 100 },
+    { game: "e", gameID: "e", beforeExpiry: 500 },
+    { game: "b", gameID: "b", beforeExpiry: 200 },
+    { game: "d", gameID: "d", beforeExpiry: 400 },
+  ];
+  // Most-urgent-first order: a, b, c, d, e.
+  const order = ["a", "b", "c", "d", "e"];
+  let current = order[0];
+  const visited = [current];
+  for (let i = 0; i < order.length - 1; i++) {
+    const { next } = pickNextCorresGame(candidates, current);
+    expect(next).not.toBeNull();
+    current = next as string;
+    visited.push(current);
+  }
+  // Walked every on-turn game exactly once, in urgency order.
+  expect(visited).toEqual(order);
+  // The n-th click wraps back to the first.
+  expect(pickNextCorresGame(candidates, current).next).toBe("a");
+});
+
+it("pickNextCorresGame: waiting excludes the current game only when it is on turn", () => {
+  const candidates = [
+    { game: "a", gameID: "a", beforeExpiry: 100 },
+    { game: "b", gameID: "b", beforeExpiry: 200 },
+    { game: "c", gameID: "c", beforeExpiry: 300 },
+  ];
+  // Current game is itself on turn: it is excluded from the waiting count.
+  expect(pickNextCorresGame(candidates, "a").waiting).toBe(2);
+  // Current game is not on turn (opponent's move / different game): every
+  // on-turn game is waiting, and Next points at the most urgent.
+  const off = pickNextCorresGame(candidates, "not-on-turn");
+  expect(off.waiting).toBe(3);
+  expect(off.next).toBe("a");
+});
+
+it("pickNextCorresGame: a lone on-turn game (or none) has nowhere to cycle", () => {
+  const lone = [{ game: "a", gameID: "a", beforeExpiry: 100 }];
+  expect(pickNextCorresGame(lone, "a")).toEqual({ next: null, waiting: 0 });
+  expect(pickNextCorresGame([], "a")).toEqual({ next: null, waiting: 0 });
+});
+
+it("pickNextCorresGame: equal urgency is broken stably by gameID", () => {
+  const candidates = [
+    { game: "b", gameID: "b", beforeExpiry: 100 },
+    { game: "a", gameID: "a", beforeExpiry: 100 },
+    { game: "c", gameID: "c", beforeExpiry: 100 },
+  ];
+  // Deterministic cycle a -> b -> c -> a regardless of input order.
+  expect(pickNextCorresGame(candidates, "a").next).toBe("b");
+  expect(pickNextCorresGame(candidates, "b").next).toBe("c");
+  expect(pickNextCorresGame(candidates, "c").next).toBe("a");
 });

--- a/liwords-ui/src/utils/time_bank_calculator.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.ts
@@ -135,3 +135,95 @@ export function formatCoarseDuration(seconds: number): string {
   }
   return `${secs}s`;
 }
+
+/**
+ * Like formatCoarseDuration but renders only the single largest unit, for the
+ * compact at-a-glance time shown inline in the correspondence/league game
+ * lists. The full two-unit value (and the free-time window) belong in a
+ * tooltip. Examples: "2d", "5h", "47m", "30s", "now".
+ *
+ * Non-positive inputs render as "now" (the deadline has passed / is imminent).
+ */
+export function formatCoarseDurationShort(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "now";
+  }
+  const totalSeconds = Math.floor(seconds);
+  const days = Math.floor(totalSeconds / 86400);
+  if (days > 0) {
+    return `${days}d`;
+  }
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return `${totalSeconds % 60}s`;
+}
+
+export type NextCorresPick<T> = {
+  // The game to jump to next, or null when there is nowhere to cycle to.
+  next: T | null;
+  // How many OTHER on-turn games are waiting (excludes the current game when it
+  // is itself on turn). Drives the "(x)" count on the Next button.
+  waiting: number;
+};
+
+/**
+ * Pick the next on-turn correspondence game to jump to, cycling.
+ *
+ * The candidates are every game where it is the user's turn (the current game
+ * included if it is on turn). They are sorted by the bank-aware time-until-
+ * expiry (least first, gameID as a stable tiebreak) -- the same "most urgent
+ * first" order the correspondence/league lists use -- so this is the single
+ * source of truth shared by the in-game Next button and the gameroom's top-bar
+ * next-game cycler. Because the order is deterministic, clicking Next once per
+ * game walks every on-turn game exactly once and returns to the first after n
+ * clicks.
+ *
+ * The caller is expected to recompute this whenever the live correspondence-game
+ * set changes (e.g. a notification that another game became the user's turn), so
+ * the cycle stays current "as at last refresh".
+ */
+export function pickNextCorresGame<T>(
+  candidates: ReadonlyArray<{
+    game: T;
+    gameID: string;
+    beforeExpiry: number;
+  }>,
+  currentGameID: string | undefined,
+): NextCorresPick<T> {
+  const sorted = [...candidates].sort((a, b) => {
+    // Do not use a-b even if it should not overflow.
+    if (a.beforeExpiry < b.beforeExpiry) return -1;
+    if (a.beforeExpiry > b.beforeExpiry) return 1;
+    // Stable tiebreak so the cycle order is deterministic.
+    if (a.gameID < b.gameID) return -1;
+    if (a.gameID > b.gameID) return 1;
+    return 0;
+  });
+
+  const currentIndex = sorted.findIndex((c) => c.gameID === currentGameID);
+
+  if (currentIndex >= 0) {
+    // The current game is itself on the user's turn: advance to the next game
+    // in the cycle (null when this is the only on-turn game).
+    return {
+      next:
+        sorted.length > 1
+          ? sorted[(currentIndex + 1) % sorted.length].game
+          : null,
+      waiting: sorted.length - 1,
+    };
+  }
+
+  // The current game is not on the user's turn (opponent's move, a finished
+  // game, or a different game entirely): jump to the most urgent on-turn game.
+  return {
+    next: sorted.length > 0 ? sorted[0].game : null,
+    waiting: sorted.length,
+  };
+}


### PR DESCRIPTION
## Summary
Routes both the in-game Next button and the gameroom top-bar next-game cycler through the shared `pickNextCorresGame` helper, so they always target the same game.

## Changes
- Replace the inline next-game selection in `table.tsx` with `pickNextCorresGame`.
- Behavior is unchanged: bank-aware most-urgent order, cycling, and it still live-refreshes when another game becomes the user's turn.

## Test plan
- [x] `tsc --noEmit` clean
- [x] eslint clean (no new warnings)
- [x] `vitest` -- picker behavior (n clicks circle back) covered by the helper tests in #1877
- [x] `npm run build`

Builds on #1877. Part of the UI feedback batch (#1877-#1881).
