### PR TITLE
fix phony report never computing on annotated games

### DIFF
--- a/liwords-ui/src/utils/hooks/definitions.tsx
+++ b/liwords-ui/src/utils/hooks/definitions.tsx
@@ -196,23 +196,39 @@ export const useDefinitionAndPhonyChecker = ({
     [enableHoverDefine, definedAnagram],
   );
 
-  const [playedWords, setPlayedWords] = useState(new Set<string>());
-  useEffect(() => {
+  // The current game's played words, derived straight from gameContext.turns.
+  // The reducer builds that list synchronously (stateFromHistory) per dispatch,
+  // so no render sees a partial list. A pure derivation -- not useState+effect
+  // that RESET could clear -- so it can never be stranded empty, which is what
+  // stopped the phony report from ever computing.
+  const playedWordsRef = useRef<Set<string>>(new Set());
+  const playedWords = useMemo(() => {
     console.log(
-      "[phony-debug] playedWords-effect fire, turns:",
+      "[phony-debug] playedWords memo, turns:",
       gameContext.turns.length,
     );
-    setPlayedWords((oldPlayedWords) => {
-      const playedWords = new Set(oldPlayedWords);
-      for (const turn of gameContext.turns) {
-        for (const word of turn.wordsFormed) {
-          playedWords.add(word);
+    const words = new Set<string>();
+    for (const turn of gameContext.turns) {
+      for (const word of turn.wordsFormed) {
+        words.add(word);
+      }
+    }
+    // Reuse the previous Set instance when the word set is unchanged (a pass,
+    // or replaying a word already on the board) so effects keyed on
+    // playedWords don't re-run just because gameContext got a new reference.
+    const prev = playedWordsRef.current;
+    if (words.size === prev.size) {
+      let same = true;
+      for (const word of words) {
+        if (!prev.has(word)) {
+          same = false;
+          break;
         }
       }
-      return playedWords.size === oldPlayedWords.size
-        ? oldPlayedWords
-        : playedWords;
-    });
+      if (same) return prev;
+    }
+    playedWordsRef.current = words;
+    return words;
   }, [gameContext]);
 
   useEffect(() => {
@@ -224,7 +240,10 @@ export const useDefinitionAndPhonyChecker = ({
       lexicon,
     );
     setWordInfo({});
-    setPlayedWords(new Set());
+    // playedWords is derived from gameContext via the useMemo above -- there is
+    // nothing to clear here. The old setPlayedWords(new Set()) raced with that
+    // derivation and could leave playedWords stale-empty in production, which is
+    // why the phony report never computed.
     setUnrace(new Unrace());
     setPhonies(undefined);
     setShowDefinitionHover(undefined);


### PR DESCRIPTION
## Summary
On annotated games the phony report never appeared in production. `phonies-compute` needs `playedWords` and a defined `wordInfo` together. `playedWords` was a `useState` populated from `gameContext.turns` by an effect and cleared by the RESET effect (`[gameID, lexicon]`). In production the RPC-driven timing let the clear land after the populate, and because `gameContext` didn't change again to repopulate, `playedWords` stayed at 0 even on a game with words -> `phonies-compute` saw no words -> `phonies = undefined`, no report. Locally the timing hides it.

Make `playedWords` a `useMemo` derived straight from `gameContext.turns` and drop `setPlayedWords(new Set())` from RESET -- a pure derivation now, no effect to race and nothing for RESET to clear, so it can't be stranded empty. A `useRef` reuses the previous Set when the word set is unchanged (a pass, a repeated word) so downstream effects don't re-run needlessly. Reading `gameContext.turns` this way is safe: the reducer builds it synchronously (`stateFromHistory`) in one dispatch, so no render sees a partial list.

## Test plan
- Prod (blind, not locally reproducible): an annotated game with phonies posts its report.
- No non-annotated-game regression: `playedWords` yields the same words as before for every observed state.
- `tsc --noEmit`, eslint clean.

Note: leaves the `[phony-debug]` console logs (already on master) in place for prod verification; remove in a follow-up.