### PR TITLE
Add can_manage_broadcasts permission for site broadcast admins

### DIFF
--- a/db/migrations/202607230001_broadcast_manage_permission.down.sql
+++ b/db/migrations/202607230001_broadcast_manage_permission.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DELETE FROM role_permissions
+WHERE permission_id = (SELECT id FROM permissions WHERE code = 'can_manage_broadcasts');
+DELETE FROM permissions WHERE code = 'can_manage_broadcasts';
+
+COMMIT;

--- a/db/migrations/202607230001_broadcast_manage_permission.up.sql
+++ b/db/migrations/202607230001_broadcast_manage_permission.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+INSERT INTO permissions (code, description)
+VALUES ('can_manage_broadcasts', 'Can edit, deactivate, and otherwise administer any broadcast event.');
+
+INSERT INTO role_permissions (role_id, permission_id)
+VALUES
+    ((SELECT id FROM roles WHERE name = 'Manager'),
+     (SELECT id FROM permissions WHERE code = 'can_manage_broadcasts'));
+
+COMMIT;

--- a/pkg/auth/rbac/rbac.go
+++ b/pkg/auth/rbac/rbac.go
@@ -30,6 +30,7 @@ const (
 	CanRevokeFromLeagues            Permission = "can_revoke_from_leagues"
 	CanVerifyUserIdentities         Permission = "can_verify_user_identities"
 	CanCreateBroadcasts             Permission = "can_create_broadcasts"
+	CanManageBroadcasts             Permission = "can_manage_broadcasts"
 )
 
 // These Roles are also defined in the database.

--- a/pkg/broadcasts/service.go
+++ b/pkg/broadcasts/service.go
@@ -113,11 +113,20 @@ func (bs *BroadcastService) invalidateSlugCaches(slug string) {
 	}
 }
 
-// requireDirector checks that the authenticated user is a director for the broadcast.
+// requireDirector checks that the authenticated user is a director for the
+// broadcast, or holds the can_manage_broadcasts permission (site-wide
+// broadcast admins, who can administer any broadcast regardless of ownership).
 func (bs *BroadcastService) requireDirector(ctx context.Context, broadcastID int32) (*entity.User, error) {
 	u, err := apiserver.AuthUser(ctx, bs.userStore)
 	if err != nil {
 		return nil, err
+	}
+	canManage, err := rbac.HasPermission(ctx, bs.queries, u.ID, rbac.CanManageBroadcasts)
+	if err != nil {
+		return nil, apiserver.InternalErr(err)
+	}
+	if canManage {
+		return u, nil
 	}
 	isDir, err := bs.queries.IsBroadcastDirector(ctx, models.IsBroadcastDirectorParams{
 		BroadcastID: broadcastID,


### PR DESCRIPTION
## Summary
- Broadcast management (`UpdateBroadcast`, `TriggerPoll`, slot management, director/annotator management) was gated purely by per-broadcast `broadcast_directors` membership, with no way for a site admin to intervene on a broadcast they weren't explicitly added to as a director.
- Adds a new `can_manage_broadcasts` RBAC permission, granted to the existing `Manager` role (kept off `Admin`'s explicit grants since `Admin` already bypasses all permission checks via `admin_all_access`).
- `requireDirector` in `pkg/broadcasts/service.go` now passes for either an existing per-broadcast director or anyone holding `can_manage_broadcasts`.

## Test plan
- [x] `go build ./pkg/auth/rbac/... ./pkg/broadcasts/...`
- [x] `source local.env && go test ./pkg/broadcasts/... ./pkg/auth/rbac/...`
- [ ] Apply migration and manually verify a `Manager`-role user can update/deactivate a broadcast they aren't listed as a director on

🤖 Generated with [Claude Code](https://claude.com/claude-code)