### PR TITLE
fix [object Object] in two-column scorecard for challenged play-out

### DIFF
--- a/liwords-ui/src/gameroom/scorecard.test.tsx
+++ b/liwords-ui/src/gameroom/scorecard.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import {
+  GameEvent_Type,
+  GameEventSchema,
+} from "../gen/api/proto/vendored/macondo/macondo_pb";
+import { Board } from "../utils/cwgame/board";
+import { StandardEnglishAlphabet } from "../constants/alphabets";
+import { TwoColTurn, twoColScore } from "./scorecard";
+
+afterEach(cleanup);
+
+// twoColScore builds the two-column score text. Segments that render on their
+// own line are joined with "\n"; the scorecard render site splits on it and
+// inserts <br/>. See issue #1895.
+
+const play = (score: number, cumulative: number) =>
+  create(GameEventSchema, { rack: "ABDEKOR", score, cumulative });
+
+const challengeBonus = (bonus: number, cumulative: number) =>
+  create(GameEventSchema, {
+    type: GameEvent_Type.CHALLENGE_BONUS,
+    bonus,
+    cumulative,
+  });
+
+const endRackPts = (endRackPoints: number, cumulative: number) =>
+  create(GameEventSchema, {
+    type: GameEvent_Type.END_RACK_PTS,
+    endRackPoints,
+    cumulative,
+  });
+
+const phony = (cumulative: number) =>
+  create(GameEventSchema, {
+    type: GameEvent_Type.PHONY_TILES_RETURNED,
+    cumulative,
+  });
+
+it("shows the score for a plain play", () => {
+  expect(twoColScore([play(12, 979)])).toBe("+12");
+});
+
+it("stacks a valid-challenge bonus after the play", () => {
+  expect(twoColScore([play(12, 979), challengeBonus(5, 984)])).toBe("+12\n+5");
+});
+
+it("appends end-of-game rack points for a play-out", () => {
+  expect(twoColScore([play(12, 979), endRackPts(2, 981)])).toBe("+12+2");
+});
+
+it("blanks the score when a phony is returned", () => {
+  expect(twoColScore([play(40, 200), phony(160)])).toBe("");
+});
+
+// Regression: playing out on a word that is then challenged (and holds)
+// produces play + CHALLENGE_BONUS + END_RACK_PTS in one turn. The builder must
+// stay a plain string; the old code interpolated a ReactNode into a template
+// literal, rendering as "[object Object]". See issue #1895.
+it("renders play + challenge bonus + end rack without [object Object]", () => {
+  const text = twoColScore([
+    play(12, 979),
+    challengeBonus(5, 984),
+    endRackPts(2, 986),
+  ]);
+  expect(text).not.toContain("[object Object]");
+  expect(text).toBe("+12\n+5+2");
+});
+
+// End-to-end render of the actual TwoColTurn component. The aggregated score
+// must reach the DOM as "+12" / "+5+2" (the "\n" split into a real <br/>),
+// never "[object Object]", alongside the correct cumulative and challenge
+// label. This exercises the render path the unit tests above do not.
+it("renders the aggregated score in the DOM without [object Object]", () => {
+  const turn = {
+    events: [
+      create(GameEventSchema, {
+        rack: "ABDEKOR",
+        playedTiles: "WORD",
+        position: "3C",
+        row: 2,
+        column: 2,
+        score: 12,
+        cumulative: 979,
+      }),
+      challengeBonus(5, 984),
+      endRackPts(2, 986),
+    ],
+    firstEvtIdx: 0,
+  };
+  const { container } = render(
+    <TwoColTurn
+      turn={turn}
+      board={new Board()}
+      alphabet={StandardEnglishAlphabet}
+    />,
+  );
+  expect(container.textContent).not.toContain("[object Object]");
+  const scoreCell = container.querySelector(".two-col-score");
+  expect(scoreCell?.querySelector("br")).toBeTruthy();
+  expect(scoreCell?.textContent).toBe("+12+5+2");
+  expect(container.querySelector(".two-col-cumulative")?.textContent).toBe(
+    "986",
+  );
+  expect(container.textContent).toContain("Challenge! Valid");
+});

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -413,21 +413,53 @@ type TwoColTurnProps = {
   turnIndex?: number;
 };
 
