### PR TITLE
fix: sanitize racks in add-time history refresher

### DIFF
--- a/pkg/gameplay/meta_events.go
+++ b/pkg/gameplay/meta_events.go
@@ -8,6 +8,7 @@ import (
 	macondopb "github.com/domino14/macondo/gen/api/proto/macondo"
 	"github.com/rs/zerolog/log"
 	"github.com/woogles-io/liwords/pkg/entity"
+	"github.com/woogles-io/liwords/pkg/mod"
 	"github.com/woogles-io/liwords/pkg/stores"
 	pb "github.com/woogles-io/liwords/rpc/api/proto/ipc"
 	"google.golang.org/protobuf/proto"
@@ -278,12 +279,17 @@ func HandleMetaEvent(ctx context.Context, evt *pb.GameMetaEvent, eventChan chan<
 		wrapped.AddAudience(entity.AudGameTV, evt.GameId)
 		eventChan <- wrapped
 
-		// Also send updated time info via GameHistoryRefresher.
-		// Censor racks for spectators in league/private-analysis games.
+		// Also send updated time info via GameHistoryRefresher. Send it to
+		// each player individually (AudUser) so the bus sanitizes opponent
+		// racks; an AudGame broadcast bypasses sanitization and would reveal
+		// both racks to both players.
 		refresher := g.HistoryRefresherEvent()
+		refresher.History = proto.Clone(mod.CensorHistory(ctx, stores.UserStore, refresher.History)).(*macondopb.GameHistory)
 		if shouldCensorRacksForViewers(ctx, g, stores) {
 			playerRefresher := entity.WrapEvent(refresher, pb.MessageType_GAME_HISTORY_REFRESHER)
-			playerRefresher.AddAudience(entity.AudGame, evt.GameId)
+			for _, p := range players(g) {
+				playerRefresher.AddAudience(entity.AudUser, p+".game."+evt.GameId)
+			}
 			eventChan <- playerRefresher
 
 			censoredRefresher := proto.Clone(refresher).(*pb.GameHistoryRefresher)
@@ -293,8 +299,10 @@ func HandleMetaEvent(ctx context.Context, evt *pb.GameMetaEvent, eventChan chan<
 			eventChan <- tvRefresher
 		} else {
 			refresherWrapped := entity.WrapEvent(refresher, pb.MessageType_GAME_HISTORY_REFRESHER)
-			refresherWrapped.AddAudience(entity.AudGame, evt.GameId)
 			refresherWrapped.AddAudience(entity.AudGameTV, evt.GameId)
+			for _, p := range players(g) {
+				refresherWrapped.AddAudience(entity.AudUser, p+".game."+evt.GameId)
+			}
 			eventChan <- refresherWrapped
 		}
 

--- a/pkg/gameplay/meta_events_test.go
+++ b/pkg/gameplay/meta_events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -750,6 +751,60 @@ func TestDisallowSamePlayerAbortAcceptance(t *testing.T) {
 	// expected events: game history, request abort
 	log.Debug().Interface("evts", gsetup.consumer.evts).Msg("evts")
 	is.Equal(len(gsetup.consumer.evts), 2)
+
+	teardownGame(gsetup)
+}
+
+func TestAddTimeDoesNotBroadcastRacksToGameChannel(t *testing.T) {
+	is := is.New(t)
+	gsetup := setupNewGame()
+
+	// Jesse adds time to their opponent.
+	opponentIdx := -1
+	for i, p := range gsetup.g.History().Players {
+		if p.UserId != "3xpEkpRAy3AizbVmDg3kdi" {
+			opponentIdx = i
+		}
+	}
+	opponentTimeBefore := gsetup.g.TimeRemaining(opponentIdx)
+
+	metaEvt := &pb.GameMetaEvent{
+		Timestamp:   timestamppb.New(time.Now()),
+		Type:        pb.GameMetaEvent_ADD_TIME,
+		PlayerId:    "3xpEkpRAy3AizbVmDg3kdi", // "jesse"
+		GameId:      gsetup.g.GameID(),
+		OrigEventId: shortuuid.New(),
+	}
+
+	err := gameplay.HandleMetaEvent(context.Background(), metaEvt,
+		gsetup.consumer.ch, gsetup.stores)
+	is.NoErr(err)
+
+	gsetup.cancel()
+	<-gsetup.donechan
+
+	is.Equal(gsetup.g.TimeRemaining(opponentIdx), opponentTimeBefore+15000)
+
+	// History refreshers contain both players' racks. They must never be
+	// published to the plain game channel, which is unsanitized; they should
+	// go to each player's user channel (sanitized by the bus) and to gametv.
+	refresherCt := 0
+	for _, evt := range gsetup.consumer.evts {
+		if evt.Type != pb.MessageType_GAME_HISTORY_REFRESHER {
+			continue
+		}
+		refresherCt++
+		userAudiences := 0
+		for _, aud := range evt.Audience() {
+			is.True(!strings.HasPrefix(aud, "game."))
+			if strings.HasPrefix(aud, "user.") {
+				userAudiences++
+			}
+		}
+		is.Equal(userAudiences, 2)
+	}
+	// one refresher from StartGame, one from the ADD_TIME event.
+	is.Equal(refresherCt, 2)
 
 	teardownGame(gsetup)
 }


### PR DESCRIPTION
Fixes #1899

## The bug

Pressing the "+ time" button revealed the opponent's rack. The `ADD_TIME` case in `HandleMetaEvent` (`pkg/gameplay/meta_events.go`) sent the updated-clock `GameHistoryRefresher` to the `AudGame` audience, i.e. the raw `game.<id>` NATS channel. Events on that channel are published verbatim — the bus's `sanitize()` (which censors opponent racks and per-event rack info) only runs on the `AudUser` path in `pubToUser`. So a single press delivered the full history, including `last_known_racks` for both players, to both players.

## The fix

Route the refresher the same way `StartGame` does (`pkg/gameplay/game.go`): one event addressed to each player's `user.<uid>.game.<gid>` channel, so the bus sanitizes it per recipient, plus a `gametv` event for spectators (rack-censored when `shouldCensorRacksForViewers` applies). Also applies `mod.CensorHistory` for parity with the other refresher paths.

## Testing

Added `TestAddTimeDoesNotBroadcastRacksToGameChannel`, which asserts that no history refresher is addressed to the unsanitized `game.` channel, that the refresher reaches both players' user channels, and that the opponent's clock gains 15 seconds. The test fails against the previous code and passes with the fix; the full `pkg/gameplay` suite passes.