### PR TITLE
open analysis toast in a new tab on modifier-click

### DIFF
--- a/liwords-ui/src/store/socket_handlers.ts
+++ b/liwords-ui/src/store/socket_handlers.ts
@@ -1,6 +1,6 @@
-import { useCallback } from "react";
+import { createElement, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import {
   useChallengeResultEventStoreContext,
   useChatStoreContext,
@@ -1071,15 +1071,25 @@ export const useOnSocketMsg = () => {
             });
             if (ev.gameId !== gameContext.gameID) {
               const key = `analysis-complete-${ev.gameId}`;
+              const analysisPath = `/game/${encodeURIComponent(ev.gameId)}`;
+              // Render the toast text as router links so a plain click stays a
+              // cheap same-tab navigation, while ctrl/cmd/middle-click opens the
+              // analysis in a new tab natively -- no popup blocker, and no
+              // forced full-page reload for users who just want the same tab.
+              const analysisLink = (text: string) =>
+                createElement(
+                  Link,
+                  {
+                    to: analysisPath,
+                    onClick: () => notification.destroy(key),
+                  },
+                  text,
+                );
               notification.success({
-                message: "Computer analysis ready",
-                description: "Click to view the analysis",
+                message: analysisLink("Computer analysis ready"),
+                description: analysisLink("Click to view the analysis"),
                 key,
                 duration: 0,
-                onClick: () => {
-                  navigate(`/game/${encodeURIComponent(ev.gameId)}`);
-                  notification.destroy(key);
-                },
               });
             }
             break;


### PR DESCRIPTION
## Summary
The "Computer analysis ready" toast navigated in the same tab, yanking the user off whatever they were doing (often a live game). Renders the toast text as router links: a plain click stays a same-tab navigation, while ctrl/cmd/middle-click opens the analysis in a new tab natively (no popup blocker, opt-in).

## Test plan
- [x] tsc --noEmit, eslint, prettier clean
- [ ] visual pass needs an analysis-ready event (prod)
