### PR TITLE
feat: log game ID and all words for invalid-word plays

### DIFF
--- a/.claude/commands/player-invalid-words.md
+++ b/.claude/commands/player-invalid-words.md
@@ -1,0 +1,82 @@
+---
+description: Look up a player's invalid word attempts (VOID challenge rejections) from CloudWatch liwords-api logs
+argument-hint: <username> [days=90]
+allowed-tools: [Bash]
+---
+
+# Player Invalid Words Lookup
+
+Search CloudWatch logs for words a Woogles player tried to play that were rejected in VOID-challenge games.
+
+## Arguments
+
+The user invoked this with: $ARGUMENTS
+
+Parse the arguments as:
+- First argument: the username to search for (required)
+- Second argument: number of days to look back (optional, default: 90)
+
+## Instructions
+
+1. Parse the username and days from `$ARGUMENTS`. If no days value is given, use 90.
+
+2. Look up the player's UUID from the production database:
+
+```bash
+bin/proddb -c "SELECT uuid FROM users WHERE username ILIKE 'USERNAME';"
+```
+
+If no user is found, report that the username doesn't exist and stop.
+
+3. Start a CloudWatch Logs Insights query using the UUID (substitute UUID and DAYS).
+
+   **Primary query** — rich logs (emitted after the logging improvement was deployed):
+   ```bash
+   AWS_PROFILE=woogles-prod aws logs start-query \
+     --log-group-name /ecs/liwords-api \
+     --start-time $(date -d 'DAYS days ago' +%s) \
+     --end-time $(date +%s) \
+     --query-string 'fields @timestamp, @message | filter @message like "UUID" and @message like "invalid-word-play" | sort @timestamp asc | limit 10000' \
+     --output text
+   ```
+
+   **Fallback query** — old-format logs (from before the improvement, no game ID):
+   ```bash
+   AWS_PROFILE=woogles-prod aws logs start-query \
+     --log-group-name /ecs/liwords-api \
+     --start-time $(date -d 'DAYS days ago' +%s) \
+     --end-time $(date +%s) \
+     --query-string 'fields @timestamp, @message | filter @message like "UUID" and @message like "process-message-publish-error" and @message like "invalid words" | sort @timestamp asc | limit 10000' \
+     --output text
+   ```
+
+   Run **both** queries. Each returns a query ID.
+
+4. Wait a few seconds, then fetch the results for each query ID:
+
+```bash
+sleep 5 && AWS_PROFILE=woogles-prod aws logs get-query-results \
+  --query-id QUERY_ID \
+  --output json
+```
+
+If the status is not `Complete`, wait a few more seconds and retry.
+
+5. Parse the results:
+
+   **Rich logs** (`invalid-word-play`): Each log entry is JSON like:
+   ```json
+   {"level":"info","gameID":"AbCxYz123","userID":"3eBxxpLe84ikdRDu5nn896","words":["CRANE","AR","NE"],"error":"the play contained invalid words: AR, NE","time":"...","message":"invalid-word-play"}
+   ```
+   Fields: `gameID`, `userID`, `words` (all formed words — main word + cross-words), `error` (which of those words were invalid).
+
+   **Old-format logs** (`process-message-publish-error`): Each entry has only the `error` field containing `"the play contained invalid words: WORD1, WORD2"`. No game ID, no valid words. Label these with "(legacy log — no game ID)".
+
+6. Report:
+   - Total count of rejected plays (rich + legacy combined)
+   - Results grouped by game ID (for rich logs), then chronologically within each game. For each rejected play show:
+     - Timestamp
+     - All words formed: list `words` with invalid ones flagged (cross-reference with the `error` field)
+     - Game ID (or "(legacy — no game ID)")
+   - Legacy-log entries listed separately if any, with a note that they predate the richer logging.
+   - Any patterns worth noting: words probed multiple times, two-letter fishing, common root being inflected, etc.

