### PR TITLE
db: add partial index to fix slow league standings query

### DIFF
--- a/db/migrations/202607090001_games_division_unfinished_idx.down.sql
+++ b/db/migrations/202607090001_games_division_unfinished_idx.down.sql
@@ -1,0 +1,12 @@
+-- ============================================================================
+-- REMOVE GAMES DIVISION-UNFINISHED INDEX - MANUAL EXECUTION REQUIRED
+-- ============================================================================
+--
+-- To rollback, run this manually:
+--
+-- DROP INDEX CONCURRENTLY IF EXISTS idx_games_division_unfinished;
+--
+-- Note: DROP INDEX CONCURRENTLY also cannot run inside a transaction block.
+
+-- No-op statement to make migration valid
+SELECT 'games division-unfinished index removal documented - manual execution required' AS rollback_status;

--- a/db/migrations/202607090001_games_division_unfinished_idx.up.sql
+++ b/db/migrations/202607090001_games_division_unfinished_idx.up.sql
@@ -1,0 +1,29 @@
+-- ============================================================================
+-- GAMES DIVISION-UNFINISHED INDEX - MANUAL EXECUTION REQUIRED
+-- ============================================================================
+--
+-- Speeds up GetUnfinishedDivisionGames (pkg/league/service.go), called once per
+-- division by GetAllDivisionStandings on every public /leagues/:slug page load.
+-- Previously fell back to a BitmapAnd against idx_games_game_end_reason, a
+-- full-table index bloated ~18x from UPDATE churn (12M-row games table).
+-- This partial index scopes to only currently-unfinished games, so it starts
+-- (and stays) compact, and INCLUDEs the two returned columns for an
+-- index-only scan (no heap fetch once the visibility map catches up).
+--
+-- Verified on prod via EXPLAIN (ANALYZE, BUFFERS): 14.8ms/762 buffers ->
+-- 0.111ms/39 buffers, plan changed from BitmapAnd to Index Only Scan.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction block, so run this
+-- manually against each environment:
+--
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_games_division_unfinished
+--   ON games (league_division_id)
+--   INCLUDE (player0_id, player1_id)
+--   WHERE game_end_reason = 0;
+--
+-- Creation time: seconds (partial index, small matching set)
+-- Downtime during creation: ZERO (thanks to CONCURRENTLY)
+-- Status on prod: already created and validated as of this migration.
+
+-- No-op statement to make migration valid
+SELECT 'games division-unfinished index documented - manual execution required' AS migration_status;


### PR DESCRIPTION
## Summary
- Adds `idx_games_division_unfinished`, a partial covering index on `games(league_division_id) INCLUDE (player0_id, player1_id) WHERE game_end_reason = 0`, to fix a slow query in `GetAllDivisionStandings`.
- Migration documents a manual `CREATE INDEX CONCURRENTLY` (repo convention for `games`-table indexes, see `202509091458_game_performance_indexes.up.sql`) since it can't run inside the migration tool's transaction. **Already created and validated live on prod.**

## Root cause
`GetAllDivisionStandings` (`pkg/league/service.go:1116`) is called on every load of the public `/leagues/:slug` page, no auth gate, no polling but real foot traffic. It fans out one goroutine per division, each running 3 queries; across 40 traces sampled over 48h, `GetUnfinishedDivisionGames` was the slowest of the three in **40/40** traces (median ~8x slower than the next-slowest), accounting for ~81% of wall-clock.

```sql
-- pkg/stores/models/leagues.sql.go — GetUnfinishedDivisionGames
SELECT player0_id, player1_id
FROM games
WHERE league_division_id = $1
  AND game_end_reason = 0
```

No index matched both predicates, so the planner ran a `BitmapAnd` between `idx_games_league_division_id` and `idx_games_game_end_reason`. The second index turned out to be badly bloated: `EXPLAIN` reported touching 44,155 "rows", but `SELECT count(*) WHERE game_end_reason = 0` on prod returned only 2,438 real rows — ~18x dead-tuple bloat from constant `UPDATE` churn on the 12M-row `games` table (every move updates the row while `game_end_reason` stays `0`), compounded by `games` never having had a manual `ANALYZE`.

## Verified on prod

`EXPLAIN (ANALYZE, BUFFERS)` on the same query, before and after creating the index live:

| | Before | After |
|---|---|---|
| Plan | `BitmapAnd` (2 index scans + heap recheck) | `Index Only Scan` |
| Buffers (shared hit) | 762 | 39 |
| Execution Time | 14.783ms | 0.111ms |

And from real traffic via Jaeger (same `GetAllDivisionStandings` traces, before vs. 10 minutes after the index went live):

| | Before (40 traces / 48h) | After (100 traces / 10 min) |
|---|---|---|
| `GetUnfinishedDivisionGames` median | 64.7ms | **0.86ms** (~75x faster) |
| `GetUnfinishedDivisionGames` max | 89.6ms | 21.1ms |
| Overall request wall-clock median | 100.5ms | **12.3ms** (~8x faster) |
| Overall request wall-clock max | 233.5ms | 139.7ms |

## Why this index and not others
- **Partial** (`WHERE game_end_reason = 0`) — only currently-unfinished games are indexed at all, so it starts (and stays) small and isn't exposed to the same bloat pattern as the full-table `idx_games_game_end_reason`, which indexes every game regardless of status.
- **`INCLUDE (player0_id, player1_id)`** — the two columns the query actually selects are carried as index payload, enabling an index-only scan with no heap fetch (once the visibility map catches up).

## Out of scope (noted during investigation, not part of this PR)
- `idx_games_game_end_reason` bloat itself — a `REINDEX CONCURRENTLY` would shrink it, but this fix routes around it rather than repairing it.
- `games.last_analyze` has apparently never run manually — worth a periodic `ANALYZE` policy check separately.
- Annotated/broadcast games insert a `games` row without setting `game_end_reason` (`pkg/omgwords/stores/db.go:60-71`), leaving it `NULL`. Confirmed harmless here (0 of the 2,438 real `game_end_reason=0` rows are `type=1`), but a separate legacy-hack smell the code already flags with `// We will need to migrate this`.
- Batching the 3-queries-per-division N+1 pattern, or a short-TTL cache on `GetAllDivisionStandings` — discussed as optional follow-ups but not needed now since the index removes the dominant cost.

## Test plan
- [x] `EXPLAIN (ANALYZE, BUFFERS)` on prod, before/after — plan flipped from `BitmapAnd` to `Index Only Scan`
- [x] Live traffic comparison via Jaeger traces, before/after (table above)
- [x] Index already created via `CREATE INDEX CONCURRENTLY` on prod (zero downtime)
- [ ] Run migration against other environments (staging/local) to keep them in sync — manual, see migration file for the exact command

🤖 Generated with [Claude Code](https://claude.com/claude-code)