### PR TITLE
fix the australian draw reset off-by-one and store reset_round 0-based

### DIFF
--- a/api/proto/ipc/tournament.proto
+++ b/api/proto/ipc/tournament.proto
@@ -135,17 +135,16 @@ message RoundControl {
   int32 control_loss_activation_round = 18;
   int32 place_prizes = 19;
 
-  // reset_round is the Australian Draw repeat-reset point, stored as a
-  // 1-based round number (valid >= 1). A meeting in 1-based round r is
-  // avoided as a repeat iff r >= reset_round, so meetings in earlier rounds
-  // are allowed to recur. This emulates a day-based reset (e.g. set 9 so
-  // rounds 1-8 are forgiven when pairing round 9 onward). 0/unset is treated
-  // as 1 (reset from round 1 = avoid all prior meetings, the default
-  // no-repeat behavior); do not rely on the proto3 zero-default as a
-  // meaningful sentinel -- the reader clamps it explicitly. reset_round at or
-  // past the current round forgives every prior meeting (King-of-the-Hill).
-  // When even a strict pairing is impossible the reset point is relaxed
-  // upward one round at a time.
+  // reset_round is the Australian Draw repeat-reset point, a 0-based round
+  // number (matching the 0-based rounds used everywhere else). A meeting in
+  // round r is avoided as a repeat iff r >= reset_round, so meetings in
+  // earlier rounds are allowed to recur. This emulates a day-based reset (e.g.
+  // set 8 so rounds 0-7 are forgiven when pairing round 8 onward). The proto3
+  // zero-default (0) means reset from round 0 = avoid all prior meetings (the
+  // default no-repeat behavior). reset_round at or past the current round
+  // forgives every prior meeting (King-of-the-Hill). When even a strict
+  // pairing is impossible the reset point is relaxed upward one round at a
+  // time.
   uint32 reset_round = 20;
 }
 

