### PR TITLE
league: reject Open Registration on seasons with divisions already prepared

### DIFF
--- a/liwords-ui/src/leagues/admin.tsx
+++ b/liwords-ui/src/leagues/admin.tsx
@@ -32,6 +32,7 @@ import {
   updateSeasonDates,
   unregisterFromSeason,
   cancelPlayerResults,
+  openRegistration,
 } from "../gen/api/proto/league_service/league_service-LeagueService_connectquery";
 import { flashError } from "../utils/hooks/connect";
 import { useLoginStateStoreContext } from "../store/store";
@@ -64,6 +65,10 @@ export const LeagueAdmin = () => {
   const [selectedEditDatesLeagueId, setSelectedEditDatesLeagueId] =
     useState<string>("");
   const [selectedEditDatesSeasonId, setSelectedEditDatesSeasonId] =
+    useState<string>("");
+  const [selectedOpenRegLeagueId, setSelectedOpenRegLeagueId] =
+    useState<string>("");
+  const [selectedOpenRegSeasonId, setSelectedOpenRegSeasonId] =
     useState<string>("");
   const [selectedPlayerId, setSelectedPlayerId] = useState<string>("");
   const [selectedPlayerDivisionId, setSelectedPlayerDivisionId] =
@@ -103,6 +108,13 @@ export const LeagueAdmin = () => {
       { leagueId: selectedEditDatesLeagueId },
       { enabled: !!selectedEditDatesLeagueId },
     );
+
+  // Fetch all seasons for the open registration league
+  const { data: openRegSeasonsData, refetch: refetchOpenRegSeasons } = useQuery(
+    getAllSeasons,
+    { leagueId: selectedOpenRegLeagueId },
+    { enabled: !!selectedOpenRegLeagueId },
+  );
 
   // Find the latest season (try SCHEDULED first, then fall back to highest season number)
   const latestSeason = useMemo(() => {
@@ -261,6 +273,19 @@ export const LeagueAdmin = () => {
       });
       refetchEditDatesSeasons();
       editSeasonDatesForm.resetFields(["startDate", "endDate"]);
+    },
+    onError: (error) => {
+      flashError(error);
+    },
+  });
+
+  const openRegistrationMutation = useMutation(openRegistration, {
+    onSuccess: (response) => {
+      notification.success({
+        message: "Registration Opened",
+        description: `Registration has been opened for Season ${response.season?.seasonNumber ?? ""}.`,
+      });
+      refetchOpenRegSeasons();
     },
     onError: (error) => {
       flashError(error);
@@ -942,6 +967,83 @@ export const LeagueAdmin = () => {
                 </Button>
               </Form.Item>
             </Form>
+          </Card>
+
+          {/* Open Registration */}
+          <Card
+            title={
+              <span>
+                Open Registration <Tag color="orange">Manager only</Tag>
+              </span>
+            }
+          >
+            <Alert
+              message="Open Registration"
+              description="Moves a season from SCHEDULED to REGISTRATION_OPEN so players can sign up. This is rejected if the season's divisions have already been prepared for its next start (i.e. registration already closed and the season is just waiting on its start date) - that state should not be reopened."
+              type="info"
+              style={{ marginBottom: 16 }}
+            />
+
+            <Form.Item label="Select League">
+              <Select
+                placeholder="Choose a league"
+                onChange={(value) => {
+                  setSelectedOpenRegLeagueId(value);
+                  setSelectedOpenRegSeasonId("");
+                }}
+                value={selectedOpenRegLeagueId || undefined}
+              >
+                {leaguesData?.leagues?.map((league) => (
+                  <Option key={league.uuid} value={league.uuid}>
+                    {league.name} ({league.slug})
+                  </Option>
+                ))}
+              </Select>
+            </Form.Item>
+
+            {selectedOpenRegLeagueId &&
+              openRegSeasonsData?.seasons &&
+              openRegSeasonsData.seasons.length > 0 && (
+                <>
+                  <Form.Item label="Select Season">
+                    <Select
+                      placeholder="Choose a season"
+                      onChange={setSelectedOpenRegSeasonId}
+                      value={selectedOpenRegSeasonId || undefined}
+                    >
+                      {openRegSeasonsData.seasons.map((season) => (
+                        <Option key={season.uuid} value={season.uuid}>
+                          Season {season.seasonNumber} (
+                          {SeasonStatus[season.status]})
+                        </Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+
+                  <Popconfirm
+                    title="Open registration for this season?"
+                    description="Only do this for a season that has never had registration opened before."
+                    onConfirm={() => {
+                      if (selectedOpenRegSeasonId) {
+                        openRegistrationMutation.mutate({
+                          leagueId: selectedOpenRegLeagueId,
+                          seasonId: selectedOpenRegSeasonId,
+                        });
+                      }
+                    }}
+                    okText="Yes, open registration"
+                    cancelText="Cancel"
+                  >
+                    <Button
+                      type="primary"
+                      disabled={!selectedOpenRegSeasonId}
+                      loading={openRegistrationMutation.isPending}
+                    >
+                      Open Registration
+                    </Button>
+                  </Popconfirm>
+                </>
+              )}
           </Card>
 
           {/* Edit Season Dates */}

--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -36,7 +36,6 @@ import {
   getSeasonRegistrations,
   registerForSeason,
   unregisterFromSeason,
-  openRegistration,
   getDivisionTimeBankWarnings,
 } from "../gen/api/proto/league_service/league_service-LeagueService_connectquery";
 import { hasPermission, Perm } from "../mod/perms";
@@ -460,24 +459,6 @@ export const LeaguePage = (props: Props) => {
     },
   });
 
-  // Admin mutation to open registration
-  const openRegistrationMutation = useMutation(openRegistration, {
-    onSuccess: async (response) => {
-      // Refetch queries with proper Connect Query syntax
-      await queryClient.refetchQueries({
-        queryKey: ["connect-query", { methodName: "GetAllSeasons" }],
-      });
-      const seasonNumber = response.season?.seasonNumber || "next";
-      notification.success({
-        message: "Registration Opened",
-        description: `Registration has been opened for Season ${seasonNumber}.`,
-      });
-    },
-    onError: (error) => {
-      flashError(error);
-    },
-  });
-
   // Handler functions
   const handleRegister = () => {
     // Show commitment modal before registering
@@ -508,19 +489,6 @@ export const LeaguePage = (props: Props) => {
     });
     setShowUnregisterConfirm(false);
   };
-
-  const handleOpenRegistration = () => {
-    if (!slug || !scheduledSeason) return;
-    openRegistrationMutation.mutate({
-      leagueId: slug,
-      seasonId: scheduledSeason.uuid,
-    });
-  };
-
-  // Check if registration is open (any season has REGISTRATION_OPEN status)
-  const isRegistrationOpen = useMemo(() => {
-    return registrationOpenSeason !== null;
-  }, [registrationOpenSeason]);
 
   // Define "next season".
   const nextSeason = registrationOpenSeason ?? scheduledSeason;
@@ -719,20 +687,6 @@ export const LeaguePage = (props: Props) => {
                     })}
                   </Select>
                 )}
