### PR TITLE
style the correspondence next button like play on mobile

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -2974,13 +2974,13 @@ p.rune {
     }
 
     // Correspondence-only "Next (x)" jump button. Shown only in place of a dead
-    // Play (when it is not the user's turn), never beside a live Play. Keep it a
-    // compact, normal-height button rather than the big square Play uses on
-    // mobile.
+    // Play (when it is not the user's turn), never beside a live Play. Styled
+    // like Play -- same big square footprint on mobile -- but the width is
+    // allowed to grow so the "Next (x)" label is not clipped.
     &.play.next-game {
-      min-width: auto;
+      min-width: calc($board-size-mobile * 0.25);
       width: auto;
-      height: calc(($board-size-mobile / 8) - 9px);
+      height: calc($board-size-mobile * 0.25);
 
       .next-game-count {
         margin-left: 4px;


### PR DESCRIPTION
## Summary
When the in-game Next button replaces a dead Play (opponent's turn), it should look like Play. On desktop it already did; on mobile a leftover rule -- from when Next sat beside Play and had to be compact -- shrank it below Play's square. Match Play's square height and min-width, leaving width to grow so the "Next (x)" label is not clipped.

## Test plan
- [x] `npx prettier --write` (scss-only change)
- [x] `npm run build` succeeds
- [ ] manual check on mobile (Next replacing Play matches Play's size, label not clipped) not yet run -- hard to stage locally without a correspondence game on the opponent's turn

Follows up the button change in #1879.
