### PR TITLE
redirect to the annotated-game view when /game/ gets an annotated id

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -608,6 +608,16 @@ export const Table = React.memo((props: Props) => {
           }
         }
       } catch (e) {
+        // Annotated games are stored as GameDocuments; the metadata Get endpoint
+        // rejects them ("annotated game ... should be accessed via GetDocument,
+        // not Get"). A faulty /game/<id> link to an annotated game -- e.g. from
+        // the analysis-ready notification or a profile link -- lands here.
+        // Redirect to the /anno/ view that can actually load it (replace, so the
+        // dead /game/ URL is not left in history) instead of showing an error.
+        if (gameID && String(e).includes("GetDocument")) {
+          window.location.replace(`/anno/${encodeURIComponent(gameID)}`);
+          return;
+        }
         message.error({
           content: `Failed to fetch game information; please refresh. (Error: ${e})`,
           duration: 10,

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -614,7 +614,10 @@ export const Table = React.memo((props: Props) => {
         // the analysis-ready notification or a profile link -- lands here.
         // Redirect to the /anno/ view that can actually load it (replace, so the
         // dead /game/ URL is not left in history) instead of showing an error.
-        if (gameID && String(e).includes("GetDocument")) {
+        if (
+          gameID &&
+          String(e).includes("should be accessed via GetDocument")
+        ) {
           window.location.replace(`/anno/${encodeURIComponent(gameID)}`);
           return;
         }


### PR DESCRIPTION
## Summary
Fixes the "annotated game ... should be accessed via GetDocument, not Get" error users hit when a `/game/<id>` link points at an annotated game.

## Bug
Annotated games are stored as GameDocuments, so the metadata `Get` endpoint rejects them (`pkg/stores/game/db.go:174`). A faulty `/game/<id>` link to an annotated game -- from the analysis-ready notification, a profile link, or any other source -- falls into the gameroom's metadata-fetch catch and surfaces that raw error to the user.

## Fix
Trap that specific failure in the catch and `window.location.replace` to `/anno/<id>` (the view that can load it; `replace` so the dead `/game/` URL isn't left in history). This fixes every faulty-link source in one place instead of patching links one by one.

Detection matches the distinctive, id-free phrase "should be accessed via GetDocument" (produced only by that backend error), not the bare "GetDocument" token -- so an unrelated error that merely mentions the RPC cannot trigger a wrong redirect. Frontend-only (no proto/backend change).

## Test plan
- [x] `tsc --noEmit` clean
- [x] eslint clean (no new warnings)
- [x] `npm run build`
- [ ] manual: open a `/game/<annotated-id>` link -> redirects to `/anno/<id>` (not run by me -- needs an annotated game id)

Fixes #1741.
