### PR TITLE
make the correspondence next button inherit play's responsive size

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -2973,19 +2973,12 @@ p.rune {
       margin: 0 6px;
     }
 
-    // Correspondence-only "Next (x)" jump button. Shown only in place of a dead
-    // Play (when it is not the user's turn), never beside a live Play. Styled
-    // like Play -- same big square footprint on mobile -- but the width is
-    // allowed to grow so the "Next (x)" label is not clipped.
-    &.play.next-game {
-      min-width: calc($board-size-mobile * 0.25);
-      width: auto;
-      height: calc($board-size-mobile * 0.25);
-
-      .next-game-count {
-        margin-left: 4px;
-        opacity: 0.7;
-      }
+    // Correspondence-only "Next (x)" jump button. It replaces a dead Play (when
+    // it is not the user's turn), so it inherits Play's size-aware box verbatim
+    // -- no dimensions of its own. Only the count badge needs styling.
+    &.play.next-game .next-game-count {
+      margin-left: 4px;
+      opacity: 0.7;
     }
   }
 


### PR DESCRIPTION
## Summary
The in-game Next button (which replaces a dead Play when it's not your turn) rendered as a large square at every screen size, while Play itself is size-aware. This makes Next inherit Play's responsive box exactly.

## Bug
`.play.next-game` pinned mobile dimensions (height/min-width = 0.25*board). At specificity (0,4,1) it out-specified the `@media (min-width: 1024px) .play { height: 36px }` rule (0,3,1) -- which only targets `.play` -- so the mobile square won at all widths, including desktop.

## Fix
Drop all box dimensions from `.play.next-game`. Since Next now only ever replaces Play (never beside it, per #1879), it should simply be Play's box -- it inherits `.play` verbatim at every breakpoint (big square on mobile, 36px on desktop). Only the count badge keeps its styling.

## Test plan
- [x] `npx prettier --write`
- [x] `npm run build`
- [ ] manual visual (desktop: Next == Play; narrow: Next == Play square, label fits) not yet run -- hard to stage a corres game in the not-your-turn state locally

Fixes the regression from #1882; follows up #1879.
