### PR TITLE
league: fetch all-division standings from one consistent snapshot

### DIFF
--- a/db/queries/leagues.sql
+++ b/db/queries/leagues.sql
@@ -422,6 +422,51 @@ FROM games
 WHERE league_division_id = $1
   AND game_end_reason = 0;
 
+-- name: GetStandingsForDivisions :many
+-- Batched GetStandings for a whole season: fetch every listed division's
+-- standings in one query, ordered by division_number so the caller can split
+-- the flat result into contiguous per-division buckets (groupByDivision).
+-- Reuses idx_league_standings_division_id via = ANY. Row shape matches
+-- GetStandings; sorting within a division is still done in Go.
+SELECT ls.id, ls.division_id, ls.user_id, ls.wins, ls.losses, ls.draws,
+       ls.spread, ls.games_played, ls.games_remaining, ls.result, ls.updated_at,
+       ls.total_score, ls.total_opponent_score, ls.total_bingos, ls.total_opponent_bingos,
+       ls.total_turns, ls.high_turn, ls.high_game, ls.timeouts, ls.blanks_played,
+       ls.total_tiles_played, ls.total_opponent_tiles_played,
+       ls.total_mistake_index, ls.games_analyzed,
+       u.uuid as user_uuid, u.username
+FROM league_standings ls
+JOIN users u ON ls.user_id = u.id
+JOIN league_divisions d ON d.uuid = ls.division_id
+WHERE ls.division_id = ANY(@division_ids::uuid[])
+ORDER BY d.division_number;
+
+-- name: GetDivisionRegistrationsForDivisions :many
+-- Batched GetDivisionRegistrations for a whole season, ordered by
+-- division_number then registration_date (preserving the single-division
+-- order within each division). Reuses idx_league_registrations_division_id
+-- via = ANY.
+SELECT lr.*, u.uuid as user_uuid, u.username
+FROM league_registrations lr
+JOIN users u ON lr.user_id = u.id
+JOIN league_divisions d ON d.uuid = lr.division_id
+WHERE lr.division_id = ANY(@division_ids::uuid[])
+ORDER BY d.division_number, lr.registration_date;
+
+-- name: GetUnfinishedGamesForDivisions :many
+-- Batched GetUnfinishedDivisionGames for a whole season. Adds league_division_id
+-- to the projection (the single-division query omits it) so the flat result can
+-- be split by division. Reuses the idx_games_division_unfinished partial index
+-- via = ANY; ordered by division_number to align with the divisions list.
+SELECT g.league_division_id AS division_id,
+       g.player0_id,
+       g.player1_id
+FROM games g
+JOIN league_divisions d ON d.uuid = g.league_division_id
+WHERE g.league_division_id = ANY(@division_ids::uuid[])
+  AND g.game_end_reason = 0
+ORDER BY d.division_number;
+
 -- name: GetSeasonZeroMoveGames :many
 -- Get all in-progress games in a season that have zero moves
 -- Uses timers field: if lu (last update) == ts (time started), no moves have been made

