### PR TITLE
auto-size the chat input and add chat text-size and timestamp options

### DIFF
--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -477,12 +477,16 @@ p {
   }
 }
 
-.chat input[name="chat-input"] {
+.chat textarea[name="chat-input"] {
   position: absolute;
   bottom: 0;
   left: 0;
   width: calc(100% - 12px);
   margin: 6px;
+  // Auto-sizes up to a few rows so a full message can be read while typing;
+  // it grows upward from the bottom over the most recent messages and
+  // collapses back to one row after sending.
+  resize: none;
   @include colorModed() {
     background: m($card-background);
     color: m($gray-extreme);

--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -289,8 +289,51 @@ p {
     }
   }
 
+  .chat-context {
+    position: relative;
+  }
+
+  .chat-font-size {
+    display: flex;
+    gap: 4px;
+    position: absolute;
+    right: 6px;
+    top: 6px;
+    z-index: 2;
+  }
+
+  .chat-font-size-btn {
+    background: transparent;
+    border: 1px solid;
+    border-radius: 4px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 2px 7px;
+    @include colorModed() {
+      border-color: m($gray-medium);
+      color: m($gray-medium);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
+
+    &:first-child {
+      font-size: 12px;
+    }
+
+    &:last-child {
+      font-size: 16px;
+    }
+  }
+
   .entities {
     padding: 12px 24px 0px;
+    // Multiply the message text size by the user's chat font-size setting
+    // (1 = default, so no visual change unless the user opts into a larger
+    // size). Applied here so it scales the whole message list uniformly.
+    font-size: calc(1em * var(--chat-font-scale, 1));
     .chat-entity {
       width: 100%;
       width: 100%;
@@ -376,7 +419,9 @@ p {
           color: m($secondary);
         }
         & {
-          visibility: hidden;
+          // Base visibility is driven by the "always show timestamps" pref
+          // (default hidden); the :hover rule above still reveals it on hover.
+          visibility: var(--chat-timestamp-visibility, hidden);
           float: right;
           font-size: 75%;
           margin: 3px 0;

--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -200,8 +200,11 @@ export const Chat = React.memo((props: Props) => {
     Set<string> | undefined
   >(undefined);
   const onChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setCurMsg(e.target.value);
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      // Collapse any newlines (e.g. from a paste) into spaces so messages
+      // stay single-line: they render without line breaks anyway, and this
+      // avoids newline-flooding to scroll away others' chat.
+      setCurMsg(e.target.value.replace(/[\r\n]+/g, " "));
     },
     [setCurMsg],
   );
@@ -701,7 +704,11 @@ export const Chat = React.memo((props: Props) => {
   }, []);
 
   const onKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Any Enter sends. Chat messages are single-line (a newline renders as
+      // a space, so it is never a real line break); the auto-sizing textarea
+      // only exists to read a long message while typing, not to compose
+      // multi-line paragraphs.
       if (e.key === "Enter" && channel) {
         e.preventDefault();
         // Send if non-trivial
@@ -944,9 +951,10 @@ export const Chat = React.memo((props: Props) => {
                     {entities}
                   </div>
                   <form>
-                    <Input
+                    <Input.TextArea
                       autoFocus={!defaultChannel.startsWith("chat.game")}
                       autoComplete="off"
+                      autoSize={{ minRows: 1, maxRows: 6 }}
                       placeholder={
                         channel === "chat.lobby"
                           ? "Ask or answer question..."

--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -10,6 +10,7 @@ import { Card, Input, Tabs, App } from "antd";
 import { LeftOutlined } from "@ant-design/icons";
 import { singularCount } from "../utils/plural";
 import { ChatEntity } from "./chat_entity";
+import { useApplyChatPrefs, useChatFontScaleControl } from "./chat_prefs";
 import {
   useChatStoreContext,
   useLoginStateStoreContext,
@@ -199,6 +200,12 @@ export const Chat = React.memo((props: Props) => {
   const [updatedChannels, setUpdatedChannels] = useState<
     Set<string> | undefined
   >(undefined);
+  // Apply the chat display prefs (text size + always-show-timestamps) as CSS
+  // variables. They are configured under Settings > Preferences and via the
+  // in-chat A-/A+ control, and sync live across open tabs (no refresh).
+  useApplyChatPrefs();
+  const chatFontControl = useChatFontScaleControl();
+
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       // Collapse any newlines (e.g. from a paste) into spaces so messages
@@ -866,6 +873,26 @@ export const Chat = React.memo((props: Props) => {
                 id="chat-context"
                 className={`chat-context${hasScroll ? " scrolling" : ""}`}
               >
+                <div className="chat-font-size">
+                  <button
+                    type="button"
+                    className="chat-font-size-btn"
+                    aria-label="Decrease chat text size"
+                    disabled={chatFontControl.atMin}
+                    onClick={chatFontControl.decrease}
+                  >
+                    A-
+                  </button>
+                  <button
+                    type="button"
+                    className="chat-font-size-btn"
+                    aria-label="Increase chat text size"
+                    disabled={chatFontControl.atMax}
+                    onClick={chatFontControl.increase}
+                  >
+                    A+
+                  </button>
+                </div>
                 {loggedIn ? (
                   <p
                     className={`breadcrumb clickable${

--- a/liwords-ui/src/chat/chat_prefs.ts
+++ b/liwords-ui/src/chat/chat_prefs.ts
@@ -1,0 +1,73 @@
+import { useEffect } from "react";
+import {
+  useLocalStorage,
+  useLocalStorageBool,
+} from "../utils/use_local_storage";
+
+// Chat display preferences, configured under Settings > Secret features and
+// stored in localStorage (so they are per-device). They are applied as CSS
+// custom properties that chat.scss reads: --chat-font-scale multiplies the
+// message text size, and --chat-timestamp-visibility is the timestamp's base
+// visibility (hover still reveals it). Because they go through useLocalStorage
+// (useSyncExternalStore + the "storage" event), changing one in any tab updates
+// every open tab live, without a refresh.
+
+export const CHAT_FONT_SCALE_KEY = "chatFontScale";
+export const CHAT_ALWAYS_TIMESTAMPS_KEY = "chatAlwaysShowTimestamps";
+
+// Stored as strings so they can go through useLocalStorage directly.
+export const CHAT_FONT_SCALE_OPTIONS: Array<{ label: string; value: string }> =
+  [
+    { label: "Normal", value: "1" },
+    { label: "Large", value: "1.15" },
+    { label: "Larger", value: "1.3" },
+    { label: "Largest", value: "1.5" },
+  ];
+
+const applyChatFontScale = (scale: string): void => {
+  const n = parseFloat(scale);
+  document.body.style.setProperty(
+    "--chat-font-scale",
+    Number.isFinite(n) && n > 0 ? String(n) : "1",
+  );
+};
+
+const applyAlwaysShowChatTimestamps = (always: boolean): void => {
+  document.body.style.setProperty(
+    "--chat-timestamp-visibility",
+    always ? "visible" : "hidden",
+  );
+};
+
+// Applies the chat display prefs as CSS variables and re-applies whenever they
+// change in this or any other tab. Call it from the chat surface.
+export const useApplyChatPrefs = (): void => {
+  const [scale] = useLocalStorage(CHAT_FONT_SCALE_KEY, "1");
+  const [alwaysTimestamps] = useLocalStorageBool(CHAT_ALWAYS_TIMESTAMPS_KEY);
+  useEffect(() => {
+    applyChatFontScale(scale);
+  }, [scale]);
+  useEffect(() => {
+    applyAlwaysShowChatTimestamps(alwaysTimestamps);
+  }, [alwaysTimestamps]);
+};
+
+// Backs the in-chat A-/A+ control. It reads and writes the same font-scale
+// pref, so it stays in sync with the Settings dropdown and every open tab, and
+// steps through the discrete sizes.
+export const useChatFontScaleControl = (): {
+  atMin: boolean;
+  atMax: boolean;
+  decrease: () => void;
+  increase: () => void;
+} => {
+  const [scale, setScale] = useLocalStorage(CHAT_FONT_SCALE_KEY, "1");
+  const values = CHAT_FONT_SCALE_OPTIONS.map((o) => o.value);
+  const idx = Math.max(0, values.indexOf(scale));
+  return {
+    atMin: idx <= 0,
+    atMax: idx >= values.length - 1,
+    decrease: () => setScale(values[Math.max(0, idx - 1)]),
+    increase: () => setScale(values[Math.min(values.length - 1, idx + 1)]),
+  };
+};

--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -1,6 +1,15 @@
 import React, { useCallback, useState } from "react";
 import { Col, Row, Select, Switch } from "antd";
 import {
+  useLocalStorage,
+  useLocalStorageBool,
+} from "../utils/use_local_storage";
+import {
+  CHAT_ALWAYS_TIMESTAMPS_KEY,
+  CHAT_FONT_SCALE_KEY,
+  CHAT_FONT_SCALE_OPTIONS,
+} from "../chat/chat_prefs";
+import {
   preferredSortOrder,
   setPreferredSortOrder,
   setSharedEnableAutoShuffle,
@@ -178,6 +187,13 @@ export const Preferences = React.memo(() => {
   const setBoardMode = useUIStore((state) => state.setBoardMode);
   const tileMode = useUIStore(selectTileMode);
   const setTileMode = useUIStore((state) => state.setTileMode);
+
+  const [chatFontScale, setChatFontScale] = useLocalStorage(
+    CHAT_FONT_SCALE_KEY,
+    "1",
+  );
+  const [alwaysShowChatTimestamps, setAlwaysShowChatTimestamps] =
+    useLocalStorageBool(CHAT_ALWAYS_TIMESTAMPS_KEY);
 
   const initialPuzzleLexicon =
     localStorage?.getItem("puzzleLexicon") || undefined;
@@ -502,6 +518,41 @@ export const Preferences = React.memo(() => {
           </Select>
         </Col>
       </Row>
+      <div className="section-header">Chat</div>
+      <Row>
+        <Col span={12}>
+          <div className="chat-text-size">Chat text size</div>
+          <div className="chat-size-selection">
+            <Select
+              className="chat-font-size-select"
+              size="large"
+              value={chatFontScale}
+              onChange={setChatFontScale}
+            >
+              {CHAT_FONT_SCALE_OPTIONS.map(({ label, value }) => (
+                <Select.Option value={value} key={value}>
+                  {label}
+                </Select.Option>
+              ))}
+            </Select>
+          </div>
+        </Col>
+      </Row>
+      <div className="toggles-section">
+        <div className="chat-toggle-fill">
+          <div className="toggle-section">
+            <div className="title">Always show chat timestamps</div>
+            <div>
+              <div>Show chat timestamps instead of only on hover</div>
+              <Switch
+                checked={alwaysShowChatTimestamps}
+                onChange={setAlwaysShowChatTimestamps}
+                className="chat-timestamps-toggle"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 });

--- a/liwords-ui/src/settings/settings.scss
+++ b/liwords-ui/src/settings/settings.scss
@@ -204,7 +204,8 @@
   .preferences {
     .tile-order,
     .tile-style,
-    .board-style {
+    .board-style,
+    .chat-text-size {
       font-weight: bold;
     }
     .tile-order-select {
@@ -214,6 +215,12 @@
     }
     .toggles-section {
       display: flex;
+    }
+    // Make a lone toggle row fill the width so its switch sits at the far
+    // right, matching the dark-mode toggle (whose row is widened by a
+    // long-description sibling).
+    .chat-toggle-fill {
+      flex: 1;
     }
     .toggle-section {
       margin-bottom: 24px;
@@ -514,7 +521,8 @@
 }
 .tile-selection,
 .board-selection,
-.puzzle-lexicon-selection {
+.puzzle-lexicon-selection,
+.chat-size-selection {
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- Single-line chat input becomes an auto-sizing textarea (1-6 rows); Enter sends, pasted newlines collapse to spaces (chat renders no line breaks).
- Per-device **chat text size** (Normal..Largest) via A-/A+ in the chat header and a Preferences dropdown.
- **Always show chat timestamps** toggle in Preferences (vs on-hover).
- All stored via `useLocalStorage` and applied as CSS vars, so a change updates every open tab's chat live.

## Test plan
- Long message grows the input 1-6 rows, Enter sends.
- A-/A+, the Preferences dropdown, and the toggle all take effect; two tabs stay in sync live.
- `tsc --noEmit`, eslint clean.