### PR TITLE
link to admin panel from roles & permissions settings

### DIFF
--- a/liwords-ui/src/settings/roles_permissions.tsx
+++ b/liwords-ui/src/settings/roles_permissions.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { Tag, Card, Spin, Alert, Divider } from "antd";
-import { SafetyOutlined, CrownOutlined } from "@ant-design/icons";
+import { Link } from "react-router";
+import { Alert, Button, Card, Divider, Spin, Tag } from "antd";
+import { CrownOutlined, SafetyOutlined, ToolOutlined } from "@ant-design/icons";
 import { useQuery } from "@connectrpc/connect-query";
 import {
   getSelfRoles,
   getSelfPermissions,
 } from "../gen/api/proto/user_service/user_service-AuthorizationService_connectquery";
+import { hasAnyPermission, ADMIN_PANEL_PERMS } from "../mod/perms";
 
 // Human-readable permission names
 const PERMISSION_LABELS: Record<string, string> = {
@@ -60,6 +62,7 @@ export const RolesPermissions = () => {
 
   const roles = selfRoles?.roles || [];
   const allPermissions = selfPermissions?.permissions || [];
+  const canAccessAdmin = hasAnyPermission(allPermissions, ADMIN_PANEL_PERMS);
 
   return (
     <div className="roles-permissions-container" style={{ padding: "24px" }}>
@@ -70,6 +73,16 @@ export const RolesPermissions = () => {
       <p className="description" style={{ marginBottom: "24px" }}>
         View your assigned roles and permissions on Woogles.
       </p>
+
+      {canAccessAdmin && (
+        <div style={{ marginBottom: "24px" }}>
+          <Link to="/admin">
+            <Button type="primary" icon={<ToolOutlined />} size="large">
+              Go to Admin Panel
+            </Button>
+          </Link>
+        </div>
+      )}
 
       {roles.length === 0 ? (
         <Alert


### PR DESCRIPTION
## Summary
Add a "Go to Admin Panel" button on Settings > Roles & Permissions, shown only to users whose permissions grant `/admin` access (`ADMIN_PANEL_PERMS`). Lets staff reach admin tools from the phone PWA, which has no address bar.

## Test plan
- Button shows for admin/manager/mod; hidden for non-staff.
- `tsc --noEmit`, eslint clean.