### PR TITLE
pin the next-game target so a refresh cannot bounce it to the top

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -100,6 +100,7 @@ import { create, toBinary } from "@bufbuild/protobuf";
 import { useTournamentCompetitorState } from "../hooks/use_tournament_competitor_state";
 import { showTurnNotification } from "../utils/notifications";
 import {
+  nextPin,
   onTurnCountdowns,
   pickNextCorresGame,
 } from "../utils/time_bank_calculator";
@@ -1043,47 +1044,72 @@ export const Table = React.memo((props: Props) => {
     return Array.from(byID.values());
   }, [localCorresGames, liveCorresGames]);
 
-  const { nextCorresGame, corresGamesWaiting } = useMemo(() => {
-    const isCorrespondence =
-      gameInfo.gameRequest?.gameMode === GameMode.CORRESPONDENCE;
+  // Live snapshot: the games where it is the user's turn, the urgency-ranked
+  // immediate-next candidate, and the (live) count of other waiting games.
+  const { corresCandidates, immediateNextID, corresGamesWaiting } =
+    useMemo(() => {
+      const isCorrespondence =
+        gameInfo.gameRequest?.gameMode === GameMode.CORRESPONDENCE;
+      if (!isCorrespondence || !userID || corresGames.length === 0) {
+        return {
+          corresCandidates: [],
+          immediateNextID: null,
+          corresGamesWaiting: 0,
+        };
+      }
 
-    if (!isCorrespondence || !userID) {
-      return { nextCorresGame: null, corresGamesWaiting: 0 };
-    }
+      // Every game where it is the user's turn (current game included). "now"
+      // need not be Date.now(); any const that minimizes overflow works.
+      const now = Date.now();
+      const corresCandidates = corresGames
+        .filter((ag) => {
+          const playerIndex = ag.players.findIndex((p) => p.uuid === userID);
+          return playerIndex !== -1 && playerIndex === ag.playerOnTurn;
+        })
+        .map((ag) => {
+          // Real time-until-expiry for the on-turn player (per-turn allowance +
+          // that player's remaining bank - elapsed). The backend now sends the
+          // live bank, so this is bank-aware rather than the old per-turn proxy.
+          const timeElapsedSecs = (now - (ag.lastUpdate || 0)) / 1000;
+          const onTurnIdx = ag.playerOnTurn ?? 0;
+          const bankSecs = (ag.timeBank?.[onTurnIdx] ?? 0) / 1000;
+          const { beforeExpiry } = onTurnCountdowns(
+            ag.incrementSecs,
+            bankSecs,
+            timeElapsedSecs,
+          );
+          return { game: ag, gameID: ag.gameID, beforeExpiry };
+        });
 
-    if (corresGames.length === 0) {
-      return { nextCorresGame: null, corresGamesWaiting: 0 };
-    }
+      // Urgency-ranked "next" -- the same logic the top-bar cycler and the
+      // in-game Next button share. This is the candidate to pin on first sight.
+      const { next, waiting } = pickNextCorresGame(corresCandidates, gameID);
+      return {
+        corresCandidates,
+        immediateNextID: next?.gameID ?? null,
+        corresGamesWaiting: waiting,
+      };
+    }, [gameInfo.gameRequest?.gameMode, userID, gameID, corresGames]);
 
-    // Every game where it is the user's turn (current game included). "now"
-    // need not be Date.now(); any const that minimizes overflow works.
-    const now = Date.now();
-    const candidates = corresGames
-      .filter((ag) => {
-        const playerIndex = ag.players.findIndex((p) => p.uuid === userID);
-        return playerIndex !== -1 && playerIndex === ag.playerOnTurn;
-      })
-      .map((ag) => {
-        // Real time-until-expiry for the on-turn player (per-turn allowance +
-        // that player's remaining bank - elapsed). The backend now sends the
-        // live bank, so this is bank-aware rather than the old per-turn proxy.
-        const timeElapsedSecs = (now - (ag.lastUpdate || 0)) / 1000;
-        const onTurnIdx = ag.playerOnTurn ?? 0;
-        const bankSecs = (ag.timeBank?.[onTurnIdx] ?? 0) / 1000;
-        const { beforeExpiry } = onTurnCountdowns(
-          ag.incrementSecs,
-          bankSecs,
-          timeElapsedSecs,
-        );
-        return { game: ag, gameID: ag.gameID, beforeExpiry };
-      });
+  // Pin the Next target so a live refresh cannot move it. Once you move (or an
+  // opponent's move arrives), the current game leaves the on-turn set and the
+  // picker would otherwise fall back to the most-urgent game -- yanking you
+  // back to the top instead of letting you play once through all your games.
+  // The pin is set on first sight and held; nextPin only replaces it when it
+  // goes invalid or when a next first appears. It resets on navigation (a new
+  // page is a fresh mount). The "(n)" count above stays live.
+  const [pinnedNextID, setPinnedNextID] = useState<string | null | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    const onTurnIDs = new Set(corresCandidates.map((c) => c.gameID));
+    setPinnedNextID((prev) => nextPin(prev, onTurnIDs, immediateNextID));
+  }, [corresCandidates, immediateNextID]);
 