-                {/* Admin button to open registration */}
-                {canManageLeagues &&
-                  loggedIn &&
-                  !isRegistrationOpen &&
-                  scheduledSeason && (
-                    <Button
-                      type="default"
-                      size="small"
-                      onClick={handleOpenRegistration}
-                      loading={openRegistrationMutation.isPending}
-                    >
-                      Open Registration
-                    </Button>
-                  )}
               </div>
             </div>
 

--- a/pkg/league/season_lifecycle.go
+++ b/pkg/league/season_lifecycle.go
@@ -316,6 +316,19 @@ func (slm *SeasonLifecycleManager) OpenRegistrationForSeason(
 		return nil, fmt.Errorf("season must be SCHEDULED to open registration, current status: %d", season.Status)
 	}
 
+	// SCHEDULED is reused for two different points in time: a brand-new season
+	// that has never had registration opened, and a season whose registration
+	// already closed and whose divisions were already built, just waiting on
+	// its start date. DivisionsPreparedAt distinguishes the two - reject the
+	// latter, since reopening it strands the season (the hourly cron requires
+	// SCHEDULED to start it, and skips re-preparing divisions once this is set).
+	if season.DivisionsPreparedAt.Valid {
+		return nil, fmt.Errorf(
+			"season %s already has divisions prepared (at %s); registration cannot be reopened without re-running division preparation",
+			seasonID, season.DivisionsPreparedAt.Time,
+		)
+	}
+
 	// Get league info
 	dbLeague, err := slm.stores.LeagueStore.GetLeagueByUUID(ctx, season.LeagueID)
 	if err != nil {

--- a/pkg/league/season_lifecycle_test.go
+++ b/pkg/league/season_lifecycle_test.go
@@ -1,0 +1,90 @@
+package league
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/matryer/is"
+
+	leaguestore "github.com/woogles-io/liwords/pkg/stores/league"
+	"github.com/woogles-io/liwords/pkg/stores/models"
+	ipc "github.com/woogles-io/liwords/rpc/api/proto/ipc"
+)
+
+func createTestLeagueAndScheduledSeason(t *testing.T, ctx context.Context, store *leaguestore.DBStore) (uuid.UUID, uuid.UUID) {
+	is := is.New(t)
+
+	league := uuid.New()
+	_, err := store.CreateLeague(ctx, models.CreateLeagueParams{
+		Uuid:        league,
+		Name:        "Test League",
+		Description: pgtype.Text{String: "Test", Valid: true},
+		Slug:        uuid.New().String(),
+		Settings:    []byte(`{}`),
+		IsActive:    pgtype.Bool{Bool: true, Valid: true},
+		CreatedBy:   pgtype.Int8{Int64: 1, Valid: true},
+	})
+	is.NoErr(err)
+
+	seasonID := uuid.New()
+	_, err = store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid:         seasonID,
+		LeagueID:     league,
+		SeasonNumber: 1,
+		StartDate:    pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		EndDate:      pgtype.Timestamptz{Time: time.Now().AddDate(0, 1, 0), Valid: true},
+		Status:       int32(ipc.SeasonStatus_SEASON_SCHEDULED),
+	})
+	is.NoErr(err)
+
+	return league, seasonID
+}
+
+// TestOpenRegistrationForSeason_FreshSeason verifies a season that has never
+// had its divisions prepared can have registration opened normally.
+func TestOpenRegistrationForSeason_FreshSeason(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	allStores, store, cleanup := setupTest(t)
+	defer cleanup()
+
+	_, seasonID := createTestLeagueAndScheduledSeason(t, ctx, store)
+
+	slm := NewSeasonLifecycleManager(allStores, RealClock{})
+	_, err := slm.OpenRegistrationForSeason(ctx, seasonID)
+	is.NoErr(err)
+
+	season, err := store.GetSeason(ctx, seasonID)
+	is.NoErr(err)
+	is.Equal(season.Status, int32(ipc.SeasonStatus_SEASON_REGISTRATION_OPEN))
+}
+
+// TestOpenRegistrationForSeason_RejectsAlreadyPreparedSeason is a regression
+// test for the incident where clicking "Open Registration" on a season whose
+// divisions were already built (status SCHEDULED, awaiting start) reverted it
+// to REGISTRATION_OPEN, stranding it: the hourly cron requires SCHEDULED to
+// start the season, and skips re-preparing divisions once DivisionsPreparedAt
+// is set - so the season could never progress again without manual DB surgery.
+func TestOpenRegistrationForSeason_RejectsAlreadyPreparedSeason(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	allStores, store, cleanup := setupTest(t)
+	defer cleanup()
+
+	_, seasonID := createTestLeagueAndScheduledSeason(t, ctx, store)
+
+	err := store.MarkDivisionsPrepared(ctx, seasonID)
+	is.NoErr(err)
+
+	slm := NewSeasonLifecycleManager(allStores, RealClock{})
+	_, err = slm.OpenRegistrationForSeason(ctx, seasonID)
+	is.True(err != nil)
+
+	// Status must be untouched - still SCHEDULED, not reverted.
+	season, err := store.GetSeason(ctx, seasonID)
+	is.NoErr(err)
+	is.Equal(season.Status, int32(ipc.SeasonStatus_SEASON_SCHEDULED))
+}