--- a/pkg/league/all_division_standings_integration_test.go
+++ b/pkg/league/all_division_standings_integration_test.go
@@ -1,0 +1,122 @@
+package league
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/matryer/is"
+
+	"github.com/woogles-io/liwords/pkg/stores/models"
+	pb "github.com/woogles-io/liwords/rpc/api/proto/league_service"
+)
+
+// TestGetAllDivisionStandings_Integration exercises the batched, single-snapshot
+// GetAllDivisionStandings against a real Postgres. Three divisions are created
+// OUT of division_number order (2, 3, 1) to prove the endpoint orders by
+// division_number rather than insertion or uuid order, and the middle division
+// (2) has a registered player but NO standings row. That empty-standings case is
+// exactly what the groupByDivision lockstep must handle: the batched
+// GetStandingsForDivisions returns rows only for divisions 1 and 3, so division
+// 2 must line up with an empty bucket instead of stealing division 3's rows.
+func TestGetAllDivisionStandings_Integration(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	allStores, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	store := allStores.LeagueStore
+	_, seasonID := createLeagueAndSeason(t, ctx, allStores)
+
+	mkDivision := func(number int32) uuid.UUID {
+		id := uuid.New()
+		_, err := store.CreateDivision(ctx, models.CreateDivisionParams{
+			Uuid:           id,
+			SeasonID:       seasonID,
+			DivisionNumber: number,
+			DivisionName:   pgtype.Text{String: "Division", Valid: true},
+		})
+		is.NoErr(err)
+		return id
+	}
+
+	// Insert out of order on purpose.
+	div2 := mkDivision(2)
+	div3 := mkDivision(3)
+	div1 := mkDivision(1)
+
+	register := func(userID int32, divID uuid.UUID, withStanding bool, wins, spread int32) {
+		_, err := store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID:     userID,
+			SeasonID:   seasonID,
+			Status:     pgtype.Text{String: "REGISTERED", Valid: true},
+			DivisionID: pgtype.UUID{Bytes: divID, Valid: true},
+		})
+		is.NoErr(err)
+		if withStanding {
+			err = store.UpsertStanding(ctx, models.UpsertStandingParams{
+				UserID:     userID,
+				DivisionID: divID,
+				Wins:       pgtype.Int4{Int32: wins, Valid: true},
+				Losses:     pgtype.Int4{Int32: 0, Valid: true},
+				Draws:      pgtype.Int4{Int32: 0, Valid: true},
+				Spread:     pgtype.Int4{Int32: spread, Valid: true},
+			})
+			is.NoErr(err)
+		}
+	}
+
+	// Div 1: users 1,2 with standings. Div 2: user 3 registered, NO standings.
+	// Div 3: users 4,5 with standings.
+	register(1, div1, true, 5, 100)
+	register(2, div1, true, 3, 50)
+	register(3, div2, false, 0, 0)
+	register(4, div3, true, 4, 80)
+	register(5, div3, true, 2, 20)
+
+	svc := &LeagueService{store: store}
+	resp, err := svc.GetAllDivisionStandings(
+		ctx,
+		connect.NewRequest(&pb.SeasonRequest{SeasonId: seasonID.String()}),
+	)
+	is.NoErr(err)
+
+	divs := resp.Msg.Divisions
+	is.Equal(len(divs), 3)
+
+	// Ordered by division_number, not insertion/uuid order.
+	is.Equal(divs[0].DivisionNumber, int32(1))
+	is.Equal(divs[1].DivisionNumber, int32(2))
+	is.Equal(divs[2].DivisionNumber, int32(3))
+
+	// Correct grouping, including the empty-middle-division case: division 2 has
+	// exactly the one registered-but-unplayed player (zero-filled), and division
+	// 3's players did not leak into division 2.
+	is.Equal(len(divs[0].Standings), 2) // div 1
+	is.Equal(len(divs[1].Standings), 1) // div 2 (zero-filled registration)
+	is.Equal(len(divs[2].Standings), 2) // div 3
+
+	is.Equal(divs[1].Standings[0].UserId, "test-uuid-3")
+
+	div1Users := map[string]bool{}
+	for _, s := range divs[0].Standings {
+		div1Users[s.UserId] = true
+	}
+	is.True(div1Users["test-uuid-1"])
+	is.True(div1Users["test-uuid-2"])
+	is.True(!div1Users["test-uuid-4"]) // div 3 player must not appear in div 1
+
+	// Ranks are 1..n per division and bounds are populated and sane.
+	for _, d := range divs {
+		n := int32(len(d.Standings))
+		for i, s := range d.Standings {
+			is.Equal(s.Rank, int32(i+1))
+			is.True(s.BestRank >= 1 && s.BestRank <= n)
+			is.True(s.WorstRank >= 1 && s.WorstRank <= n)
+			is.True(s.BestRank <= s.WorstRank)
+		}
+	}
+}

