### PR TITLE
fix(ui): keep placed tiles when clock time is added

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -456,8 +456,17 @@ export const BoardPanel = React.memo((props: Props) => {
       // Prevent stuck tiles.
       fullReset = true;
     } else if (!dep.isMyTurn) {
-      // Opponent's turn means we have just made a move. (Assumption: there are only two players.)
-      fullReset = true;
+      // Opponent's turn usually means we have just made a move. (Assumption:
+      // there are only two players.) But a GameHistoryRefresher can also
+      // arrive mid-turn without any move being made (e.g. the opponent's
+      // clock was given more time), in which case the board is unchanged and
+      // tentatively placed tiles should be left alone.
+      const lettersChanged =
+        lastLetters.length !== props.board.letters.length ||
+        lastLetters.some((ml, idx) => ml !== props.board.letters[idx]);
+      if (lettersChanged) {
+        fullReset = true;
+      }
     } else {
       // Opponent just did something. Check if it affects any premove.
       // TODO: revisit when supporting non-square boards.


### PR DESCRIPTION
Fixes #1906

## Problem

Pressing the `+` button ("give opponent 15 seconds") while you have tentatively placed tiles on the board recalls those tiles to your rack. Pressing `+` again puts them back on the board, and it keeps toggling with every press.

## Cause

The server responds to `GameMetaEvent_ADD_TIME` with a full `GameHistoryRefresher` to sync clocks. The board-sync effect in `board_panel.tsx` treated any refresh arriving while off turn as "we just made a move" and did a full reset, recalling the placed tiles. The reset also backs up the tentative state keyed by `(board letters, rack)` for the challenge/premove flow; since ADD_TIME changes neither, the next refresher found that backup and restored it — hence the toggle.

## Fix

Only perform the off-turn full reset when the board letters actually changed. A real move by us always changes the board (a play) or the rack contents (an exchange, which the tile-match check above already catches), so the reset still happens in all the cases it was meant for. Mid-turn refreshers that change nothing — ADD_TIME, socket reconnects while premoving — now leave tentative tiles alone.

## Testing

- `vitest run`: all 72 tests pass, identical to master (the 7 test files that fail to collect do so on master too, due to a pre-existing `localStorage`-at-module-load environment issue).
- `tsc`, `eslint`, `prettier`: clean for the changed file (remaining tsc errors are pre-existing in `board3d/scene.ts` / `computer_analysis.tsx`).