--- a/.claude/commands/player-ip.md
+++ b/.claude/commands/player-ip.md
@@ -1,0 +1,47 @@
+---
+description: Look up a player's IP addresses from CloudWatch liwords-socket logs and geolocate them
+argument-hint: <username> [days=3]
+allowed-tools: [Bash]
+---
+
+# Player IP Lookup
+
+Look up IP addresses for a Woogles player from CloudWatch logs and geolocate each unique IP.
+
+## Arguments
+
+The user invoked this with: $ARGUMENTS
+
+Parse the arguments as:
+- First argument: the username to search for (required)
+- Second argument: number of days to look back (optional, default: 3)
+
+## Instructions
+
+1. Parse the username and days from `$ARGUMENTS`. If no days value is given, use 3.
+
+2. Run this command to fetch logs (substitute USERNAME and DAYS):
+
+```bash
+AWS_PROFILE=woogles-prod aws logs filter-log-events \
+  --log-group-name "/ecs/liwords-socket" \
+  --filter-pattern '{ $.username = "USERNAME" }' \
+  --start-time $(date -d 'DAYS days ago' +%s000) \
+  --query 'events[*].message' \
+  --output json
+```
+
+3. From the results, extract all values of the `ips` field. The format is `"client_ip, aws_ip"` — the **first** IP is the client's IP; the second is AWS infrastructure (ignore it).
+
+4. Collect all unique client IPs across all log entries.
+
+5. For each unique client IP, run:
+
+```bash
+curl -s https://ipinfo.io/IP_HERE/json
+```
+
+6. Report:
+   - The unique client IP(s) found with geolocation details (city, region, country, org/ISP, hostname)
+   - A session summary table: date/time, client IP, duration (first to last pong in the session), connection ID
+   - Note if the IP looks like a VPN, proxy, or datacenter vs. residential ISP

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -507,6 +507,25 @@ func PlayMove(ctx context.Context,
 
 	_, err := entGame.Game.ValidateMove(m)
 	if err != nil {
+		// Invalid-word plays (VOID challenge rule) form legal words on the board but
+		// fail lexicon validation. FormedWords succeeds only for a geometrically legal
+		// tile play, so a successful call here — after ValidateMove failed — uniquely
+		// identifies the invalid-words case. Log all words (valid + invalid) plus the
+		// game ID for analysis. The error returned to the client is unchanged.
+		if m.Action() == move.MoveTypePlay {
+			if formed, fwErr := entGame.Board().FormedWords(m); fwErr == nil && len(formed) > 0 {
+				words := make([]string, len(formed))
+				for i, w := range formed {
+					words[i] = w.UserVisible(entGame.Alphabet())
+				}
+				log.Info().
+					Str("gameID", entGame.GameID()).
+					Str("userID", userID).
+					Strs("words", words).
+					Err(err).
+					Msg("invalid-word-play")
+			}
+		}
 		return err
 	}
 	// This cannot be deferred, because if performEndgameDuties expires the game this would unexpire it.


### PR DESCRIPTION
## Summary

- Invalid-word plays in VOID-challenge games were previously only logged with the invalid words themselves and no game ID (via the generic `process-message-publish-error` log in `bus.go`)
- Adds a structured `invalid-word-play` Info log at the `ValidateMove` failure site in `PlayMove` (`pkg/gameplay/game.go`) with:
  - `gameID` — the game where the play was attempted
  - `userID` — the player who attempted it
  - `words` — **all** words formed by the play (main word + cross-words, valid and invalid)
  - `error` — the existing macondo error string identifying which words were invalid
- The error returned to the frontend is completely unchanged

## Test plan

- [ ] `go build ./pkg/gameplay/...` passes (no new imports needed)
- [ ] The error returned to clients is unchanged — VOID-challenge behavior is unaffected
- [ ] After deploy: play an invalid word in a VOID-challenge game and confirm the `invalid-word-play` log appears in `/ecs/liwords-api` with `gameID`, `userID`, and the full `words` array

🤖 Generated with [Claude Code](https://claude.ai/claude-code)