--- a/pkg/league/season_standings.go
+++ b/pkg/league/season_standings.go
@@ -1,0 +1,25 @@
+package league
+
+import "github.com/google/uuid"
+
+// groupByDivision splits a flat, division_number-ordered result set into one
+// contiguous bucket per division, aligned to divIDs.
+//
+// Precondition: rows are globally ordered so that all rows sharing a division
+// id form a single contiguous run, and those runs appear in the same order as
+// divIDs. Both hold when the query and GetDivisionsBySeason are ORDER BY
+// division_number. Matching is by division id, not "the next run", so a
+// division with no rows yields an empty bucket without stealing a later
+// division's run.
+func groupByDivision[T any](divIDs []uuid.UUID, rows []T, divOf func(T) uuid.UUID) [][]T {
+	buckets := make([][]T, len(divIDs))
+	ri := 0
+	for di, id := range divIDs {
+		start := ri
+		for ri < len(rows) && divOf(rows[ri]) == id {
+			ri++
+		}
+		buckets[di] = rows[start:ri]
+	}
+	return buckets
+}

--- a/pkg/league/season_standings_test.go
+++ b/pkg/league/season_standings_test.go
@@ -1,0 +1,78 @@
+package league
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// The batched GetAllDivisionStandings fetches every division's rows in one
+// query ordered by division_number, then splits the flat result into one
+// contiguous bucket per division. groupByDivision does that split. The rows
+// are globally ordered by division_number and each carries its division id, so
+// a division's rows form a contiguous run in the same order as the divisions
+// slice. A division with no rows must yield an empty bucket WITHOUT stealing a
+// later division's run -- that misalignment is the bug this helper must avoid.
+
+type gbdRow struct {
+	d uuid.UUID
+	v int
+}
+
+func gbdKey(r gbdRow) uuid.UUID { return r.d }
+
+func TestGroupByDivision_Contiguous(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	rows := []gbdRow{{a, 1}, {a, 2}, {b, 3}, {c, 4}, {c, 5}}
+	got := groupByDivision([]uuid.UUID{a, b, c}, rows, gbdKey)
+	require.Len(t, got, 3)
+	require.Equal(t, []gbdRow{{a, 1}, {a, 2}}, got[0])
+	require.Equal(t, []gbdRow{{b, 3}}, got[1])
+	require.Equal(t, []gbdRow{{c, 4}, {c, 5}}, got[2])
+}
+
+func TestGroupByDivision_EmptyMiddleDivisionKeepsAlignment(t *testing.T) {
+	// B has no rows. Its bucket must be empty and C must still line up -- a
+	// naive "next run belongs to next division" walk would give C's rows to B.
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	rows := []gbdRow{{a, 1}, {c, 2}}
+	got := groupByDivision([]uuid.UUID{a, b, c}, rows, gbdKey)
+	require.Len(t, got, 3)
+	require.Equal(t, []gbdRow{{a, 1}}, got[0])
+	require.Empty(t, got[1])
+	require.Equal(t, []gbdRow{{c, 2}}, got[2])
+}
+
+func TestGroupByDivision_LeadingEmptyDivision(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	rows := []gbdRow{{b, 1}, {c, 2}}
+	got := groupByDivision([]uuid.UUID{a, b, c}, rows, gbdKey)
+	require.Len(t, got, 3)
+	require.Empty(t, got[0])
+	require.Equal(t, []gbdRow{{b, 1}}, got[1])
+	require.Equal(t, []gbdRow{{c, 2}}, got[2])
+}
+
+func TestGroupByDivision_TrailingEmptyDivision(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	rows := []gbdRow{{a, 1}, {b, 2}}
+	got := groupByDivision([]uuid.UUID{a, b, c}, rows, gbdKey)
+	require.Len(t, got, 3)
+	require.Equal(t, []gbdRow{{a, 1}}, got[0])
+	require.Equal(t, []gbdRow{{b, 2}}, got[1])
+	require.Empty(t, got[2])
+}
+
+func TestGroupByDivision_AllEmpty(t *testing.T) {
+	a, b := uuid.New(), uuid.New()
+	got := groupByDivision([]uuid.UUID{a, b}, []gbdRow{}, gbdKey)
+	require.Len(t, got, 2)
+	require.Empty(t, got[0])
+	require.Empty(t, got[1])
+}
+
+func TestGroupByDivision_NoDivisions(t *testing.T) {
+	got := groupByDivision([]uuid.UUID{}, []gbdRow{{uuid.New(), 1}}, gbdKey)
+	require.Empty(t, got)
+}

