### PR TITLE
open own name to game history in standings

### DIFF
--- a/liwords-ui/src/leagues/standings.tsx
+++ b/liwords-ui/src/leagues/standings.tsx
@@ -18,6 +18,7 @@ import {
 } from "../gen/api/proto/ipc/league_pb";
 import { SeasonRegistrationsResponse } from "../gen/api/proto/league_service/league_service_pb";
 import { PlayerGameHistoryModal } from "./player_game_history_modal";
+import { DisplayUserTitle } from "../shared/display_title";
 import { UsernameWithContext } from "../shared/usernameWithContext";
 
 // Get placement status icon and tooltip
@@ -419,17 +420,31 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
             }
           >
             <strong>
-              <UsernameWithContext
-                username={username}
-                userID={record.userId}
-                sendMessage={onChat}
-                omitSendMessage={!onChat}
-                omitBadges
-                infoText="View game history"
-                handleInfoText={() =>
-                  handlePlayerClick(record.userId, username)
-                }
-              />
+              {isCurrentUser ? (
+                // Own name: skip the context menu (which would offer "View
+                // profile") and open this player's game history directly on a
+                // single click, while still showing the title badge.
+                <span
+                  className="user-context-menu"
+                  style={{ cursor: "pointer" }}
+                  onClick={() => handlePlayerClick(record.userId, username)}
+                >
+                  {username}
+                  <DisplayUserTitle uuid={record.userId} />
+                </span>
+              ) : (
+                <UsernameWithContext
+                  username={username}
+                  userID={record.userId}
+                  sendMessage={onChat}
+                  omitSendMessage={!onChat}
+                  omitBadges
+                  infoText="View game history"
+                  handleInfoText={() =>
+                    handlePlayerClick(record.userId, username)
+                  }
+                />
+              )}
             </strong>
             {placementIndicator && (
               <Tooltip title={placementIndicator.tooltip}>


### PR DESCRIPTION
## Summary
Clicking your own name in league standings opened a context menu whose only extra option ("View profile") is useless for yourself. For the current user's row, opens game history directly on a single click (still rendering the title badge); other players' rows keep the menu.

## Test plan
- [x] tsc --noEmit, eslint, prettier clean
- [ ] visual pass needs league standings + prod data
