### PR TITLE
sort opponent-turn league games by updated_at

### DIFF
--- a/liwords-ui/src/leagues/league_correspondence_games.tsx
+++ b/liwords-ui/src/leagues/league_correspondence_games.tsx
@@ -83,7 +83,11 @@ export const LeagueCorrespondenceGames: React.FC<
         .beforeExpiry;
     };
 
-    // Sort: user's turn first, then by the real time-until-expiry (ascending).
+    // Sort: user's turn first (by real time-until-expiry, ascending, since
+    // those are the urgent ones), then opponent's-turn games by updated_at
+    // (ascending, oldest first) - you don't act on those, so a deadline you
+    // don't own is not a useful ordering. updated_at is the time of the last
+    // event (normally our move, since it is now their turn).
     return filtered.sort((a, b) => {
       const aOnTurn =
         a.playerOnTurn !== undefined &&
@@ -97,7 +101,10 @@ export const LeagueCorrespondenceGames: React.FC<
       if (aOnTurn && !bOnTurn) return -1;
       if (!aOnTurn && bOnTurn) return 1;
 
-      return expiryOf(a) - expiryOf(b);
+      if (aOnTurn && bOnTurn) {
+        return expiryOf(a) - expiryOf(b);
+      }
+      return (a.lastUpdate ?? Infinity) - (b.lastUpdate ?? Infinity);
     });
   }, [correspondenceGames, leagueSlug, userID]);
 


### PR DESCRIPTION
## Summary

In "My League Games", games where it is the opponent's turn are not
deadlines the user acts on, so ordering them by the opponent's
time-until-expiry was not useful. Sort opponent-turn games by
`updated_at` ascending (oldest move first) instead. Games on the user's
turn are unchanged: still listed first, ordered by real
time-until-expiry.

`updated_at` on an opponent-turn game is the time of the last event --
normally the user's own move that handed over the turn (or the
opponent's challenge of it).

## Test plan

- [x] `prettier --check` clean on the changed file
- [x] `eslint` clean on the changed file
- [x] `tsc --noEmit` clean
- [ ] my-turn games remain first, ordered by expiry; opponent-turn games
      follow in oldest-updated-first order (manual, in-app)