--- a/pkg/league/service.go
+++ b/pkg/league/service.go
@@ -1123,36 +1123,57 @@ func (ls *LeagueService) GetAllDivisionStandings(
 		return nil, apiserver.InvalidArg("invalid season_id")
 	}
 
-	// Get all divisions for season
-	divisions, err := ls.store.GetDivisionsBySeason(ctx, seasonID)
+	// Fetch the whole season's divisions, standings, registrations, and
+	// unfinished games in one repeatable-read transaction. A consistent snapshot
+	// is required for correct rank bounds: CalculatePossibleRanks correlates each
+	// player's games remaining (from standings) with the unfinished pairing list,
+	// so a game finishing between two reads would desync them into impossible
+	// bounds. It also collapses the old per-division N*3 query fan-out into three
+	// batched queries.
+	snapshot, err := ls.store.GetSeasonStandingsSnapshot(ctx, seasonID)
 	if err != nil {
-		return nil, apiserver.InternalErr(fmt.Errorf("failed to get divisions: %w", err))
+		return nil, apiserver.InternalErr(fmt.Errorf("failed to get season standings: %w", err))
 	}
+	divisions := snapshot.Divisions
 
-	// Get standings for each division. Divisions are independent, so run the
-	// per-division work concurrently; the CPU-bound CalculatePossibleRanks
-	// call dominates on large divisions near mid-season and bounds wall-clock
-	// at max-per-division instead of sum.
-	protoDivisions := make([]*ipc.Division, len(divisions))
-	eg, egCtx := errgroup.WithContext(ctx)
+	// Split the batched, division_number-ordered rows into per-division buckets
+	// aligned to divisions. The standings and registration row shapes match the
+	// single-division queries, so convert them and reuse the assembly below.
+	divIDs := make([]uuid.UUID, len(divisions))
 	for i, division := range divisions {
+		divisionUUID, err := uuid.FromBytes(division.Uuid[:])
+		if err != nil {
+			return nil, apiserver.InternalErr(fmt.Errorf("failed to parse division UUID: %w", err))
+		}
+		divIDs[i] = divisionUUID
+	}
+	allStandings := make([]models.GetStandingsRow, len(snapshot.Standings))
+	for i, r := range snapshot.Standings {
+		allStandings[i] = models.GetStandingsRow(r)
+	}
+	allRegistrations := make([]models.GetDivisionRegistrationsRow, len(snapshot.Registrations))
+	for i, r := range snapshot.Registrations {
+		allRegistrations[i] = models.GetDivisionRegistrationsRow(r)
+	}
+	standingsByDivision := groupByDivision(divIDs, allStandings,
+		func(r models.GetStandingsRow) uuid.UUID { return r.DivisionID })
+	registrationsByDivision := groupByDivision(divIDs, allRegistrations,
+		func(r models.GetDivisionRegistrationsRow) uuid.UUID { return uuid.UUID(r.DivisionID.Bytes) })
+	unfinishedByDivision := groupByDivision(divIDs, snapshot.Unfinished,
+		func(r models.GetUnfinishedGamesForDivisionsRow) uuid.UUID { return uuid.UUID(r.DivisionID.Bytes) })
+
+	// Divisions are independent, so run the per-division assembly concurrently;
+	// the CPU-bound CalculatePossibleRanks call dominates on large divisions near
+	// mid-season and bounds wall-clock at max-per-division instead of sum. All DB
+	// I/O is already done above, so these goroutines are pure CPU.
+	protoDivisions := make([]*ipc.Division, len(divisions))
+	var eg errgroup.Group
+	for i, division := range divisions {
+		divisionUUID := divIDs[i]
+		standings := standingsByDivision[i]
+		registrations := registrationsByDivision[i]
+		unfinished := unfinishedByDivision[i]
 		eg.Go(func() error {
-			divisionUUID, err := uuid.FromBytes(division.Uuid[:])
-			if err != nil {
-				return apiserver.InternalErr(fmt.Errorf("failed to parse division UUID: %w", err))
-			}
-
-			standings, err := ls.store.GetStandings(egCtx, divisionUUID)
-			if err != nil {
-				return apiserver.InternalErr(fmt.Errorf("failed to get standings: %w", err))
-			}
-
-			// Get registrations for the division to ensure all players are shown
-			registrations, err := ls.store.GetDivisionRegistrations(egCtx, divisionUUID)
-			if err != nil {
-				return apiserver.InternalErr(fmt.Errorf("failed to get registrations: %w", err))
-			}
-
 			// Build a map of existing standings by user ID
 			standingsMap := make(map[int32]models.GetStandingsRow)
 			for _, standing := range standings {
@@ -1250,10 +1271,6 @@ func (ls *LeagueService) GetAllDivisionStandings(
 			}
 
 			// Compute possible rank bounds using actual remaining pairings
-			unfinished, err := ls.store.GetUnfinishedDivisionGames(egCtx, divisionUUID)
-			if err != nil {
-				return apiserver.InternalErr(fmt.Errorf("failed to get unfinished games: %w", err))
-			}
 			standingInfos := make([]standingInfo, len(standings))
 			for j, s := range standings {
 				standingInfos[j] = StandingInfoFromRow(

--- a/pkg/league/standings_test.go
+++ b/pkg/league/standings_test.go
@@ -112,6 +112,13 @@ func (m *mockLeagueStore) GetGameLeagueInfo(ctx context.Context, gameUUID string
 	return models.GetGameLeagueInfoRow{}, nil
 }
 
+func (m *mockLeagueStore) GetSeasonStandingsSnapshot(ctx context.Context, seasonID uuid.UUID) (*league.SeasonStandingsSnapshot, error) {
+	// Not exercised by the current tests. GetAllDivisionStandings assembly is
+	// covered via the groupByDivision unit tests; wire this up if a
+	// handler-level test needs it.
+	return nil, fmt.Errorf("GetSeasonStandingsSnapshot not implemented in mockLeagueStore")
+}
+
 // Stubs for other interface methods
 func (m *mockLeagueStore) CreateLeague(ctx context.Context, arg models.CreateLeagueParams) (models.League, error) {
 	return models.League{}, nil

--- a/pkg/stores/league/db.go
+++ b/pkg/stores/league/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -90,6 +91,10 @@ type Store interface {
 	GetGameLeagueInfo(ctx context.Context, gameUUID string) (models.GetGameLeagueInfoRow, error)
 	GetSeasonPlayersWithUnstartedGames(ctx context.Context, seasonID uuid.UUID) ([]models.GetSeasonPlayersWithUnstartedGamesRow, error)
 	GetPlayerSeasonOpponents(ctx context.Context, seasonID uuid.UUID, userUUID string) ([]string, error)
+
+	// Batched season snapshot for GetAllDivisionStandings, read in a single
+	// repeatable-read transaction so the rank-bounds inputs stay consistent.
+	GetSeasonStandingsSnapshot(ctx context.Context, seasonID uuid.UUID) (*SeasonStandingsSnapshot, error)
 
 	// Time bank operations
 	AddTimeBankSinglePlayer(ctx context.Context, arg models.AddTimeBankSinglePlayerParams) (int64, error)
@@ -434,6 +439,69 @@ func (s *DBStore) GetUnfinishedLeagueGames(ctx context.Context, seasonID uuid.UU
 
 func (s *DBStore) GetUnfinishedDivisionGames(ctx context.Context, divisionID uuid.UUID) ([]models.GetUnfinishedDivisionGamesRow, error) {
 	return s.queries.GetUnfinishedDivisionGames(ctx, pgtype.UUID{Bytes: divisionID, Valid: true})
+}
+
+// SeasonStandingsSnapshot is a single repeatable-read view of everything
+// GetAllDivisionStandings needs: the season's divisions plus every division's
+// standings, registrations, and unfinished games. Each list is fetched in one
+// batched query (= ANY over the season's division ids) ordered by
+// division_number, so the caller can split them into contiguous per-division
+// buckets with groupByDivision. Reading them in one transaction keeps the
+// rank-bounds inputs -- games remaining (from standings) and the unfinished
+// pairing list -- mutually consistent; separate per-division reads on pooled
+// connections can observe a game finishing mid-scan and produce impossible
+// bounds.
+type SeasonStandingsSnapshot struct {
+	Divisions     []models.LeagueDivision
+	Standings     []models.GetStandingsForDivisionsRow
+	Registrations []models.GetDivisionRegistrationsForDivisionsRow
+	Unfinished    []models.GetUnfinishedGamesForDivisionsRow
+}
+
+func (s *DBStore) GetSeasonStandingsSnapshot(ctx context.Context, seasonID uuid.UUID) (*SeasonStandingsSnapshot, error) {
+	tx, err := s.dbPool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) // read-only snapshot; nothing to commit
+
+	q := s.queries.WithTx(tx)
+
+	divisions, err := q.GetDivisionsBySeason(ctx, seasonID)
+	if err != nil {
+		return nil, err
+	}
+	divIDs := make([]uuid.UUID, len(divisions))
+	for i, d := range divisions {
+		id, err := uuid.FromBytes(d.Uuid[:])
+		if err != nil {
+			return nil, err
+		}
+		divIDs[i] = id
+	}
+
+	standings, err := q.GetStandingsForDivisions(ctx, divIDs)
+	if err != nil {
+		return nil, err
+	}
+	registrations, err := q.GetDivisionRegistrationsForDivisions(ctx, divIDs)
+	if err != nil {
+		return nil, err
+	}
+	unfinished, err := q.GetUnfinishedGamesForDivisions(ctx, divIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SeasonStandingsSnapshot{
+		Divisions:     divisions,
+		Standings:     standings,
+		Registrations: registrations,
+		Unfinished:    unfinished,
+	}, nil
 }
 
 func (s *DBStore) ForceFinishGame(ctx context.Context, arg models.ForceFinishGameParams) error {

--- a/pkg/stores/models/leagues.sql.go
+++ b/pkg/stores/models/leagues.sql.go
@@ -660,6 +660,71 @@ func (q *Queries) GetDivisionRegistrations(ctx context.Context, divisionID pgtyp
 	return items, nil
 }
 
+const getDivisionRegistrationsForDivisions = `-- name: GetDivisionRegistrationsForDivisions :many
+SELECT lr.id, lr.user_id, lr.season_id, lr.division_id, lr.registration_date, lr.firsts_count, lr.status, lr.placement_status, lr.previous_division_rank, lr.seasons_away, lr.created_at, lr.updated_at, u.uuid as user_uuid, u.username
+FROM league_registrations lr
+JOIN users u ON lr.user_id = u.id
+JOIN league_divisions d ON d.uuid = lr.division_id
+WHERE lr.division_id = ANY($1::uuid[])
+ORDER BY d.division_number, lr.registration_date
+`
+
+type GetDivisionRegistrationsForDivisionsRow struct {
+	ID                   int64
+	UserID               int32
+	SeasonID             uuid.UUID
+	DivisionID           pgtype.UUID
+	RegistrationDate     pgtype.Timestamptz
+	FirstsCount          pgtype.Int4
+	Status               pgtype.Text
+	PlacementStatus      pgtype.Int4
+	PreviousDivisionRank pgtype.Int4
+	SeasonsAway          pgtype.Int4
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	UserUuid             string
+	Username             string
+}
+
+// Batched GetDivisionRegistrations for a whole season, ordered by
+// division_number then registration_date (preserving the single-division
+// order within each division). Reuses idx_league_registrations_division_id
+// via = ANY.
+func (q *Queries) GetDivisionRegistrationsForDivisions(ctx context.Context, divisionIds []uuid.UUID) ([]GetDivisionRegistrationsForDivisionsRow, error) {
+	rows, err := q.db.Query(ctx, getDivisionRegistrationsForDivisions, divisionIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetDivisionRegistrationsForDivisionsRow
+	for rows.Next() {
+		var i GetDivisionRegistrationsForDivisionsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.SeasonID,
+			&i.DivisionID,
+			&i.RegistrationDate,
+			&i.FirstsCount,
+			&i.Status,
+			&i.PlacementStatus,
+			&i.PreviousDivisionRank,
+			&i.SeasonsAway,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.UserUuid,
+			&i.Username,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getDivisionTimeBankStatus = `-- name: GetDivisionTimeBankStatus :many
 SELECT
     u.id as user_id,
@@ -2213,6 +2278,102 @@ func (q *Queries) GetStandings(ctx context.Context, divisionID uuid.UUID) ([]Get
 	return items, nil
 }
 
+const getStandingsForDivisions = `-- name: GetStandingsForDivisions :many
+SELECT ls.id, ls.division_id, ls.user_id, ls.wins, ls.losses, ls.draws,
+       ls.spread, ls.games_played, ls.games_remaining, ls.result, ls.updated_at,
+       ls.total_score, ls.total_opponent_score, ls.total_bingos, ls.total_opponent_bingos,
+       ls.total_turns, ls.high_turn, ls.high_game, ls.timeouts, ls.blanks_played,
+       ls.total_tiles_played, ls.total_opponent_tiles_played,
+       ls.total_mistake_index, ls.games_analyzed,
+       u.uuid as user_uuid, u.username
+FROM league_standings ls
+JOIN users u ON ls.user_id = u.id
+JOIN league_divisions d ON d.uuid = ls.division_id
+WHERE ls.division_id = ANY($1::uuid[])
+ORDER BY d.division_number
+`
+
+type GetStandingsForDivisionsRow struct {
+	ID                       int64
+	DivisionID               uuid.UUID
+	UserID                   int32
+	Wins                     pgtype.Int4
+	Losses                   pgtype.Int4
+	Draws                    pgtype.Int4
+	Spread                   pgtype.Int4
+	GamesPlayed              pgtype.Int4
+	GamesRemaining           pgtype.Int4
+	Result                   pgtype.Int4
+	UpdatedAt                pgtype.Timestamptz
+	TotalScore               pgtype.Int4
+	TotalOpponentScore       pgtype.Int4
+	TotalBingos              pgtype.Int4
+	TotalOpponentBingos      pgtype.Int4
+	TotalTurns               pgtype.Int4
+	HighTurn                 pgtype.Int4
+	HighGame                 pgtype.Int4
+	Timeouts                 pgtype.Int4
+	BlanksPlayed             pgtype.Int4
+	TotalTilesPlayed         pgtype.Int4
+	TotalOpponentTilesPlayed pgtype.Int4
+	TotalMistakeIndex        pgtype.Float8
+	GamesAnalyzed            pgtype.Int4
+	UserUuid                 string
+	Username                 string
+}
+
+// Batched GetStandings for a whole season: fetch every listed division's
+// standings in one query, ordered by division_number so the caller can split
+// the flat result into contiguous per-division buckets (groupByDivision).
+// Reuses idx_league_standings_division_id via = ANY. Row shape matches
+// GetStandings; sorting within a division is still done in Go.
+func (q *Queries) GetStandingsForDivisions(ctx context.Context, divisionIds []uuid.UUID) ([]GetStandingsForDivisionsRow, error) {
+	rows, err := q.db.Query(ctx, getStandingsForDivisions, divisionIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetStandingsForDivisionsRow
+	for rows.Next() {
+		var i GetStandingsForDivisionsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.DivisionID,
+			&i.UserID,
+			&i.Wins,
+			&i.Losses,
+			&i.Draws,
+			&i.Spread,
+			&i.GamesPlayed,
+			&i.GamesRemaining,
+			&i.Result,
+			&i.UpdatedAt,
+			&i.TotalScore,
+			&i.TotalOpponentScore,
+			&i.TotalBingos,
+			&i.TotalOpponentBingos,
+			&i.TotalTurns,
+			&i.HighTurn,
+			&i.HighGame,
+			&i.Timeouts,
+			&i.BlanksPlayed,
+			&i.TotalTilesPlayed,
+			&i.TotalOpponentTilesPlayed,
+			&i.TotalMistakeIndex,
+			&i.GamesAnalyzed,
+			&i.UserUuid,
+			&i.Username,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUnfinishedDivisionGames = `-- name: GetUnfinishedDivisionGames :many
 SELECT
     player0_id,
@@ -2238,6 +2399,47 @@ func (q *Queries) GetUnfinishedDivisionGames(ctx context.Context, leagueDivision
 	for rows.Next() {
 		var i GetUnfinishedDivisionGamesRow
 		if err := rows.Scan(&i.Player0ID, &i.Player1ID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUnfinishedGamesForDivisions = `-- name: GetUnfinishedGamesForDivisions :many
+SELECT g.league_division_id AS division_id,
+       g.player0_id,
+       g.player1_id
+FROM games g
+JOIN league_divisions d ON d.uuid = g.league_division_id
+WHERE g.league_division_id = ANY($1::uuid[])
+  AND g.game_end_reason = 0
+ORDER BY d.division_number
+`
+
+type GetUnfinishedGamesForDivisionsRow struct {
+	DivisionID pgtype.UUID
+	Player0ID  pgtype.Int4
+	Player1ID  pgtype.Int4
+}
+
+// Batched GetUnfinishedDivisionGames for a whole season. Adds league_division_id
+// to the projection (the single-division query omits it) so the flat result can
+// be split by division. Reuses the idx_games_division_unfinished partial index
+// via = ANY; ordered by division_number to align with the divisions list.
+func (q *Queries) GetUnfinishedGamesForDivisions(ctx context.Context, divisionIds []uuid.UUID) ([]GetUnfinishedGamesForDivisionsRow, error) {
+	rows, err := q.db.Query(ctx, getUnfinishedGamesForDivisions, divisionIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetUnfinishedGamesForDivisionsRow
+	for rows.Next() {
+		var i GetUnfinishedGamesForDivisionsRow
+		if err := rows.Scan(&i.DivisionID, &i.Player0ID, &i.Player1ID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
## Summary
Rewrites GetAllDivisionStandings to read the whole season in one repeatable-read snapshot via batched `= ANY(division_ids)` queries, then splits the flat result per division with a groupByDivision lockstep -- replacing the N*3 query fan-out across errgroup goroutines that each grabbed their own pooled connection.

## Bug
The old fan-out had no consistent view, so a game finishing mid-request could desync a player's games-remaining count (standings) from the unfinished pairing list, yielding impossible rank bounds (best > worst, or a rank outside [1,N]).

## Guarantees
No migration, no new index -- reuses idx_league_standings_division_id, idx_league_registrations_division_id, idx_games_division_unfinished. Proto response unchanged; backend-only, no frontend change.

## Test plan
- [x] `go build ./...`, `go vet`, gofmt clean
- [x] groupByDivision unit tests (empty middle/leading/trailing divisions)
- [x] real-Postgres integration test: 3 divisions inserted out of order plus an empty middle division -> correct order, grouping, and bounds
- [x] rank-bounds suite green (unchanged)
