### PR TITLE
tick the correspondence and league deadline displays

### DIFF
--- a/liwords-ui/src/gameroom/simple_timer.tsx
+++ b/liwords-ui/src/gameroom/simple_timer.tsx
@@ -6,10 +6,15 @@ export const SimpleTimer = ({
   lastRefreshedPerformanceNow,
   millisAtLastRefresh,
   isRunning,
+  format,
 }: {
   lastRefreshedPerformanceNow: Millis;
   millisAtLastRefresh: Millis;
   isRunning: boolean;
+  // Optional formatter for the displayed (clamped, non-negative) millis. When
+  // omitted, the timer renders as "M:SS". Correspondence/league deadline
+  // displays pass millisToTimeStrWithoutDays for a "d:hh:mm:ss" clock.
+  format?: (millis: number) => string;
 }) => {
   const [, setRerender] = useState(0);
   const requestRerender = useCallback(
@@ -31,6 +36,10 @@ export const SimpleTimer = ({
       return () => clearTimeout(t);
     }
   }); // no dependency list, this effect should run on every render.
+
+  if (format) {
+    return <>{format(Math.max(currentMillis, 0))}</>;
+  }
 
   const currentSec = Math.ceil(currentMillis / 1000);
   const nonnegativeSec = Math.max(currentSec, 0);

--- a/liwords-ui/src/leagues/league_correspondence_games.tsx
+++ b/liwords-ui/src/leagues/league_correspondence_games.tsx
@@ -134,25 +134,6 @@ export const LeagueCorrespondenceGames: React.FC<
             game.players.findIndex((p) => p.uuid === userID) ===
               game.playerOnTurn;
 
-          // Bank-aware countdowns for the on-turn player: before-expiry is the
-          // hard deadline (per-turn allowance + bank - elapsed), before-bleed
-          // is the free-time window before the bank starts draining. The shared
-          // CorrespondenceTurnIndicator renders these (and the low-time /
-          // time-bank escalations) from the values below.
-          const now = Date.now();
-          let countdowns: ReturnType<typeof onTurnCountdowns> | undefined;
-          let hasTimeBank = false;
-          if (game.playerOnTurn !== undefined && game.lastUpdate) {
-            const timeElapsedSecs = (now - game.lastUpdate) / 1000;
-            const bankSecs = (game.timeBank?.[game.playerOnTurn] ?? 0) / 1000;
-            hasTimeBank = bankSecs > 0;
-            countdowns = onTurnCountdowns(
-              game.incrementSecs,
-              bankSecs,
-              timeElapsedSecs,
-            );
-          }
-
           // Get opponent name and scores
           const userPlayerIndex = game.players.findIndex(
             (p) => p.uuid === userID,
@@ -233,12 +214,17 @@ export const LeagueCorrespondenceGames: React.FC<
                     </span>
                   )}
                 </div>
