### PR TITLE
add temporary debug logs for phony-report chat timing

### DIFF
--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -583,6 +583,12 @@ export const Chat = React.memo((props: Props) => {
         const chats = await socializeClient.getChatsForChannel({
           channel: newChannel,
         });
+        console.log(
+          "[phony-debug] chat channel-load clearChat, channel:",
+          newChannel,
+          "server messages:",
+          chats.messages?.length,
+        );
         clearChat();
         const messages: Array<ChatMessage> = chats.messages;
         if (messages) {

--- a/liwords-ui/src/store/store.tsx
+++ b/liwords-ui/src/store/store.tsx
@@ -991,12 +991,17 @@ const RealStore = ({ children, ...props }: Props) => {
   const challengeResultEvent = useCallback(
     (sge: ServerChallengeResultEvent) => {
       console.log("sge", sge);
+      const message = sge.valid
+        ? "Challenged play was valid"
+        : `Play was challenged off the board! Returned tiles: ${machineWordToRunes(sortTiles(runesToMachineWord(sge.returnedTiles, gameContext.alphabet), gameContext.alphabet), gameContext.alphabet)}`;
+      console.log(
+        "[phony-debug] challengeResultEvent addChat, message:",
+        message,
+      );
       addChat({
         entityType: ChatEntityType.ServerMsg,
         sender: "",
-        message: sge.valid
-          ? "Challenged play was valid"
-          : `Play was challenged off the board! Returned tiles: ${machineWordToRunes(sortTiles(runesToMachineWord(sge.returnedTiles, gameContext.alphabet), gameContext.alphabet), gameContext.alphabet)}`,
+        message,
         id: randomID(),
         channel: "server",
       });

--- a/liwords-ui/src/utils/hooks/definitions.tsx
+++ b/liwords-ui/src/utils/hooks/definitions.tsx
@@ -198,6 +198,10 @@ export const useDefinitionAndPhonyChecker = ({
 
   const [playedWords, setPlayedWords] = useState(new Set<string>());
   useEffect(() => {
+    console.log(
+      "[phony-debug] playedWords-effect fire, turns:",
+      gameContext.turns.length,
+    );
     setPlayedWords((oldPlayedWords) => {
       const playedWords = new Set(oldPlayedWords);
       for (const turn of gameContext.turns) {
@@ -213,6 +217,12 @@ export const useDefinitionAndPhonyChecker = ({
 
   useEffect(() => {
     // forget everything if it goes to a new game
+    console.log(
+      "[phony-debug] RESET effect fire, gameID:",
+      gameID,
+      "lexicon:",
+      lexicon,
+    );
     setWordInfo({});
     setPlayedWords(new Set());
     setUnrace(new Unrace());
@@ -221,6 +231,12 @@ export const useDefinitionAndPhonyChecker = ({
   }, [gameID, lexicon]);
 
   useEffect(() => {
+    console.log(
+      "[phony-debug] compute-wordInfo effect, gameDone:",
+      gameDone,
+      "playedWords.size:",
+      playedWords.size,
+    );
     if (gameDone || showDefinitionHover) {
       // when definition is requested, get definitions for all words (up to
       // that point) that have not yet been defined. this is an intentional
@@ -322,6 +338,16 @@ export const useDefinitionAndPhonyChecker = ({
   }, [anagrams, showDefinitionHover, lexicon, wordClient, wordInfo, unrace]);
 
   useEffect(() => {
+    console.log(
+      "[phony-debug] phonies-compute effect, phonies:",
+      phonies,
+      "gameDone:",
+      gameDone,
+      "playedWords.size:",
+      playedWords.size,
+      "wordInfo keys:",
+      Object.keys(wordInfo).length,
+    );
     if (phonies === null) {
       if (gameDone) {
         const phonies: Array<string> = [];
@@ -348,6 +374,7 @@ export const useDefinitionAndPhonyChecker = ({
 
   const lastPhonyReport = useRef("");
   useEffect(() => {
+    console.log("[phony-debug] post effect, phonies:", phonies);
     if (!phonies) return;
     if (phonies.length) {
       // since +false === 0 and +true === 1, this is [unchallenged, challenged]


### PR DESCRIPTION
## Summary

Temporary console.log instrumentation to diagnose the annotated-game phony report ("All words played are valid" / invalid-words list) sometimes failing to post to chat. This is reproducible on desktop with devtools open, so merging deploys the logs where the effect firing order can be read directly in the console.

The main payload is the `definitions.tsx` logging. Two additional logs (`chat.tsx`, `store.tsx`) instrument a chat-clear-clobber theory and the challenge "Returned tiles" message; these are low-cost and ride along, but are not expected to help the separate mobile "returned tiles" report (no console access on phone).

Meant to be merged briefly to collect logs, then reverted once root cause is confirmed.

## Changes

- `definitions.tsx`: log each effect (playedWords fill, game/lexicon reset, wordInfo compute, phonies compute, post-to-chat) to capture firing order. The hook is shared across live, annotated, and editor views, so these fire for all game types.
- `chat.tsx`: log channel + server-message count right before `clearChat()` wipes local chat state on channel load.
- `store.tsx`: log the built challenge-result message before `addChat`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] eslint clean on changed files
- [ ] merge, open an affected annotated game on desktop, read console effect ordering
- [ ] revert once root cause confirmed
