### PR TITLE
fix invisible analysis-ready toast text

### DIFF
--- a/liwords-ui/src/store/analysis_toast.test.tsx
+++ b/liwords-ui/src/store/analysis_toast.test.tsx
@@ -1,0 +1,127 @@
+import { App, ConfigProvider } from "antd";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as path from "node:path";
+import * as sass from "sass";
+import { useEffect } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { liwordsDarkTheme, liwordsDefaultTheme } from "../themes";
+
+// Covers the "Computer analysis ready" toast in socket_handlers.ts. Both halves
+// of it broke once already (#1917) and neither is visible to tsc or eslint, so
+// they are pinned here.
+
+const srcDir = path.join(__dirname, "..");
+
+beforeAll(() => {
+  const { css } = sass.compile(path.join(srcDir, "App.scss"), {
+    loadPaths: [srcDir],
+  });
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+});
+
+const toRgb = (hex: string) => {
+  const n = parseInt(hex.replace("#", ""), 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+};
+
+type Handlers = {
+  onClick?: (event?: React.MouseEvent<HTMLDivElement>) => void;
+  onAuxClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+};
+
+const Toast = (props: Handlers) => {
+  const { notification } = App.useApp();
+  useEffect(() => {
+    notification.success({
+      message: "Computer analysis ready",
+      description: "Click to view the analysis",
+      duration: 0,
+      onClick: props.onClick,
+      props: { onAuxClick: props.onAuxClick },
+    });
+  }, [notification, props]);
+  return null;
+};
+
+const showToast = async (mode: "dark" | "default", handlers: Handlers = {}) => {
+  const theme = mode === "dark" ? liwordsDarkTheme : liwordsDefaultTheme;
+  document.body.className = `mode--${mode}`;
+  render(
+    <ConfigProvider theme={theme}>
+      <App>
+        <Toast {...handlers} />
+      </App>
+    </ConfigProvider>,
+  );
+  return {
+    message: await screen.findByText("Computer analysis ready"),
+    description: screen.getByText("Click to view the analysis"),
+    background: toRgb(theme.components.Notification.colorBgElevated),
+  };
+};
+
+// Toasts render in a portal at body level, where the global `a` rule in
+// App.scss resolves to $primary-dark -- which is exactly the notice background
+// in both modes. So toast text rendered as a link is invisible, which is what
+// #1917 shipped. antd paints the notice background via cssinjs `:where()`
+// selectors that jsdom cannot resolve, so the background is derived from the
+// token that produces it rather than read back off the element.
+describe.each(["dark", "default"] as const)(
+  "analysis toast in %s mode",
+  (mode) => {
+    it("does not paint the toast text the color of the toast itself", async () => {
+      const { message, description, background } = await showToast(mode);
+
+      expect(getComputedStyle(message).color).not.toBe(background);
+      expect(getComputedStyle(description).color).not.toBe(background);
+    });
+  },
+);
+
+// The toast opens the analysis on click, and a new tab on modifier/middle
+// click. Both rely on antd behavior its types do not promise.
+describe("analysis toast click wiring", () => {
+  it("hands a real mouse event to antd's onClick, which antd types as zero-arg", async () => {
+    const onClick = vi.fn();
+    const { message } = await showToast("dark", { onClick });
+
+    await userEvent.click(message);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    // The optional-parameter signature is only sound if the event is real.
+    expect(onClick.mock.calls[0][0]?.ctrlKey).toBe(false);
+  });
+
+  it("reports modifier keys, so ctrl-click can open a new tab", async () => {
+    const onClick = vi.fn();
+    const { message } = await showToast("dark", { onClick });
+
+    const user = userEvent.setup();
+    await user.keyboard("{Control>}");
+    await user.click(message);
+
+    expect(onClick.mock.calls[0][0].ctrlKey).toBe(true);
+  });
+
+  it("delivers onAuxClick through `props`, which antd does not clobber", async () => {
+    const onAuxClick = vi.fn();
+    const { message } = await showToast("dark", { onAuxClick });
+
+    await userEvent.pointer({ target: message, keys: "[MouseMiddle]" });
+
+    expect(onAuxClick).toHaveBeenCalledTimes(1);
+    expect(onAuxClick.mock.calls[0][0].button).toBe(1);
+  });
+
+  it("does not fire the toast's onClick when the close button is clicked", async () => {
+    const onClick = vi.fn();
+    await showToast("dark", { onClick });
+
+    await userEvent.click(screen.getByLabelText("Close"));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/liwords-ui/src/store/socket_handlers.ts
+++ b/liwords-ui/src/store/socket_handlers.ts
@@ -1071,14 +1071,34 @@ export const useOnSocketMsg = () => {
             });
             if (ev.gameId !== gameContext.gameID) {
               const key = `analysis-complete-${ev.gameId}`;
+              const analysisPath = `/game/${encodeURIComponent(ev.gameId)}`;
               notification.success({
                 message: "Computer analysis ready",
                 description: "Click to view the analysis",
                 key,
                 duration: 0,
-                onClick: () => {
-                  navigate(`/game/${encodeURIComponent(ev.gameId)}`);
+                // antd types this as a zero-arg callback, but it is passed
+                // straight through to the notice div, so React does hand us the
+                // event. An optional parameter keeps that usable without a cast.
+                onClick: (event?: React.MouseEvent<HTMLDivElement>) => {
+                  if (event?.ctrlKey || event?.altKey || event?.metaKey) {
+                    window.open(analysisPath);
+                  } else {
+                    navigate(analysisPath);
+                  }
                   notification.destroy(key);
+                },
+                // antd spreads `props` onto the notice div and then sets its
+                // own onClick last, so an onClick here would be clobbered --
+                // onAuxClick is untouched and is the only way to get one.
+                props: {
+                  onAuxClick: (event: React.MouseEvent<HTMLDivElement>) => {
+                    if (event.button === 1) {
+                      // middle-click
+                      window.open(analysisPath);
+                      notification.destroy(key);
+                    }
+                  },
                 },
               });
             }

--- a/liwords-ui/src/store/socket_handlers.ts
+++ b/liwords-ui/src/store/socket_handlers.ts
@@ -1,6 +1,6 @@
-import { createElement, useCallback } from "react";
+import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import {
   useChallengeResultEventStoreContext,
   useChatStoreContext,
@@ -1071,25 +1071,15 @@ export const useOnSocketMsg = () => {
             });
             if (ev.gameId !== gameContext.gameID) {
               const key = `analysis-complete-${ev.gameId}`;
-              const analysisPath = `/game/${encodeURIComponent(ev.gameId)}`;
-              // Render the toast text as router links so a plain click stays a
-              // cheap same-tab navigation, while ctrl/cmd/middle-click opens the
-              // analysis in a new tab natively -- no popup blocker, and no
-              // forced full-page reload for users who just want the same tab.
-              const analysisLink = (text: string) =>
-                createElement(
-                  Link,
-                  {
-                    to: analysisPath,
-                    onClick: () => notification.destroy(key),
-                  },
-                  text,
-                );
               notification.success({
-                message: analysisLink("Computer analysis ready"),
-                description: analysisLink("Click to view the analysis"),
+                message: "Computer analysis ready",
+                description: "Click to view the analysis",
                 key,
                 duration: 0,
+                onClick: () => {
+                  navigate(`/game/${encodeURIComponent(ev.gameId)}`);
+                  notification.destroy(key);
+                },
               });
             }
             break;


### PR DESCRIPTION
## Summary
The "Computer analysis ready" toast text was invisible. Fixes issues in #1917.

Toasts render in a portal at body level, where the global `a` rule in App.scss
resolves to $primary-dark -- which is exactly the notice background: #c9f0ff in
dark mode, #11659e in light. #1917 rendered the toast's message and description
as router Links, so the text took the link color and matched the toast it sat
on. Both modes were affected; only dark mode was reported.

First commit is a straight revert of #1917, which fixes the bug on its own. The
second brings the new-tab behavior back without a link, reading the modifier
keys off the toast's own onClick the way active_games.tsx already does it: a
plain click navigates in the same tab, ctrl/alt/cmd-click and middle-click open
a new tab. That also restores clicking anywhere on the toast, which #1917 had
narrowed to just the text.

## Test plan
- [x] `vitest` -- new `analysis_toast.test.tsx` compiles App.scss into jsdom and
      renders the real toast, so text color is checked against the real cascade;
      putting #1917's link back fails both modes. Also pins the two antd
      behaviors the toast relies on that its types do not promise: onClick
      receives the mouse event, and props.onAuxClick survives onto the notice div
- [x] `tsc --noEmit`, `eslint`, `prettier --check` clean on each commit
- [ ] visual pass needs a live analysis-ready event