-                {(isUserTurn || countdowns) && (
+                {game.playerOnTurn !== undefined && (
                   <div className="turn-indicator-compact">
                     <CorrespondenceTurnIndicator
-                      onTurn={!!isUserTurn}
-                      countdowns={countdowns}
-                      hasTimeBank={hasTimeBank}
+                      perspective={
+                        isUserTurn
+                          ? { kind: "mine" }
+                          : { kind: "opponent", playerName: opponentName }
+                      }
+                      lastUpdateMs={game.lastUpdate || undefined}
+                      incrementMs={game.incrementSecs * 1000}
+                      bankMs={game.timeBank?.[game.playerOnTurn] ?? 0}
                     />
                   </div>
                 )}

--- a/liwords-ui/src/lobby/correspondence_games.tsx
+++ b/liwords-ui/src/lobby/correspondence_games.tsx
@@ -22,10 +22,7 @@ import {
   GameInfoResponse,
 } from "../gen/api/proto/ipc/omgwords_pb";
 import { useClient } from "../utils/hooks/connect";
-import {
-  OnTurnCountdowns,
-  onTurnCountdowns,
-} from "../utils/time_bank_calculator";
+import { onTurnCountdowns } from "../utils/time_bank_calculator";
 import { GameMetadataService } from "../gen/api/proto/game_service/game_service_pb";
 
 type Props = {
@@ -137,16 +134,13 @@ export const CorrespondenceGames = (props: Props) => {
             onTurn = playerIndex === ag.playerOnTurn;
           }
 
-          // Compute the bank-aware countdowns for whoever is on turn. The
-          // before-expiry value is the real time-remaining we sort by (per-turn
-          // allowance + that player's remaining bank - elapsed); the shared
-          // CorrespondenceTurnIndicator renders it (and the low-time / time-bank
-          // escalations). This replaces the old bank-blind `incrementSecs -
-          // elapsed` proxy, which sorted league games (which have banks) wrong.
+          // The before-expiry value is the real time-remaining we sort by
+          // (per-turn allowance + that player's remaining bank - elapsed). This
+          // replaces the old bank-blind `incrementSecs - elapsed` proxy, which
+          // sorted league games (which have banks) wrong. The indicator itself
+          // ticks the live deadline from the clock anchor below.
           const now = Date.now();
           let timeRemainingSecs = Infinity;
-          let hasTimeBank = false;
-          let countdowns: OnTurnCountdowns | undefined;
           if (
             ag.playerOnTurn !== undefined &&
             ag.lastUpdate &&
@@ -154,26 +148,33 @@ export const CorrespondenceGames = (props: Props) => {
           ) {
             const timeElapsedSecs = (now - ag.lastUpdate) / 1000;
             const bankSecs = (ag.timeBank?.[ag.playerOnTurn] ?? 0) / 1000;
-            hasTimeBank = bankSecs > 0;
-            countdowns = onTurnCountdowns(
+            timeRemainingSecs = onTurnCountdowns(
               ag.incrementSecs,
               bankSecs,
               timeElapsedSecs,
-            );
-            timeRemainingSecs = countdowns.beforeExpiry;
+            ).beforeExpiry;
           }
 
-          // Condensed shared turn / countdown indicator: red "Your turn" with a
-          // coarse time inline and the full "expires in X, free for Y" detail in
-          // the tooltip; the opponent's clock is greyed since it is not the
-          // user's deadline.
-          const turnDisplay: ReactNode = (
-            <CorrespondenceTurnIndicator
-              onTurn={onTurn}
-              countdowns={countdowns}
-              hasTimeBank={hasTimeBank}
-            />
-          );
+          // Shared turn / countdown indicator: the live "d:hh:mm:ss" deadline
+          // inline (red "Your turn" / greyed "Their turn") with the free-time /
+          // time-bank breakdown ticking in the tooltip.
+          const turnDisplay: ReactNode =
+            ag.playerOnTurn === undefined ? null : (
+              <CorrespondenceTurnIndicator
+                perspective={
+                  onTurn
+                    ? { kind: "mine" }
+                    : {
+                        kind: "opponent",
+                        playerName:
+                          ag.players[ag.playerOnTurn]?.displayName || "?",
+                      }
+                }
+                lastUpdateMs={ag.lastUpdate || undefined}
+                incrementMs={(ag.incrementSecs || 0) * 1000}
+                bankMs={ag.timeBank?.[ag.playerOnTurn] ?? 0}
+              />
+            );
 
           return {
             gameID: ag.gameID,

--- a/liwords-ui/src/shared/corres_turn_indicator.test.tsx
+++ b/liwords-ui/src/shared/corres_turn_indicator.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  CorrespondencePerspective,
+  CorrespondenceTurnIndicator,
+} from "./corres_turn_indicator";
+
+// Pin both clocks so the time computations and the SimpleTimer display are
+// deterministic: Date.now() drives elapsed; performance.now() is fixed, so each
+// SimpleTimer renders its anchored value exactly (no extrapolation drift).
+const FIXED_NOW = 1_700_000_000_000;
+const HOUR = 3600 * 1000;
+const MIN = 60 * 1000;
+
+beforeEach(() => {
+  vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+  vi.spyOn(performance, "now").mockReturnValue(1000);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderIndicator(
+  perspective: CorrespondencePerspective,
+  opts: { elapsedMs: number; incrementMs: number; bankMs: number },
+) {
+  return render(
+    <CorrespondenceTurnIndicator
+      perspective={perspective}
+      lastUpdateMs={FIXED_NOW - opts.elapsedMs}
+      incrementMs={opts.incrementMs}
+      bankMs={opts.bankMs}
+    />,
+  );
+}
+
+// Common anchor: 10h per-turn allowance, 96h bank, 2m elapsed (not bleeding).
+// X = 10h + 96h - 2m = 105h58m = 4d 9h 58m; Y = 10h - 2m = 9h58m; Z = 96h.
+const notBleeding = {
+  elapsedMs: 2 * MIN,
+  incrementMs: 10 * HOUR,
+  bankMs: 96 * HOUR,
+};
+
+it("mine, not bleeding: 'Your turn' + the ticking d:hh:mm:ss deadline inline", () => {
+  const { getByText } = renderIndicator({ kind: "mine" }, notBleeding);
+  expect(getByText("Your turn")).toBeInTheDocument();
+  expect(getByText("4:09:58:00")).toBeInTheDocument();
+});
+
+it("mine, not bleeding: tooltip breaks the deadline into free time (Y) and bank (Z)", async () => {
+  const { getByText, findByText } = renderIndicator(
+    { kind: "mine" },
+    notBleeding,
+  );
+  fireEvent.mouseOver(getByText("Your turn"));
+  // Y (free window) = 9h58m -> 09:58:00, Z (bank) = 96h -> 4:00:00:00.
+  expect(
+    await findByText(/Your free time: 09:58:00, time bank: 4:00:00:00/),
+  ).toBeInTheDocument();
+});
+
+it("mine, bleeding: deadline counts down the bank; tooltip says it is draining", async () => {
+  // 10h05m elapsed: past the per-turn allowance, so the bank is bleeding.
+  // X = Z = 96h - 5m = 95h55m = 3d 23h 55m.
+  const { getByText, findByText } = renderIndicator(
+    { kind: "mine" },
+    {
+      elapsedMs: 10 * HOUR + 5 * MIN,
+      incrementMs: 10 * HOUR,
+      bankMs: 96 * HOUR,
+    },
+  );
+  expect(getByText("3:23:55:00")).toBeInTheDocument();
+  fireEvent.mouseOver(getByText("Your turn"));
+  expect(await findByText(/draining/i)).toBeInTheDocument();
+});
+
+it("opponent: greyed 'Their turn' + possessive, bank-free tooltip", async () => {
+  // No bank: X = 24h - 2m = 23h58m.
+  const { getByText, findByText } = renderIndicator(
+    { kind: "opponent", playerName: "Blibble" },
+    { elapsedMs: 2 * MIN, incrementMs: 24 * HOUR, bankMs: 0 },
+  );
+  expect(getByText("Their turn")).toBeInTheDocument();
+  expect(getByText("23:58:00")).toBeInTheDocument();
+  fireEvent.mouseOver(getByText("Their turn"));
+  expect(
+    await findByText(/Blibble's clock times out in 23:58:00/),
+  ).toBeInTheDocument();
+});
+
+it("spectator: labels by the on-turn player's name, no 'Your'/'Their'", () => {
+  const { getByText, queryByText } = renderIndicator(
+    { kind: "spectator", playerName: "ather" },
+    notBleeding,
+  );
+  expect(getByText("ather")).toBeInTheDocument();
+  expect(getByText("4:09:58:00")).toBeInTheDocument();
+  expect(queryByText("Your turn")).not.toBeInTheDocument();
+  expect(queryByText("Their turn")).not.toBeInTheDocument();
+});
+
+it("no clock anchor: renders the label only, no time, no crash", () => {
+  const { getByText, queryByText } = render(
+    <CorrespondenceTurnIndicator perspective={{ kind: "mine" }} />,
+  );
+  expect(getByText("Your turn")).toBeInTheDocument();
+  expect(queryByText(/\d+:\d\d/)).not.toBeInTheDocument();
+});

--- a/liwords-ui/src/shared/corres_turn_indicator.tsx
+++ b/liwords-ui/src/shared/corres_turn_indicator.tsx
@@ -1,11 +1,8 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Tooltip } from "antd";
 import { ClockCircleOutlined, FieldTimeOutlined } from "@ant-design/icons";
-import {
-  OnTurnCountdowns,
-  formatCoarseDuration,
-  formatCoarseDurationShort,
-} from "../utils/time_bank_calculator";
+import { SimpleTimer } from "../gameroom/simple_timer";
+import { millisToTimeStrWithoutDays } from "../store/timer_controller";
 
 // "Your turn" is always shown in this red so a glance at the list (especially
 // on mobile) tells you which games need a move. The low-time and time-bank
@@ -17,97 +14,213 @@ const YOUR_TURN_COLOR = "#ff4d4f";
 // the same here as it does on the board.
 const TIME_BANK_COLOR = "#52c41a";
 // Under a day to a forced timeout: surface the urgency with a clock icon.
-const LOW_TIME_SECS = 86400;
+const LOW_TIME_MS = 86400 * 1000;
+// setTimeout caps delays at ~24.8 days (2^31-1 ms); cap our transition timers
+// at that and let them reschedule. A correspondence deadline never reaches that
+// far out, so the cap is only a defensive backstop.
+const MAX_TIMEOUT_MS = 2147483647;
+
+// The shared "d:hh:mm:ss" clock (degrading to hh:mm:ss / mm:ss under a day /
+// hour), without subseconds. The same formatter the in-game clock uses, so the
+// list and the board read identically.
+const fmtClock = (millis: number) => millisToTimeStrWithoutDays(millis, false);
+
+// Perspective controls only the label, colour and the tooltip's possessive
+// subject -- never the ticking. "mine"/"opponent" are the participant views (the
+// league card and lobby list, which only ever show the viewer's own games);
+// "spectator" is the third-person view for the all-players standings popup.
+export type CorrespondencePerspective =
+  | { kind: "mine" }
+  | { kind: "opponent"; playerName: string }
+  | { kind: "spectator"; playerName: string };
 
 type Props = {
-  // Whether it is the logged-in user's turn in this game.
-  onTurn: boolean;
-  // Bank-aware countdowns for whoever is on turn; undefined when unknown.
-  countdowns?: OnTurnCountdowns;
-  // Whether the on-turn player still has time bank left to drain. Non-league
-  // correspondence games typically have no bank, so they never "bleed" -- they
-  // simply time out when the per-turn allowance runs out.
-  hasTimeBank?: boolean;
+  perspective: CorrespondencePerspective;
+  // The on-turn player's clock anchor: the epoch ms of their last move, their
+  // per-turn allowance (ms) and their remaining time bank (ms). When any is
+  // undefined the clock is unknown and only the turn label is shown.
+  lastUpdateMs?: number;
+  incrementMs?: number;
+  bankMs?: number;
 };
 
-// Condensed turn / time indicator shared by the lobby correspondence list and
-// the league "My League Games" card. The inline text stays terse -- "Your turn"
-// (red) plus a single coarse time unit -- while the verbose "expires in X, free
-// for Y" detail lives in the tooltip.
+// Turn / time indicator shared by the lobby correspondence list and the league
+// "My League Games" card. The inline text is the label plus a live "d:hh:mm:ss"
+// countdown to the hard deadline (X = per-turn allowance + bank - elapsed); the
+// tooltip breaks that down into the free window (Y) and the time bank (Z = X-Y),
+// each ticking. Exactly one of Y/Z drains at a time: Y until the bank starts
+// bleeding, then Z.
 export const CorrespondenceTurnIndicator = (props: Props) => {
-  const { onTurn, countdowns, hasTimeBank } = props;
+  const { perspective, lastUpdateMs, incrementMs, bankMs } = props;
 
-  if (!onTurn) {
-    // Opponent's clock -- greyed, since it is not the user's deadline.
-    const short = countdowns
-      ? formatCoarseDurationShort(countdowns.beforeExpiry)
-      : null;
-    const tooltip = countdowns
-      ? `Opponent's clock (not your deadline). Times out in ${formatCoarseDuration(
-          countdowns.beforeExpiry,
-        )}.`
-      : "Opponent's turn.";
+  const [, setRerender] = useState(0);
+  const requestRerender = useCallback(
+    () => setRerender((n) => (n + 1) | 0),
+    [],
+  );
+
+  // Anchor both clocks at the same instant: Date.now() places us on the
+  // server's epoch timeline (lastUpdateMs), while performance.now() is the
+  // monotonic reference the SimpleTimers extrapolate from (immune to wall-clock
+  // jumps). They are read together, so no conversion between them is needed.
+  const perfNow = performance.now();
+  const haveClock =
+    lastUpdateMs !== undefined &&
+    incrementMs !== undefined &&
+    bankMs !== undefined;
+
+  const incMs = incrementMs ?? 0;
+  const bnkMs = bankMs ?? 0;
+  const elapsedMs = lastUpdateMs === undefined ? 0 : Date.now() - lastUpdateMs;
+  const expiryMs = incMs + bnkMs - elapsedMs; // X: hard deadline (forfeit)
+  const bleedMs = Math.max(0, incMs - elapsedMs); // Y: free window before bleed
+  const bankRemMs = expiryMs - bleedMs; // Z: time bank remaining
+  const hasBank = haveClock && bnkMs > 0;
+  const isBleeding = hasBank && bleedMs <= 0;
+  const isLowTime = haveClock && expiryMs < LOW_TIME_MS;
+
+  // Re-render at the next state transition so the icon and tooltip template
+  // switch exactly when the state changes; the SimpleTimers handle the
+  // per-second number ticking themselves. Schedule the soonest of: bank starts
+  // bleeding (Y -> 0), low-time (X crosses 24h) and timeout (X -> 0). The delay
+  // is computed off the perfNow anchor so it stays precise, and capped at the
+  // setTimeout maximum (it then reschedules harmlessly).
+  useEffect(() => {
+    if (!haveClock) return;
+    const transitions = [expiryMs];
+    if (hasBank && !isBleeding) transitions.push(bleedMs);
+    if (!isLowTime) transitions.push(expiryMs - LOW_TIME_MS);
+    const next = Math.min(...transitions.filter((t) => t > 0));
+    if (!Number.isFinite(next)) return;
+    const delay = Math.min(
+      Math.max(next - (performance.now() - perfNow), 0),
+      MAX_TIMEOUT_MS,
+    );
+    const t = window.setTimeout(requestRerender, delay);
+    return () => window.clearTimeout(t);
+  });
+
+  let label: string;
+  let labelColor: string | undefined;
+  let outerOpacity: number | undefined;
+  let timeOpacity: number | undefined;
+  let subject: string; // possessive tooltip subject
+  let turnClass: string;
+  switch (perspective.kind) {
+    case "mine":
+      label = "Your turn";
+      labelColor = YOUR_TURN_COLOR;
+      timeOpacity = 0.7;
+      subject = "Your";
+      turnClass = "your-turn";
+      break;
+    case "opponent":
+      label = "Their turn";
+      outerOpacity = 0.55;
+      subject = `${perspective.playerName}'s`;
+      turnClass = "their-turn";
+      break;
+    case "spectator":
+      label = perspective.playerName;
+      timeOpacity = 0.7;
+      subject = `${perspective.playerName}'s`;
+      turnClass = "spectator-turn";
+      break;
+  }
+
+  if (!haveClock) {
     return (
-      <span className="corres-turn their-turn" style={{ opacity: 0.55 }}>
-        <Tooltip title={tooltip}>
-          Their turn
-          {short ? (
-            <span className="corres-turn-time" style={{ marginLeft: 6 }}>
-              {short}
-            </span>
-          ) : null}
-        </Tooltip>
+      <span
+        className={`corres-turn ${turnClass}`}
+        style={{ opacity: outerOpacity }}
+      >
+        <span style={{ color: labelColor }}>{label}</span>
       </span>
     );
   }
 
-  // Only a game with bank still to spend can "bleed"; a no-bank correspondence
-  // game just times out when its per-turn allowance runs out.
-  const isBleeding =
-    !!countdowns && !!hasTimeBank && countdowns.beforeBleed <= 0;
-  const isLowTime = countdowns
-    ? countdowns.beforeExpiry < LOW_TIME_SECS
-    : false;
-  const short = countdowns
-    ? formatCoarseDurationShort(countdowns.beforeExpiry)
-    : null;
-  const tooltip = !countdowns
-    ? "Your turn."
-    : isBleeding
-      ? `Using your time bank -- times out in ${formatCoarseDuration(
-          countdowns.beforeExpiry,
-        )}.`
-      : hasTimeBank
-        ? `Times out in ${formatCoarseDuration(
-            countdowns.beforeExpiry,
-          )} (free for ${formatCoarseDuration(
-            countdowns.beforeBleed,
-          )} before your time bank starts draining).`
-        : `Times out in ${formatCoarseDuration(countdowns.beforeExpiry)}.`;
+  const xTimer = (
+    <SimpleTimer
+      lastRefreshedPerformanceNow={perfNow}
+      millisAtLastRefresh={expiryMs}
+      isRunning
+      format={fmtClock}
+    />
+  );
+  // Y ticks only before bleeding; Z is steady until the bank bleeds, then ticks
+  // (one timer, isRunning = isBleeding) -- so exactly one of them is moving.
+  const yTimer = (
+    <SimpleTimer
+      lastRefreshedPerformanceNow={perfNow}
+      millisAtLastRefresh={bleedMs}
+      isRunning={!isBleeding}
+      format={fmtClock}
+    />
+  );
+  const zTimer = (
+    <SimpleTimer
+      lastRefreshedPerformanceNow={perfNow}
+      millisAtLastRefresh={bankRemMs}
+      isRunning={isBleeding}
+      format={fmtClock}
+    />
+  );
+
+  let tooltip: React.ReactNode;
+  if (!hasBank) {
+    // No bank (typical non-league correspondence): no bank terminology, so a
+    // correspondence-only player never sees the "time bank" concept.
+    tooltip = (
+      <span>
+        {subject} clock times out in {xTimer}
+      </span>
+    );
+  } else if (isBleeding) {
+    tooltip = (
+      <span>
+        {subject} time bank: {zTimer} draining
+      </span>
+    );
+  } else {
+    tooltip = (
+      <span>
+        {subject} free time: {yTimer}, time bank: {zTimer}
+      </span>
+    );
+  }
+
+  // Icons escalate the on-turn player's state. They show only on the viewer's
+  // own turn for now (the participant lists); the spectator popup will decide
+  // its own icon treatment.
+  const icon =
+    perspective.kind === "mine" ? (
+      isBleeding ? (
+        <FieldTimeOutlined
+          className="corres-turn-icon"
+          style={{ color: TIME_BANK_COLOR, marginRight: 4 }}
+        />
+      ) : isLowTime ? (
+        <ClockCircleOutlined
+          className="corres-turn-icon"
+          style={{ color: YOUR_TURN_COLOR, marginRight: 4 }}
+        />
+      ) : null
+    ) : null;
 
   return (
-    <span className="corres-turn your-turn">
+    <span
+      className={`corres-turn ${turnClass}`}
+      style={{ opacity: outerOpacity }}
+    >
       <Tooltip title={tooltip}>
-        {isBleeding ? (
-          <FieldTimeOutlined
-            className="corres-turn-icon"
-            style={{ color: TIME_BANK_COLOR, marginRight: 4 }}
-          />
-        ) : isLowTime ? (
-          <ClockCircleOutlined
-            className="corres-turn-icon"
-            style={{ color: YOUR_TURN_COLOR, marginRight: 4 }}
-          />
-        ) : null}
-        <span style={{ color: YOUR_TURN_COLOR }}>Your turn</span>
-        {short ? (
-          <span
-            className="corres-turn-time"
-            style={{ marginLeft: 6, opacity: 0.7 }}
-          >
-            {short}
-          </span>
-        ) : null}
+        {icon}
+        <span style={{ color: labelColor }}>{label}</span>
+        <span
+          className="corres-turn-time"
+          style={{ marginLeft: 6, opacity: timeOpacity }}
+        >
+          {xTimer}
+        </span>
       </Tooltip>
     </span>
   );

--- a/liwords-ui/src/utils/time_bank_calculator.test.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.test.ts
@@ -1,6 +1,4 @@
 import {
-  formatCoarseDuration,
-  formatCoarseDurationShort,
   nextPin,
   onTurnCountdowns,
   pickNextCorresGame,
@@ -58,32 +56,6 @@ it("onTurnCountdowns: the bank changes sort order vs the bank-blind proxy", () =
   const lowBank = onTurnCountdowns(perTurn, 3600, elapsed).beforeExpiry;
   const highBank = onTurnCountdowns(perTurn, 10 * 3600, elapsed).beforeExpiry;
   expect(lowBank).toBeLessThan(highBank);
-});
-
-it("formatCoarseDuration: renders coarse two-unit-max labels", () => {
-  expect(formatCoarseDuration(2 * 86400 + 3 * 3600)).toBe("2d 3h");
-  expect(formatCoarseDuration(2 * 86400)).toBe("2d");
-  expect(formatCoarseDuration(5 * 3600 + 12 * 60)).toBe("5h 12m");
-  expect(formatCoarseDuration(5 * 3600)).toBe("5h");
-  expect(formatCoarseDuration(47 * 60)).toBe("47m");
-  expect(formatCoarseDuration(30)).toBe("30s");
-});
-
-it("formatCoarseDuration: non-positive and non-finite render as 'now'", () => {
-  expect(formatCoarseDuration(0)).toBe("now");
-  expect(formatCoarseDuration(-100)).toBe("now");
-  expect(formatCoarseDuration(Infinity)).toBe("now");
-  expect(formatCoarseDuration(NaN)).toBe("now");
-});
-
-it("formatCoarseDurationShort: renders only the single largest unit", () => {
-  expect(formatCoarseDurationShort(2 * 86400 + 3 * 3600)).toBe("2d");
-  expect(formatCoarseDurationShort(5 * 3600 + 12 * 60)).toBe("5h");
-  expect(formatCoarseDurationShort(47 * 60 + 30)).toBe("47m");
-  expect(formatCoarseDurationShort(30)).toBe("30s");
-  expect(formatCoarseDurationShort(0)).toBe("now");
-  expect(formatCoarseDurationShort(-5)).toBe("now");
-  expect(formatCoarseDurationShort(Infinity)).toBe("now");
 });
 
 it("pickNextCorresGame: clicking Next once per game cycles through all and returns to the first", () => {

--- a/liwords-ui/src/utils/time_bank_calculator.ts
+++ b/liwords-ui/src/utils/time_bank_calculator.ts
@@ -106,64 +106,6 @@ export function onTurnCountdowns(
   };
 }
 
-/**
- * Format a duration (in seconds) coarsely for the correspondence/league game
- * lists. Granularity is intentionally low (at most two adjacent units, never
- * per-second) since these are multi-hour/day countdowns that only refresh on
- * list updates. Examples: "2d 3h", "5h 12m", "47m", "30s", "now".
- *
- * Non-positive inputs render as "now" (the deadline has passed / is imminent).
- */
-export function formatCoarseDuration(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds <= 0) {
-    return "now";
-  }
-  const totalSeconds = Math.floor(seconds);
-  const days = Math.floor(totalSeconds / 86400);
-  const hours = Math.floor((totalSeconds % 86400) / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const secs = totalSeconds % 60;
-
-  if (days > 0) {
-    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
-  }
-  if (hours > 0) {
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m`;
-  }
-  return `${secs}s`;
-}
-
-/**
- * Like formatCoarseDuration but renders only the single largest unit, for the
- * compact at-a-glance time shown inline in the correspondence/league game
- * lists. The full two-unit value (and the free-time window) belong in a
- * tooltip. Examples: "2d", "5h", "47m", "30s", "now".
- *
- * Non-positive inputs render as "now" (the deadline has passed / is imminent).
- */
-export function formatCoarseDurationShort(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds <= 0) {
-    return "now";
-  }
-  const totalSeconds = Math.floor(seconds);
-  const days = Math.floor(totalSeconds / 86400);
-  if (days > 0) {
-    return `${days}d`;
-  }
-  const hours = Math.floor((totalSeconds % 86400) / 3600);
-  if (hours > 0) {
-    return `${hours}h`;
-  }
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  if (minutes > 0) {
-    return `${minutes}m`;
-  }
-  return `${totalSeconds % 60}s`;
-}
-
 export type NextCorresPick<T> = {
   // The game to jump to next, or null when there is nowhere to cycle to.
   next: T | null;


### PR DESCRIPTION
## Summary
The lobby "My Games" and league "My League Games" lists showed a static, coarse "2d" / "5h" time that only refreshed on data updates. Render a live d:hh:mm:ss countdown to the hard deadline (per-turn allowance + bank - elapsed) inline instead, with the free-time / time-bank breakdown ticking in the tooltip. This replaces the coarse condensed time added in #1878.

## Changes
- CorrespondenceTurnIndicator now takes the clock anchor (the on-turn player's last-move timestamp, per-turn allowance and remaining bank) and drives SimpleTimer leaves: the inline deadline X, and in the tooltip the free window Y and the bank Z = X - Y. Exactly one of Y/Z drains at a time -- Y until the bank bleeds, then Z.
- The indicator re-renders only at state transitions (bleed start, the 24h low-time mark, timeout), scheduled off a performance.now anchor and capped at the setTimeout maximum, so the icon and tooltip wording switch exactly on the transition while the SimpleTimers handle the per-second ticking.
- SimpleTimer gains an optional format prop (default M:SS unchanged), so the displays reuse its drift-free, self-scheduling tick with the d:hh:mm:ss formatter.
- A perspective prop (mine / opponent / spectator) carries the label, colour and possessive tooltip subject. The spectator case is unused here -- it is the seam for the league season-games modal (follow-up PR).
- Removed the now-dead coarse-duration formatters.

## Test plan
- [x] vitest: new render tests for the indicator (labels, d:hh:mm:ss format + degradation, tooltip breakdown, perspectives, no-clock path)
- [x] tsc --noEmit, eslint, prettier
- [x] smoke-tested in a browser across all states -- rendering and live ticking confirmed
