### PR TITLE
fit the lobby correspondence turn label on one line

### DIFF
--- a/liwords-ui/src/lobby/correspondence_games.tsx
+++ b/liwords-ui/src/lobby/correspondence_games.tsx
@@ -173,6 +173,7 @@ export const CorrespondenceGames = (props: Props) => {
                 lastUpdateMs={ag.lastUpdate || undefined}
                 incrementMs={(ag.incrementSecs || 0) * 1000}
                 bankMs={ag.timeBank?.[ag.playerOnTurn] ?? 0}
+                compact
               />
             );
 

--- a/liwords-ui/src/shared/corres_turn_indicator.test.tsx
+++ b/liwords-ui/src/shared/corres_turn_indicator.test.tsx
@@ -24,7 +24,12 @@ afterEach(() => {
 
 function renderIndicator(
   perspective: CorrespondencePerspective,
-  opts: { elapsedMs: number; incrementMs: number; bankMs: number },
+  opts: {
+    elapsedMs: number;
+    incrementMs: number;
+    bankMs: number;
+    compact?: boolean;
+  },
 ) {
   return render(
     <CorrespondenceTurnIndicator
@@ -32,6 +37,7 @@ function renderIndicator(
       lastUpdateMs={FIXED_NOW - opts.elapsedMs}
       incrementMs={opts.incrementMs}
       bankMs={opts.bankMs}
+      compact={opts.compact}
     />,
   );
 }
@@ -87,6 +93,31 @@ it("opponent: greyed 'Their turn' + possessive, bank-free tooltip", async () => 
   expect(getByText("Their turn")).toBeInTheDocument();
   expect(getByText("23:58:00")).toBeInTheDocument();
   fireEvent.mouseOver(getByText("Their turn"));
+  expect(
+    await findByText(/Blibble's clock times out in 23:58:00/),
+  ).toBeInTheDocument();
+});
+
+it("compact mine: 'You' replaces 'Your turn'; the ticking deadline still shows", () => {
+  const { getByText, queryByText } = renderIndicator(
+    { kind: "mine" },
+    { ...notBleeding, compact: true },
+  );
+  expect(getByText("You")).toBeInTheDocument();
+  expect(queryByText("Your turn")).not.toBeInTheDocument();
+  expect(getByText("4:09:58:00")).toBeInTheDocument();
+});
+
+it("compact opponent: 'Opp' replaces 'Their turn'; tooltip keeps the full possessive", async () => {
+  const { getByText, queryByText, findByText } = renderIndicator(
+    { kind: "opponent", playerName: "Blibble" },
+    { elapsedMs: 2 * MIN, incrementMs: 24 * HOUR, bankMs: 0, compact: true },
+  );
+  expect(getByText("Opp")).toBeInTheDocument();
+  expect(queryByText("Their turn")).not.toBeInTheDocument();
+  // compact only shrinks the inline label -- the tooltip still spells out whose
+  // clock it is.
+  fireEvent.mouseOver(getByText("Opp"));
   expect(
     await findByText(/Blibble's clock times out in 23:58:00/),
   ).toBeInTheDocument();

--- a/liwords-ui/src/shared/corres_turn_indicator.tsx
+++ b/liwords-ui/src/shared/corres_turn_indicator.tsx
@@ -227,10 +227,13 @@ export const CorrespondenceTurnIndicator = (props: Props) => {
       <Tooltip title={tooltip}>
         {icon}
         {label ? <span style={{ color: labelColor }}>{label}</span> : null}
-        <span
-          className="corres-turn-time"
-          style={{ marginLeft: label ? 6 : 0, opacity: timeOpacity }}
-        >
+        {/* Separate label and clock with a real space, not the time span's
+            margin: a space is a line-break opportunity, so a narrow column
+            wraps cleanly to label / clock ("Your turn" / "10:09:33:33")
+            rather than overflowing as one unbreakable run. A margin gives
+            the gap but never breaks, and would indent the clock on wrap. */}
+        {label ? " " : null}
+        <span className="corres-turn-time" style={{ opacity: timeOpacity }}>
           {xTimer}
         </span>
       </Tooltip>

--- a/liwords-ui/src/shared/corres_turn_indicator.tsx
+++ b/liwords-ui/src/shared/corres_turn_indicator.tsx
@@ -47,6 +47,11 @@ type Props = {
   lastUpdateMs?: number;
   incrementMs?: number;
   bankMs?: number;
+  // Shorten the participant labels ("Your turn" -> "You", "Their turn" -> "Opp")
+  // for width-constrained surfaces. The lobby correspondence list opts in (its
+  // narrow TURN column wraps the two-word label past the ticking clock); the
+  // wider league card keeps the full wording.
+  compact?: boolean;
 };
 
 // Turn / time indicator shared by the lobby correspondence list and the league
@@ -56,7 +61,7 @@ type Props = {
 // each ticking. Exactly one of Y/Z drains at a time: Y until the bank starts
 // bleeding, then Z.
 export const CorrespondenceTurnIndicator = (props: Props) => {
-  const { perspective, lastUpdateMs, incrementMs, bankMs } = props;
+  const { perspective, lastUpdateMs, incrementMs, bankMs, compact } = props;
 
   const [, setRerender] = useState(0);
   const requestRerender = useCallback(
@@ -113,14 +118,14 @@ export const CorrespondenceTurnIndicator = (props: Props) => {
   let turnClass: string;
   switch (perspective.kind) {
     case "mine":
-      label = "Your turn";
+      label = compact ? "You" : "Your turn";
       labelColor = YOUR_TURN_COLOR;
       timeOpacity = 0.7;
       subject = "Your";
       turnClass = "your-turn";
       break;
     case "opponent":
-      label = "Their turn";
+      label = compact ? "Opp" : "Their turn";
       outerOpacity = 0.55;
       subject = `${perspective.playerName}'s`;
       turnClass = "their-turn";


### PR DESCRIPTION
## Summary

Follows up on #1878 (added the shared correspondence turn indicator) and #1887 (made its deadline tick live). The lobby's narrow TURN column wrapped the two-word "Your turn" / "Their turn" label past the ticking deadline -- breaking mid-label as "Your" / "turn 4:09:33:33".

Two changes (one commit each):

1. Separate the label and clock with a real space instead of the time span's left margin. A margin renders a gap but is not a line-break opportunity, so a narrow column could only break inside the label (or, for a single-word label, not at all). A space gives the same gap and is a break point, so a tight column now wraps cleanly to label / clock ("Your turn" / "10:09:33:33"). This lives in the shared indicator, so it helps every surface. The clock is a single space-less token in every format (mm:ss, hh:mm:ss, d:hh:mm:ss), so it never splits.

2. Add a `compact` mode to the shared turn indicator and opt the lobby list into it: it renders "You" / "Opp", keeping the red / dimmed colors. The wider league "My League Games" card and the season-games modal keep the full wording.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean (no new warnings)
- [x] `prettier --check` clean
- [x] `vitest` corres_turn_indicator.test.tsx: 9 passed (+2 compact cases)
- [x] Layout verified via faithful standalone renders (lobby compact + clean wrap; league card and season modal unchanged); not yet checked in the running app