-const TwoColTurn = React.memo((props: TwoColTurnProps) => {
-  const { turn, board, alphabet, onSeek, isSelected } = props;
-  const evt = turn.events[0];
-
-  const coords = evt.position || "";
-  const play: React.ReactNode = displaySummary(evt, board, alphabet);
-  let score: React.ReactNode =
+// Build the compact score text for the two-column scorecard. A single turn can
+// aggregate several events: the play, a valid-challenge bonus, and end-of-game
+// rack points when a player plays out. Segments that belong on their own line
+// are joined with "\n"; the render site splits on it and inserts <br/>. Keeping
+// this a plain string (rather than nested JSX) avoids interpolating a ReactNode,
+// which would render as "[object Object]".
+export function twoColScore(events: Array<GameEvent>): string {
+  const evt = events[0];
+  // Explicitly string (not ReactNode): assigning a JSX fragment here is what
+  // produced "[object Object]" once a later branch interpolated it. See #1895.
+  let score: string =
     evt.type === GameEvent_Type.END_RACK_PTS
       ? `+${evt.endRackPoints}`
       : evt.lostScore > 0
         ? `-${evt.lostScore}`
         : `+${evt.score}`;
-  let cumulative = evt.cumulative;
+  if (events.length <= 1) {
+    return score;
+  }
+  // A returned phony zeroes the play; the score column shows nothing.
+  if (events.some((e) => e.type === GameEvent_Type.PHONY_TILES_RETURNED)) {
+    return "";
+  }
+  for (let i = 1; i < events.length; i++) {
+    switch (events[i].type) {
+      case GameEvent_Type.CHALLENGE_BONUS:
+        score = `${score}\n+${events[i].bonus}`;
+        break;
+      case GameEvent_Type.END_RACK_PTS:
+        score = `${score}+${events[i].endRackPoints}`;
+        break;
+    }
+  }
+  return score;
+}
 
-  // Handle multi-event turns (challenges, etc.)
+export const TwoColTurn = React.memo((props: TwoColTurnProps) => {
+  const { turn, board, alphabet, onSeek, isSelected } = props;
+  const evt = turn.events[0];
+
+  const coords = evt.position || "";
+  const play: React.ReactNode = displaySummary(evt, board, alphabet);
+  const score = twoColScore(turn.events);
+  // cumulative is the running total after the turn's final event.
+  const cumulative = turn.events[turn.events.length - 1].cumulative;
+
+  // phonyEvt/bonusEvt drive the challenge label shown in the rack row below.
   // Use find() rather than checking index 1 — single challenge inserts a CHALLENGE event before PHONY/BONUS.
   const phonyEvt = turn.events.find(
     (e) => e.type === GameEvent_Type.PHONY_TILES_RETURNED,
@@ -435,29 +467,6 @@ const TwoColTurn = React.memo((props: TwoColTurnProps) => {
   const bonusEvt = turn.events.find(
     (e) => e.type === GameEvent_Type.CHALLENGE_BONUS,
   );
-  if (turn.events.length > 1) {
-    if (phonyEvt) {
-      score = "";
-      cumulative = phonyEvt.cumulative;
-    } else {
-      for (let i = 1; i < turn.events.length; i++) {
-        switch (turn.events[i].type) {
-          case GameEvent_Type.CHALLENGE_BONUS:
-            score = (
-              <>
-                {score}
-                <br />+{turn.events[i].bonus}
-              </>
-            );
-            break;
-          case GameEvent_Type.END_RACK_PTS:
-            score = `${score}+${turn.events[i].endRackPoints}`;
-            break;
-        }
-        cumulative = turn.events[i].cumulative;
-      }
-    }
-  }
 
   const isPhony = !!phonyEvt;
   const isValidChallenge = !!bonusEvt;
@@ -483,7 +492,14 @@ const TwoColTurn = React.memo((props: TwoColTurnProps) => {
         {play}
       </div>
       <div className="two-col-scores">
-        <div className="two-col-score">{score}</div>
+        <div className="two-col-score">
+          {score.split("\n").map((line, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <br />}
+              {line}
+            </React.Fragment>
+          ))}
+        </div>
         <div className="two-col-cumulative">{cumulative}</div>
       </div>
       <div className="two-col-comment-spot">


### PR DESCRIPTION
## Summary

The two-column scorecard rendered `[object Object]` in the score column for a turn that aggregates a play, a valid-challenge bonus, and end-of-game rack points -- e.g. the final turn of game `BoSCFpffhv` (#1895), where a player plays out and the word is then challenged (and holds).

## Bug

`TwoColTurn` built the score column by appending the challenge bonus as a JSX fragment, then appended the end-of-game rack points with a template literal (`` `${score}+${endRackPoints}` ``). Interpolating the fragment into the template string coerced it to `[object Object]`. It only triggered when a single turn carried all three events (`TILE_PLACEMENT` + `CHALLENGE_BONUS` + `END_RACK_PTS`). The one-column view was unaffected -- it keeps the score a plain string throughout.

Introduced in #1829, which changed the challenge-bonus branch to a `<br/>` JSX fragment (the original two-column view in #1826 kept the score a string) but left the end-rack branch a template literal.

## Fix

- Extract the aggregation into a pure `twoColScore(events): string` that joins separate-line segments with `\n`; the render site splits on `\n` and inserts `<br/>`.
- Type the score `string` (return type + local), so reintroducing a `ReactNode` is now a compile error rather than `[object Object]` at runtime.
- One-column path left unchanged (already correct and type-protected via `MoveEntityObj.score: string`).

## Test plan

- [x] `vitest src/gameroom/scorecard.test.tsx` -- covers `twoColScore` for the plain / valid-challenge / play-out / phony / three-event cases, plus a DOM render of `TwoColTurn` asserting a real `<br/>`, score text `+12+5+2`, cumulative `986`, and no `[object Object]`.
- [x] `npx tsc --noEmit` clean; confirmed the string type rejects a reintroduced fragment (`TS2322: Type 'Element' is not assignable to type 'string'`).
- [x] `eslint` clean on changed files.
- [x] `prettier --check` clean.

Fixes #1895.
