### PR TITLE
populate live fields in correspondence ongoing-game update

### DIFF
--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -7,6 +7,7 @@ package gameplay
 import (
 	"context"
 	"errors"
+	"slices"
 	"sort"
 	"time"
 
@@ -767,6 +768,20 @@ func handleEventAfterLockingGame(ctx context.Context, stores *stores.Stores, use
 			if err != nil {
 				log.Err(err).Msg("error-getting-metadata-for-correspondence-update")
 			} else {
+				// GetMetadata returns final-scores/no-turn data, which is blank
+				// mid-game. Populate the live fields the lobby list needs (whose
+				// turn, current scores, time bank) so the update doesn't wipe them
+				// on the client. Mirrors ListActiveCorrespondenceForUser.
+				playerOnTurn := uint32(entGame.Game.PlayerOnTurn())
+				metadata.PlayerOnTurn = &playerOnTurn
+				metadata.Scores = []int32{
+					int32(entGame.Game.PointsFor(0)),
+					int32(entGame.Game.PointsFor(1)),
+				}
+				// Clone: the payload is serialized downstream (async), while the
+				// live game's TimeBank slice is mutated in place on later turns.
+				metadata.TimeBank = slices.Clone(entGame.Timers.TimeBank)
+
 				// Send updated game info to both players
 				wrapped := entity.WrapEvent(metadata, pb.MessageType_ONGOING_GAME_EVENT)
 				players := players(entGame)


### PR DESCRIPTION
## Summary

When an opponent moves in a correspondence/league game, the real-time
update (`ONGOING_GAME_EVENT`) was built from `GetMetadata`, which returns
final-game data: empty scores mid-game, no `player_on_turn`, no
`time_bank`. The client overwrites its full correspondence entry with
this stripped one, so the game loses its score, timer, and turn
indicator, and (with `player_on_turn` gone) sorts to the bottom of the
lobby and "My League Games" lists until the next full refresh.

This populates `player_on_turn`, current scores, and `time_bank` from the
in-memory game before sending, mirroring `ListActiveCorrespondenceForUser`
so the update carries the same fields as the initial load. Fixes both the
lobby and league correspondence lists (shared store, shared update path).

## Root cause

`GetMetadata` (`db.go`) builds a `GameInfoResponse` with
`Scores: mdata.FinalScores` (empty until game end) and never sets
`PlayerOnTurn` or `TimeBank`. Correct for finished-game metadata, wrong
for a mid-game live update.

## Guarantees

`time_bank` is cloned (`slices.Clone`) rather than aliasing the live
game's slice, which is mutated in place on later turns and would
otherwise race with the downstream (async) serialization of the event.

## Test plan

- [x] `go build ./pkg/gameplay/`
- [x] `gofmt -l pkg/gameplay/game.go` clean
- [x] `go test ./pkg/gameplay/` (DB-backed): 31 passed, 0 failed.
      No existing test covers the correspondence update path, so this
      confirms no regression to the shared move-handling flow; the fix
      itself is verified by observing that an opponent move no longer
      blanks the game or drops it to the bottom of the list.