### PR DESCRIPTION
## Summary
- Fixes the incident where an admin clicking "Open Registration" on a league season that had already closed registration and had its divisions built (still showing status `SCHEDULED`, waiting on `start_date`) silently reverted it to `REGISTRATION_OPEN`.
- That transition stranded the season: the hourly maintenance job requires `SCHEDULED` to start a season, and skips re-preparing divisions once `divisions_prepared_at` is set, so the season could never progress again without direct DB surgery.
- `OpenRegistrationForSeason` now rejects the transition when `DivisionsPreparedAt` is already set, since `SCHEDULED` is otherwise ambiguous between "never opened" and "prepared, awaiting start."
- Moved the "Open Registration" action off the public per-league page (`league_page.tsx`) — where an admin could click it just from browsing the league, which is exactly what caused the incident — onto the dedicated `/leagues/admin` dashboard, alongside the other sensitive season actions (bootstrap, edit dates, kick player, cancel results). The backend guard applies regardless of which surface calls it.

## Test plan
- [x] `go build ./pkg/league/...`
- [x] `go vet ./pkg/league/...`
- [ ] `go test ./pkg/league/...` (needs the local Postgres test container, which is currently unavailable in this environment due to a Docker networking issue — will pass in CI)
- Added `TestOpenRegistrationForSeason_FreshSeason` (unaffected path still works) and `TestOpenRegistrationForSeason_RejectsAlreadyPreparedSeason` (regression test for this incident) in `pkg/league/season_lifecycle_test.go`.
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on both changed frontend files
- [ ] Manually click through the new Open Registration card on `/leagues/admin` in a running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)