### PR TITLE
gate server-side add-time to casual games

### DIFF
--- a/pkg/gameplay/meta_events.go
+++ b/pkg/gameplay/meta_events.go
@@ -250,6 +250,17 @@ func HandleMetaEvent(ctx context.Context, evt *pb.GameMetaEvent, eventChan chan<
 			return ErrNotAllowed
 		}
 
+		// Add time is a casual-only courtesy. Reject it server-side for rated,
+		// tournament, league, and bot games -- mirroring the frontend's
+		// canAddTime gating -- so a crafted client cannot invoke it (and its
+		// clock change) where the button is hidden.
+		if g.GameReq.RatingMode == pb.RatingMode_RATED ||
+			g.GameReq.PlayerVsBot ||
+			g.LeagueID != nil ||
+			(g.TournamentData != nil && g.TournamentData.Id != "") {
+			return ErrNotAllowed
+		}
+
 		// Find opponent index (the player who is NOT the sender)
 		hist := g.History()
 		opponentIdx := -1

--- a/pkg/gameplay/meta_events_test.go
+++ b/pkg/gameplay/meta_events_test.go
@@ -758,6 +758,9 @@ func TestDisallowSamePlayerAbortAcceptance(t *testing.T) {
 func TestAddTimeDoesNotBroadcastRacksToGameChannel(t *testing.T) {
 	is := is.New(t)
 	gsetup := setupNewGame()
+	// Add-time is now gated to casual games, so make this one casual; otherwise
+	// the ADD_TIME event is rejected and no history refresher is broadcast.
+	gsetup.g.GameReq.RatingMode = pb.RatingMode_CASUAL
 
 	// Jesse adds time to their opponent.
 	opponentIdx := -1
@@ -806,5 +809,22 @@ func TestAddTimeDoesNotBroadcastRacksToGameChannel(t *testing.T) {
 	// one refresher from StartGame, one from the ADD_TIME event.
 	is.Equal(refresherCt, 2)
 
+	teardownGame(gsetup)
+}
+
+func TestHandleAddTimeRejectedInRatedGame(t *testing.T) {
+	is := is.New(t)
+	gsetup := setupNewGame()
+	// The default test game is rated: add-time must be rejected server-side.
+	is.Equal(gsetup.g.GameReq.RatingMode, pb.RatingMode_RATED)
+	err := gameplay.HandleMetaEvent(context.Background(), &pb.GameMetaEvent{
+		Timestamp: timestamppb.New(time.Now()),
+		Type:      pb.GameMetaEvent_ADD_TIME,
+		PlayerId:  "3xpEkpRAy3AizbVmDg3kdi", // "jesse"
+		GameId:    gsetup.g.GameID(),
+	}, gsetup.consumer.ch, gsetup.stores)
+	is.Equal(err, gameplay.ErrNotAllowed)
+	gsetup.cancel()
+	<-gsetup.donechan
 	teardownGame(gsetup)
 }


### PR DESCRIPTION
## Summary
ADD_TIME was only rejected for correspondence games; the server otherwise honored it regardless of type, even though the frontend hides the +time button for rated, tournament, league, and bot games. A crafted client could add time (and trigger the clock change) where the button is hidden. Reject ADD_TIME server-side for those game types to match the frontend's canAddTime gating.

## Changes
Adjusts `TestAddTimeDoesNotBroadcastRacksToGameChannel` (from #1900) to use a casual game, since add-time is now gated; its rack-sanitization assertions still hold and it now also covers the casual allowed-path.

## Test plan
- [x] `go build ./pkg/gameplay/...`, `go vet`, gofmt clean
- [ ] `go test ./pkg/gameplay/ -run AddTime` (rated -> rejected; casual -> allowed + no rack leak) needs the full DB test env; verified statically here, not executed

Related: #1900