--- a/liwords-ui/src/gen/api/proto/ipc/tournament_pb.ts
+++ b/liwords-ui/src/gen/api/proto/ipc/tournament_pb.ts
@@ -357,17 +357,16 @@ export type RoundControl = Message<"ipc.RoundControl"> & {
   placePrizes: number;
 
   /**
-   * reset_round is the Australian Draw repeat-reset point, stored as a
-   * 1-based round number (valid >= 1). A meeting in 1-based round r is
-   * avoided as a repeat iff r >= reset_round, so meetings in earlier rounds
-   * are allowed to recur. This emulates a day-based reset (e.g. set 9 so
-   * rounds 1-8 are forgiven when pairing round 9 onward). 0/unset is treated
-   * as 1 (reset from round 1 = avoid all prior meetings, the default
-   * no-repeat behavior); do not rely on the proto3 zero-default as a
-   * meaningful sentinel -- the reader clamps it explicitly. reset_round at or
-   * past the current round forgives every prior meeting (King-of-the-Hill).
-   * When even a strict pairing is impossible the reset point is relaxed
-   * upward one round at a time.
+   * reset_round is the Australian Draw repeat-reset point, a 0-based round
+   * number (matching the 0-based rounds used everywhere else). A meeting in
+   * round r is avoided as a repeat iff r >= reset_round, so meetings in
+   * earlier rounds are allowed to recur. This emulates a day-based reset (e.g.
+   * set 8 so rounds 0-7 are forgiven when pairing round 8 onward). The proto3
+   * zero-default (0) means reset from round 0 = avoid all prior meetings (the
+   * default no-repeat behavior). reset_round at or past the current round
+   * forgives every prior meeting (King-of-the-Hill). When even a strict
+   * pairing is impossible the reset point is relaxed upward one round at a
+   * time.
    *
    * @generated from field: uint32 reset_round = 20;
    */

--- a/liwords-ui/src/tournament/director_tools/ghetto_tools/round_control_fields.tsx
+++ b/liwords-ui/src/tournament/director_tools/ghetto_tools/round_control_fields.tsx
@@ -336,10 +336,11 @@ export const rdCtrlFromSetting = (
       break;
 
     case PairingMethod.AUSTRALIAN_DRAW:
-      // resetRound is the 1-based reset point, stored directly in the proto
-      // (no offset). Round 1 = avoid all repeats. An unset value defaults to
-      // the input minimum of 1; the backend clamps anything below 1 to 1.
-      rdCtrl.resetRound = rdSetting.resetRound || 1;
+      // The Reset Round field is 1-based (a round number; the default is 1 =
+      // avoid all repeats), but the proto/engine store reset_round 0-based like
+      // every other round. Convert on the way in: input N -> N-1. Default input
+      // 1 -> 0, which is also the proto3 zero-default ("avoid all").
+      rdCtrl.resetRound = (rdSetting.resetRound ?? 1) - 1;
       break;
 
     case PairingMethod.PAIRING_METHOD_COP:

--- a/liwords-ui/src/tournament/director_tools/ghetto_tools/round_controls.tsx
+++ b/liwords-ui/src/tournament/director_tools/ghetto_tools/round_controls.tsx
@@ -517,10 +517,11 @@ const SetDivisionRoundControls = (props: { tournamentID: string }) => {
           allowOverMaxRepeats: v.allowOverMaxRepeats,
           repeatRelativeWeight: v.repeatRelativeWeight,
           winDifferenceRelativeWeight: v.winDifferenceRelativeWeight,
-          // Australian Draw-specific field, stored 1-based in the proto (the
-          // reset point as a round number). Carry it through unchanged; the
-          // editor and rdCtrlFromSetting use the same 1-based value.
-          resetRound: v.resetRound,
+          // Australian Draw-specific field. The proto stores reset_round
+          // 0-based; the editor's Reset Round field is a 1-based round number,
+          // so convert proto -> editor with +1 (rdCtrlFromSetting does the -1
+          // on the way back).
+          resetRound: v.resetRound + 1,
           // COP-specific fields
           gibsonSpreads: v.gibsonSpreads,
           hopefulnessThresholds: v.hopefulnessThresholds,

--- a/pkg/pair/australian.go
+++ b/pkg/pair/australian.go
@@ -319,9 +319,11 @@ func australianMatch(n int, blocked [][]bool) ([]int, bool) {
 // considered a repeat at the active reset round, and blockedPair reports a hard
 // director block. currentRound is the round being paired. The reset starts at
 // earliestReset and is relaxed (incremented) one round at a time; raising it
-// must be monotonically more permissive. The final, fully relaxed pass uses
-// reset == currentRound+1 (no past round counts as a repeat); if even that pass
-// cannot pair the field the failure is final. n is the padded, even field size.
+// must be monotonically more permissive. The fully relaxed pass uses
+// reset == currentRound: a prior meeting can only be in a round < currentRound
+// (the round being paired has not happened yet), so reset == currentRound
+// already forgives every repeat. If even that pass cannot pair the field the
+// failure is final. n is the padded, even field size.
 func australianMatchWithReset(
 	n int,
 	earliestReset int,
@@ -348,13 +350,15 @@ func australianMatchWithReset(
 		}
 
 		// The next pass relaxes the repeat rule by one round. The pass at
-		// reset == currentRound+1 forbids no repeats at all, so if it still
-		// fails the obstruction is a hard block (director block or parity), not
-		// a repeat, and the failure is final.
-		if reset >= currentRound+1 {
+		// reset == currentRound already forbids no repeats at all -- every prior
+		// meeting is in a round < currentRound -- so if it still fails the
+		// obstruction is a hard block (director block or parity), not a repeat,
+		// and the failure is final. (Relaxing further, to currentRound+1, would
+		// rebuild an identical block matrix and fail identically.)
+		if reset >= currentRound {
 			return nil, fmt.Errorf(
 				"australian draw could not pair %d players even after relaxing"+
-					" the repeat rule past round %d", n, currentRound)
+					" the repeat rule to round %d", n, currentRound)
 		}
 	}
 }

--- a/pkg/pair/australian.go
+++ b/pkg/pair/australian.go
@@ -332,14 +332,30 @@ func australianMatchWithReset(
 	hasPlayedSince func(a, b, reset int) bool,
 	blockedPair func(a, b int) bool,
 ) ([]int, error) {
-	for reset := earliestReset; ; reset++ {
-		blocked := make([][]bool, n)
-		for i := range blocked {
-			blocked[i] = make([]bool, n)
+	// The director-block half of the block matrix is constant across reset
+	// passes (blockedPair does not depend on reset), so compute it once. Only
+	// the repeat half (hasPlayedSince) changes as the reset relaxes, so each
+	// pass overwrites the reused blocked matrix in place rather than allocating
+	// a fresh one. australianMatch reads blocked without mutating it, so reuse
+	// is safe.
+	dirBlocked := make([][]bool, n)
+	blocked := make([][]bool, n)
+	for i := range blocked {
+		dirBlocked[i] = make([]bool, n)
+		blocked[i] = make([]bool, n)
+	}
+	for a := 0; a < n; a++ {
+		for b := a + 1; b < n; b++ {
+			d := blockedPair(a, b)
+			dirBlocked[a][b] = d
+			dirBlocked[b][a] = d
 		}
+	}
+
+	for reset := earliestReset; ; reset++ {
 		for a := 0; a < n; a++ {
 			for b := a + 1; b < n; b++ {
-				block := blockedPair(a, b) || hasPlayedSince(a, b, reset)
+				block := dirBlocked[a][b] || hasPlayedSince(a, b, reset)
 				blocked[a][b] = block
 				blocked[b][a] = block
 			}

--- a/pkg/pair/australian.go
+++ b/pkg/pair/australian.go
@@ -157,8 +157,16 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 	// its writes on a failed branch, so on return false pairings is unchanged.
 	// The field is even and each step removes a pair, so every recursive r is
 	// even too.
-	var casement func(r []int, allowFlip bool) bool
-	casement = func(r []int, allowFlip bool) bool {
+	// Per-depth scratch buffers for the remaining-positions list, so the
+	// backtracking allocates nothing per node. Each level removes a pair, so
+	// the recursion depth is bounded by n/2.
+	scratch := make([][]int, n/2+1)
+	for i := range scratch {
+		scratch[i] = make([]int, n)
+	}
+
+	var casement func(r []int, allowFlip bool, depth int) bool
+	casement = func(r []int, allowFlip bool, depth int) bool {
 		if len(r) == 0 {
 			return true
 		}
@@ -178,7 +186,7 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 			}
 			pairings[p] = b
 			pairings[b] = p
-			if casement(without(r, p, b), allowFlip) {
+			if casement(withoutInto(scratch[depth], r, p, b), allowFlip, depth+1) {
 				return true
 			}
 			pairings[p] = -1
@@ -195,7 +203,7 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 			}
 			pairings[p] = b
 			pairings[b] = p
-			if casement(without(r, p, b), allowFlip) {
+			if casement(withoutInto(scratch[depth], r, p, b), allowFlip, depth+1) {
 				return true
 			}
 			pairings[p] = -1
@@ -212,7 +220,7 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 				}
 				pairings[p] = b
 				pairings[b] = p
-				if casement(without(r, p, b), allowFlip) {
+				if casement(withoutInto(scratch[depth], r, p, b), allowFlip, depth+1) {
 					return true
 				}
 				pairings[p] = -1
@@ -233,7 +241,7 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 	for i := range pairings {
 		pairings[i] = -1
 	}
-	if casement(all, false) {
+	if casement(all, false, 0) {
 		return pairings, nil
 	}
 
@@ -242,7 +250,7 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 	for i := range pairings {
 		pairings[i] = -1
 	}
-	if casement(all, true) {
+	if casement(all, true, 0) {
 		return pairings, nil
 	}
 
@@ -251,18 +259,21 @@ func australianCasementBlocked(n int, blocked [][]bool) ([]int, error) {
 			" configured blocks", n)
 }
 
-// without returns the positions in r (ascending) with a and b removed,
-// preserving order. r[0] is always a; b is some later element. The result is a
-// fresh slice so recursion never aliases the caller's view of r.
-func without(r []int, a, b int) []int {
-	rest := make([]int, 0, len(r)-2)
+// withoutInto writes the positions in r (ascending) with a and b removed into
+// dst, preserving order, and returns the dst prefix holding them. r[0] is
+// always a; b is some later element. dst is a caller-provided per-depth scratch
+// buffer, so the backtracking search never allocates per node and never aliases
+// an ancestor's list (each recursion depth has its own buffer).
+func withoutInto(dst, r []int, a, b int) []int {
+	m := 0
 	for _, x := range r {
 		if x == a || x == b {
 			continue
 		}
-		rest = append(rest, x)
+		dst[m] = x
+		m++
 	}
-	return rest
+	return dst[:m]
 }
 
 // australianMatch pairs the even field of n positions in standings order by
@@ -283,8 +294,16 @@ func australianMatch(n int, blocked [][]bool) ([]int, bool) {
 		pairings[i] = -1
 	}
 
-	var match func(r []int) bool
-	match = func(r []int) bool {
+	// Per-depth scratch buffers for the remaining-positions list, so the
+	// backtracking allocates nothing per node. Each level removes a pair, so
+	// the recursion depth is bounded by n/2.
+	scratch := make([][]int, n/2+1)
+	for i := range scratch {
+		scratch[i] = make([]int, n)
+	}
+
+	var match func(r []int, depth int) bool
+	match = func(r []int, depth int) bool {
 		if len(r) == 0 {
 			return true
 		}
@@ -295,7 +314,7 @@ func australianMatch(n int, blocked [][]bool) ([]int, bool) {
 			}
 			pairings[p] = q
 			pairings[q] = p
-			if match(without(r, p, q)) {
+			if match(withoutInto(scratch[depth], r, p, q), depth+1) {
 				return true
 			}
 			pairings[p] = -1
@@ -308,7 +327,7 @@ func australianMatch(n int, blocked [][]bool) ([]int, bool) {
 	for i := range all {
 		all[i] = i
 	}
-	if !match(all) {
+	if !match(all, 0) {
 		return nil, false
 	}
 	return pairings, true

--- a/pkg/pair/australian.go
+++ b/pkg/pair/australian.go
@@ -18,9 +18,10 @@ import (
 // pairs the top remaining player with the highest-standing opponent they are
 // allowed to face, recursing on the rest and backtracking if no completion
 // exists. A rematch is avoided only when the two players met in a round at or
-// after the reset point (reset_round, a 1-based round number), so a configured
-// day boundary forgives earlier meetings; meetings before the reset may recur
-// freely. reset_round of 1 avoids every prior meeting (the default); a
+// after the reset point (reset_round, a 0-based round number, matching the
+// 0-based rounds used everywhere else), so a configured day boundary forgives
+// earlier meetings; meetings before the reset may recur freely. reset_round of
+// 0 avoids every prior meeting (the default); a
 // reset_round at or past the current round forgives them all. If no draw
 // exists under the current reset, the reset point is raised one round at a
 // time -- forgiving the next-oldest round of repeats -- and the search is
@@ -436,25 +437,15 @@ func pairAustralianDraw(members *entity.UnpairedPoolMembers) ([]int, error) {
 			return nil, err
 		}
 	} else {
-		// reset_round is stored 1-based (the reset point as a round number).
-		// Clamp it explicitly: 0/unset/legacy values mean round 1 = reset from
-		// round 1 = avoid every prior meeting (the default no-repeat behavior).
-		// Do not lean on the proto3 zero-default as API -- treat <1 as 1 here.
-		resetRound := int(members.RoundControls.ResetRound)
-		if resetRound < 1 {
-			resetRound = 1
-		}
-
-		// earliestReset is the 0-indexed round threshold the repeat rule uses
-		// (members.RoundControls.Round and the RepeatRounds history are
-		// 0-indexed). A meeting in 1-based round r == 0-indexed round r-1 is
-		// avoided iff r >= resetRound, i.e. (r-1) >= resetRound-1, so the
-		// 0-indexed threshold is resetRound-1. resetRound==1 gives threshold 0
-		// => every prior round is avoided; a large resetRound gives a high
-		// threshold => no prior round counts (King-of-the-Hill). The retry loop
-		// relaxes this threshold upward one round at a time when a strict
-		// pairing is impossible.
-		earliestReset := resetRound - 1
+		// reset_round is the 0-indexed round threshold the repeat rule uses
+		// (members.RoundControls.Round and the RepeatRounds history are also
+		// 0-indexed). A meeting in round r is avoided iff r >= reset_round, so
+		// reset_round == 0 avoids every prior round (the default) and a large
+		// reset_round forgives them all (King-of-the-Hill). The proto3 zero-
+		// default (0) is therefore the correct default and needs no clamping.
+		// The retry loop relaxes this threshold upward one round at a time when
+		// a strict pairing is impossible.
+		earliestReset := int(members.RoundControls.ResetRound)
 		if earliestReset > currentRound {
 			// A reset point past the current round would forgive everything;
 			// clamp the threshold so the strictest pass still avoids the most
@@ -466,7 +457,7 @@ func pairAustralianDraw(members *entity.UnpairedPoolMembers) ([]int, error) {
 		// when the number of rounds >= reset in which they met exceeds
 		// MaxRepeats. Meetings in rounds before reset are forgiven, so as the
 		// retry loop raises reset the rule relaxes one round at a time. The
-		// final relaxed pass (reset == currentRound+1) counts no prior round, so
+		// final relaxed pass (reset == currentRound) counts no prior round, so
 		// the field can always be paired when no hard block stands in the way.
 		// RepeatRounds may be nil (e.g. the dispatcher path on a pre-round-1
 		// sub-pool); a nil map yields no meetings and thus no repeat blocks,

--- a/pkg/pair/australian_test.go
+++ b/pkg/pair/australian_test.go
@@ -875,6 +875,33 @@ func TestAustralianResetRoundBehavior(t *testing.T) {
 	is.True(err != nil)
 }
 
+func TestAustralianResetStopsAtCurrentRound(t *testing.T) {
+	is := is.New(t)
+
+	// When no pairing exists even after fully relaxing the repeat rule, the
+	// loop must stop at reset == currentRound. A prior meeting can only be in a
+	// round < currentRound (the round being paired has not happened yet), so
+	// reset == currentRound already forgives every repeat; the pass at
+	// currentRound+1 would rebuild an identical block matrix and fail
+	// identically. Pin that the redundant currentRound+1 pass is not run by
+	// recording the largest reset the loop ever consults.
+	n := 2
+	currentRound := 5
+	maxReset := -1
+	hasPlayedSince := func(a, b, reset int) bool {
+		if reset > maxReset {
+			maxReset = reset
+		}
+		// Never forgiven, so the loop relaxes all the way and then fails.
+		return true
+	}
+	blockedPair := func(a, b int) bool { return false }
+
+	_, err := australianMatchWithReset(n, 0, currentRound, hasPlayedSince, blockedPair)
+	is.True(err != nil)
+	is.Equal(maxReset, currentRound)
+}
+
 func TestAustralianResetRoundForgivesEarlierRepeats(t *testing.T) {
 	is := is.New(t)
 

--- a/pkg/pair/australian_test.go
+++ b/pkg/pair/australian_test.go
@@ -34,8 +34,8 @@ func auMembers(round int32, maxRepeats int32, repeats map[string]int, ids ...str
 
 // auMembersRounds is auMembers with explicit control over the reset round and
 // the per-round meeting history. resetRound is the proto reset_round field,
-// stored 1-based (the reset point as a round number; a meeting in 1-based
-// round r is avoided iff r >= resetRound, and 0/unset means 1 = avoid all).
+// a 0-based round threshold (a meeting in 0-indexed round r is avoided iff
+// r >= resetRound, and 0/unset means 0 = avoid all prior meetings).
 // repeatRounds maps each pair key to the ascending list of 0-indexed rounds
 // in which the two players met (the history is 0-indexed, like round).
 func auMembersRounds(round int32, maxRepeats int32, resetRound uint32, repeats map[string]int, repeatRounds map[string][]int, ids ...string) *entity.UnpairedPoolMembers {
@@ -913,22 +913,21 @@ func TestAustralianResetRoundForgivesEarlierRepeats(t *testing.T) {
 		GetRepeatKey("a", "c"): {9},
 	}
 
-	// reset_round 9 (1-based) emulates a day boundary at round 9: the round-2
-	// a-b meeting is before it (1-based round 3 < 9) and may recur, but the
-	// round-9 a-c meeting is at or after it (1-based round 10 >= 9) and is
-	// avoided. The matcher therefore pairs a with its highest opponent b,
-	// leaving c-d.
-	m := auMembersRounds(10, 0, 9, nil, repeatRounds, "a", "b", "c", "d")
+	// reset_round 8 (0-based) emulates a day boundary at round 8: the round-2
+	// a-b meeting is before it (2 < 8) and may recur, but the round-9 a-c
+	// meeting is at or after it (9 >= 8) and is avoided. The matcher therefore
+	// pairs a with its highest opponent b, leaving c-d.
+	m := auMembersRounds(10, 0, 8, nil, repeatRounds, "a", "b", "c", "d")
 	pairings, err := pairAustralianDraw(m)
 	is.NoErr(err)
 	assertSymmetric(is, pairings)
 	got := idPairings(m, pairings)
 	is.Equal(got, map[string]string{"a": "b", "b": "a", "c": "d", "d": "c"})
 
-	// With reset_round 1 (the strict default: avoid every prior meeting) on
+	// With reset_round 0 (the strict default: avoid every prior meeting) on
 	// the same history, both prior meetings are avoided: a cannot take b
 	// (round 2) or c (round 9), so a falls to d, leaving b-c (who never met).
-	m2 := auMembersRounds(10, 0, 1, nil, repeatRounds, "a", "b", "c", "d")
+	m2 := auMembersRounds(10, 0, 0, nil, repeatRounds, "a", "b", "c", "d")
 	pairings2, err := pairAustralianDraw(m2)
 	is.NoErr(err)
 	got2 := idPairings(m2, pairings2)
@@ -939,18 +938,17 @@ func TestAustralianResetRoundRelaxesStepwise(t *testing.T) {
 	is := is.New(t)
 
 	// Two players a and b who met in (0-indexed) round 7, pairing round 10
-	// with MaxRepeats 0. reset_round starts at 7 (1-based), giving a 0-indexed
-	// threshold of 6, so the round-7 meeting is at or after the reset and is
-	// avoided; with only two players the strict pass has no legal pairing. The
-	// relaxation must raise the threshold one step at a time: thresholds 6 and
-	// 7 both still avoid the round-7 meeting (the boundary is inclusive), but
-	// threshold 8 forgives it, so the pair is finally allowed. This exercises
-	// the per-round relaxation -- it is not the all-or-nothing jump the totals
-	// map could only express.
+	// with MaxRepeats 0. reset_round starts at 6 (0-based), so the round-7
+	// meeting is at or after the reset (7 >= 6) and is avoided; with only two
+	// players the strict pass has no legal pairing. The relaxation must raise
+	// the threshold one step at a time: thresholds 6 and 7 both still avoid the
+	// round-7 meeting (the boundary is inclusive), but threshold 8 forgives it,
+	// so the pair is finally allowed. This exercises the per-round relaxation
+	// -- it is not the all-or-nothing jump the totals map could only express.
 	repeatRounds := map[string][]int{
 		GetRepeatKey("a", "b"): {7},
 	}
-	m := auMembersRounds(10, 0, 7, nil, repeatRounds, "a", "b")
+	m := auMembersRounds(10, 0, 6, nil, repeatRounds, "a", "b")
 	pairings, err := pairAustralianDraw(m)
 	is.NoErr(err)
 	assertSymmetric(is, pairings)

--- a/rpc/api/proto/ipc/tournament.pb.go
+++ b/rpc/api/proto/ipc/tournament.pb.go
@@ -693,17 +693,16 @@ type RoundControl struct {
 	// control_loss_activation_round is 0-indexed relative to the start of this COP round range.
 	ControlLossActivationRound int32 `protobuf:"varint,18,opt,name=control_loss_activation_round,json=controlLossActivationRound,proto3" json:"control_loss_activation_round,omitempty"`
 	PlacePrizes                int32 `protobuf:"varint,19,opt,name=place_prizes,json=placePrizes,proto3" json:"place_prizes,omitempty"`
-	// reset_round is the Australian Draw repeat-reset point, stored as a
-	// 1-based round number (valid >= 1). A meeting in 1-based round r is
-	// avoided as a repeat iff r >= reset_round, so meetings in earlier rounds
-	// are allowed to recur. This emulates a day-based reset (e.g. set 9 so
-	// rounds 1-8 are forgiven when pairing round 9 onward). 0/unset is treated
-	// as 1 (reset from round 1 = avoid all prior meetings, the default
-	// no-repeat behavior); do not rely on the proto3 zero-default as a
-	// meaningful sentinel -- the reader clamps it explicitly. reset_round at or
-	// past the current round forgives every prior meeting (King-of-the-Hill).
-	// When even a strict pairing is impossible the reset point is relaxed
-	// upward one round at a time.
+	// reset_round is the Australian Draw repeat-reset point, a 0-based round
+	// number (matching the 0-based rounds used everywhere else). A meeting in
+	// round r is avoided as a repeat iff r >= reset_round, so meetings in
+	// earlier rounds are allowed to recur. This emulates a day-based reset (e.g.
+	// set 8 so rounds 0-7 are forgiven when pairing round 8 onward). The proto3
+	// zero-default (0) means reset from round 0 = avoid all prior meetings (the
+	// default no-repeat behavior). reset_round at or past the current round
+	// forgives every prior meeting (King-of-the-Hill). When even a strict
+	// pairing is impossible the reset point is relaxed upward one round at a
+	// time.
 	ResetRound    uint32 `protobuf:"varint,20,opt,name=reset_round,json=resetRound,proto3" json:"reset_round,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
## Summary
Three independent tidy-ups to the Australian Draw pairing. None changes the pairings produced, except the reset_round representation, which no tournament has used yet. Follow-ups to #1870 / #1871.

## Changes
- Redundant reset pass: a prior meeting can only fall in a round < currentRound (the round being paired has not happened yet), so the reset-relaxation pass at reset == currentRound already forgives every repeat. The loop nonetheless relaxed once more to currentRound+1, rebuilding an identical block matrix and -- in the unpairable case -- rerunning the full backtracking search a second time before failing. Now terminates at reset == currentRound.
- reset_round was the lone 1-based round field; every other round (RoundControls.Round, the RepeatRounds history, the pairing engine) is 0-based. Storing it 1-based forced a `-1` conversion and a `< 1` clamp, and made the proto3 zero-default an invalid sentinel. The reset_round stored in the proto is now 0-based: the dispatcher uses it directly, the proto3 zero-default (0) naturally means "avoid every prior meeting", and the clamp and conversion both go away. The director-facing "Reset Round" field stays 1-based; the frontend converts to and from the 0-based proto (input N stored as N-1).
- Allocation: both backtracking searches (the round-1 casement repair and the later-round matcher) allocated a fresh slice at every search node. Replaced with a per-depth scratch buffer reused across the search, and the director-block matrix is built once per call instead of once per relaxation pass.

## Guarantees
The off-by-one and allocation changes are behaviour-preserving -- the full pkg/pair suite passes unchanged. The reset_round base change shifts the test values (9->8, 7->6, 1->0) to describe identical thresholds, so every expectation holds.

## Migration
None. The Australian Draw is newly added and no persisted data depends on the old 1-based reset_round.

## Test plan
- [x] go test ./pkg/pair/ (incl. a new test pinning the reset loop terminates at currentRound)
- [x] go build ./pkg/... ./rpc/...
- [x] gofmt clean; tsc --noEmit + prettier (frontend reset_round handling)