-    // Shared "next urgent, cycling" selection -- the same logic the gameroom
-    // top-bar next-game cycler and the in-game Next button both consume, so the
-    // two always point at the same game.
-    const { next, waiting } = pickNextCorresGame(candidates, gameID);
-    return { nextCorresGame: next, corresGamesWaiting: waiting };
-  }, [gameInfo.gameRequest?.gameMode, userID, gameID, corresGames]);
+  const nextCorresGame = useMemo(
+    () => corresCandidates.find((c) => c.gameID === pinnedNextID)?.game ?? null,
+    [corresCandidates, pinnedNextID],
+  );
 
   const handleNextCorresGame = useCallback(() => {
     if (nextCorresGame) {

--- a/liwords-ui/src/utils/time_bank_calculator.test.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.test.ts
@@ -1,6 +1,7 @@
 import {
   formatCoarseDuration,
   formatCoarseDurationShort,
+  nextPin,
   onTurnCountdowns,
   pickNextCorresGame,
 } from "./time_bank_calculator";
@@ -141,4 +142,29 @@ it("pickNextCorresGame: equal urgency is broken stably by gameID", () => {
   expect(pickNextCorresGame(candidates, "a").next).toBe("b");
   expect(pickNextCorresGame(candidates, "b").next).toBe("c");
   expect(pickNextCorresGame(candidates, "c").next).toBe("a");
+});
+
+it("nextPin: pins on first sight and holds it across refreshes", () => {
+  const onTurn = new Set(["a", "b", "c"]);
+  // First evaluation on the page (undefined) takes the immediate-next.
+  expect(nextPin(undefined, onTurn, "b")).toBe("b");
+  // A later refresh keeps the pinned target even though the urgency-ranked
+  // immediate-next has changed (this is the bug fix: no bouncing to [0]).
+  expect(nextPin("b", onTurn, "c")).toBe("b");
+  expect(nextPin("b", onTurn, "a")).toBe("b");
+});
+
+it("nextPin: pins a next that appears only after a later refresh", () => {
+  // No game was on the user's turn at load.
+  expect(nextPin(null, new Set<string>(), null)).toBe(null);
+  // An opponent moved -> a next appeared -> pin it.
+  expect(nextPin(null, new Set(["x"]), "x")).toBe("x");
+});
+
+it("nextPin: repicks when the pinned game leaves the on-turn set", () => {
+  // Pinned "b" was played in another tab, so it is no longer on the user's
+  // turn -> fall back to the freshly-computed immediate-next.
+  expect(nextPin("b", new Set(["a", "c"]), "c")).toBe("c");
+  // Nothing left to pin.
+  expect(nextPin("b", new Set<string>(), null)).toBe(null);
 });

--- a/liwords-ui/src/utils/time_bank_calculator.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.ts
@@ -227,3 +227,35 @@ export function pickNextCorresGame<T>(
     waiting: sorted.length,
   };
 }
+
+/**
+ * Decide which on-turn game the "Next" affordance should point at, given the
+ * previously pinned target. The target is pinned on first sight and then held
+ * across live refreshes -- a refresh must not move it. Otherwise, once the
+ * current game leaves the on-turn set (you moved, or an opponent's move
+ * arrived), pickNextCorresGame falls back to the most-urgent game and yanks you
+ * back to the top of the list, so you can never play once through all your
+ * games. The pin is replaced only when it goes invalid (the pinned game is no
+ * longer on the user's turn -- e.g. it was played in another tab) or when there
+ * was no target and one has now appeared. It resets on navigation (a new page
+ * is a fresh mount with prevPinned === undefined).
+ *
+ * - prevPinned: the currently pinned game id, null (no target), or undefined
+ *   (nothing pinned yet -- first evaluation on this page).
+ * - onTurnGameIDs: the games where it is currently the user's turn.
+ * - immediateNextGameID: the freshly-computed urgency-ranked next, or null.
+ */
+export function nextPin(
+  prevPinned: string | null | undefined,
+  onTurnGameIDs: ReadonlySet<string>,
+  immediateNextGameID: string | null,
+): string | null {
+  // Keep a still-valid pin: a live refresh changes the "(n)" count, not the
+  // target.
+  if (prevPinned != null && onTurnGameIDs.has(prevPinned)) {
+    return prevPinned;
+  }
+  // First sight, a next that has just appeared, or a repick after the pinned
+  // game went invalid.
+  return immediateNextGameID;
+}


### PR DESCRIPTION
## Summary
Lets you play once through all your correspondence games again. The Next affordance pins its target instead of re-deriving it on every live refresh.

## Bug
After you move (or an opponent's move arrives via the live refresh), the current game leaves the on-turn set, so the shared picker fell back to the most-urgent game (index 0) -- bouncing you back to the top of the list after every move.

## Fix
The urgency-ranked immediate-next is computed and pinned on first sight, then held across refreshes. The new pure `nextPin()` replaces it only when the pinned game leaves the on-turn set (e.g. played in another tab) or when a next first appears. Resets on navigation. The "(n)" count stays live; the cycle order is still urgency-based -- pinning just stops a refresh from moving the target.

## Test plan
- [x] `vitest` -- new `nextPin` tests (first-sight pin, held across refresh, appears-later, repick-on-invalidate); 14 pass
- [x] `tsc --noEmit` clean
- [x] eslint clean (no new warnings)
- [x] `npm run build`
- [ ] manual play-through (move, then Next -> next game, not back to top) not yet run -- hard to stage locally without several concurrent on-turn games

Builds on #1877 / #1880 (the shared next-game picker).
