### PR TITLE
show opponent title badges in the league game-history modal

### DIFF
--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -59,10 +59,27 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
   const columns = [
     {
       title: "Opponent",
-      dataIndex: "opponentUsername",
       key: "opponent",
       fixed: "left" as const,
-      render: (username: string) => <strong>{username}</strong>,
+      render: (
+        _: unknown,
+        record: { opponentUsername: string; opponentUserId: string },
+      ) => (
+        // Same menu helper the modal header uses: it renders the M/IM title
+        // badge and the player context menu. Stop propagation so opening the
+        // menu does not also fire the row's navigate-to-game click.
+        <strong
+          onClick={(e) => e.stopPropagation()}
+          style={{ cursor: "default" }}
+        >
+          <UsernameWithContext
+            username={record.opponentUsername}
+            userID={record.opponentUserId}
+            sendMessage={onChat}
+            omitSendMessage={!onChat}
+          />
+        </strong>
+      ),
     },
     {
       title: "Result",
@@ -132,6 +149,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
       key: game.gameId,
       gameId: game.gameId,
       opponentUsername: game.opponentUsername,
+      opponentUserId: game.opponentUserId,
       result: game.result,
       playerScore: game.playerScore,
       opponentScore: game.opponentScore,


### PR DESCRIPTION
## Summary
Renders opponent names in the season game-history modal with `UsernameWithContext` -- the same helper the modal header already uses -- so the title badge (M/IM/etc.) and player context menu appear next to each opponent name.

## Changes
- Opponent column now uses `UsernameWithContext` with the opponent UUID (already present on the `GetPlayerSeasonGames` response).
- Clicks on the name open the player menu without triggering the row's navigate-to-game handler.

## Test plan
- [x] `tsc --noEmit` clean
- [x] eslint clean (no new warnings)
- [x] `npx prettier --write`
- [x] `npm run build`

Implements a community request (title badges in the results modal). Part of the UI feedback batch (#1877-#1881).
