### PR TITLE
refine the league game-history modal

### DIFF
--- a/liwords-ui/src/leagues/league_page.tsx
+++ b/liwords-ui/src/leagues/league_page.tsx
@@ -841,6 +841,7 @@ export const LeaguePage = (props: Props) => {
                         totalDivisions={standingsData.divisions.length}
                         seasonId={displaySeasonId || ""}
                         seasonNumber={displayedSeason?.seasonNumber || 0}
+                        seasonStartDate={displayedSeason?.startDate}
                         currentUserId={userID}
                         onChat={openDirectMessage}
                         promotionFormula={displayedSeason?.promotionFormula}

--- a/liwords-ui/src/leagues/player_game_history_modal.test.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.test.tsx
@@ -1,0 +1,352 @@
+import { ConfigProvider } from "antd";
+import { cleanup, render, screen } from "@testing-library/react";
+import { timestampFromDate, type Timestamp } from "@bufbuild/protobuf/wkt";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GameEndReason } from "../gen/api/proto/ipc/omgwords_pb";
+import { liwordsDarkTheme, liwordsDefaultTheme } from "../themes";
+import {
+  dateSorter,
+  formatSeasonRange,
+  type GameRow,
+  opponentSorter,
+  PlayerGameHistoryModal,
+  resultSorter,
+  scoreSorter,
+  timeMistakeSorter,
+} from "./player_game_history_modal";
+
+// The modal has no local season data to render against, so the sort logic and
+// the display rules (combined column, spread sign, 0-vs-unanalyzed, title
+// range) are pinned here instead of by hand.
+
+afterEach(cleanup);
+
+// --- pure sorters -----------------------------------------------------------
+
+const mkRow = (o: Partial<GameRow>): GameRow => ({
+  key: o.gameId ?? "k",
+  gameId: o.gameId ?? "k",
+  opponentUsername: "opp",
+  opponentUserId: "u",
+  result: "loss",
+  playerScore: 0,
+  opponentScore: 0,
+  mistakeIndex: undefined,
+  gameDate: undefined,
+  gameEndReason: GameEndReason.NONE,
+  lastUpdateMs: undefined,
+  incrementSecs: 0,
+  onTurnTimeBankMs: 0,
+  ...o,
+});
+
+const order = (rows: GameRow[], cmp: (a: GameRow, b: GameRow) => number) =>
+  [...rows].sort(cmp).map((r) => r.gameId);
+
+describe("game-history sorters", () => {
+  it("opponent: locale name order", () => {
+    const rows = [
+      mkRow({ gameId: "z", opponentUsername: "zed" }),
+      mkRow({ gameId: "a", opponentUsername: "abe" }),
+    ];
+    expect(order(rows, opponentSorter)).toEqual(["a", "z"]);
+  });
+
+  it("result: live first, then win/draw/loss, ties by spread", () => {
+    const rows = [
+      mkRow({ gameId: "loss", result: "loss" }),
+      mkRow({
+        gameId: "win-small",
+        result: "win",
+        playerScore: 400,
+        opponentScore: 399,
+      }),
+      mkRow({
+        gameId: "win-big",
+        result: "win",
+        playerScore: 500,
+        opponentScore: 300,
+      }),
+      mkRow({ gameId: "draw", result: "draw" }),
+      mkRow({ gameId: "turn", result: "turn" }),
+      mkRow({ gameId: "inprog", result: "in_progress" }),
+    ];
+    expect(order(rows, resultSorter)).toEqual([
+      "turn",
+      "inprog",
+      "win-big",
+      "win-small",
+      "draw",
+      "loss",
+    ]);
+  });
+
+  it("score: ascending by spread", () => {
+    const rows = [
+      mkRow({ gameId: "p50", playerScore: 450, opponentScore: 400 }),
+      mkRow({ gameId: "m10", playerScore: 390, opponentScore: 400 }),
+      mkRow({ gameId: "p100", playerScore: 500, opponentScore: 400 }),
+    ];
+    expect(order(rows, scoreSorter)).toEqual(["m10", "p50", "p100"]);
+  });
+
+  it("date: ascending by last-updated", () => {
+    const rows = [
+      mkRow({ gameId: "b", gameDate: new Date(2026, 6, 20) }),
+      mkRow({ gameId: "a", gameDate: new Date(2026, 6, 10) }),
+      mkRow({ gameId: "c", gameDate: new Date(2026, 6, 30) }),
+    ];
+    expect(order(rows, dateSorter)).toEqual(["a", "b", "c"]);
+  });
+
+  it("time/mistakes: not-done first, then done; keyed within each band", () => {
+    const now = Date.now();
+    const rows = [
+      mkRow({
+        gameId: "analyzed-2",
+        mistakeIndex: 2,
+        gameDate: new Date(2026, 6, 1),
+      }),
+      mkRow({
+        gameId: "analyzed-8",
+        mistakeIndex: 8,
+        gameDate: new Date(2026, 6, 1),
+      }),
+      mkRow({ gameId: "finished-old", gameDate: new Date(2026, 6, 10) }),
+      mkRow({ gameId: "finished-new", gameDate: new Date(2026, 6, 20) }),
+      mkRow({
+        gameId: "opp-old",
+        result: "in_progress",
+        gameDate: new Date(2026, 6, 10),
+      }),
+      mkRow({
+        gameId: "opp-new",
+        result: "in_progress",
+        gameDate: new Date(2026, 6, 20),
+      }),
+      mkRow({
+        gameId: "turn-lots",
+        result: "turn",
+        lastUpdateMs: now,
+        incrementSecs: 100000,
+      }),
+      mkRow({
+        gameId: "turn-soon",
+        result: "turn",
+        lastUpdateMs: now,
+        incrementSecs: 10,
+      }),
+    ];
+    expect(order(rows, timeMistakeSorter)).toEqual([
+      "turn-soon", // band 0: soonest deadline first
+      "turn-lots",
+      "opp-new", // band 1: most recent first
+      "opp-old",
+      "finished-new", // band 2: most recent first
+      "finished-old",
+      "analyzed-8", // band 3: worst mistake first
+      "analyzed-2",
+    ]);
+  });
+});
+
+describe("formatSeasonRange", () => {
+  it("cross-year shows both years", () => {
+    const s = formatSeasonRange(new Date(2025, 11, 30), new Date(2026, 0, 14));
+    expect(s).toContain("2025");
+    expect(s).toContain("2026");
+  });
+
+  it("within one year shows the year once, with a range separator", () => {
+    const s = formatSeasonRange(new Date(2026, 6, 16), new Date(2026, 6, 30));
+    expect(s.match(/2026/g)?.length).toBe(1);
+    expect(s).toMatch(/–/); // en dash between the two days
+  });
+
+  it("a single day shows one date, no range", () => {
+    const s = formatSeasonRange(
+      new Date(2026, 6, 16, 9, 5),
+      new Date(2026, 6, 16, 21, 40),
+    );
+    expect(s).not.toMatch(/–/);
+    expect(s.match(/2026/g)?.length).toBe(1);
+  });
+});
+
+// --- rendering --------------------------------------------------------------
+
+// Keep the query and the router/store-heavy sub-components out: feed the modal
+// mock games directly and stub the opponent cell and clock down to markers.
+const mock = vi.hoisted(() => ({ games: [] as unknown[] }));
+
+vi.mock("@connectrpc/connect-query", async (importActual) => ({
+  ...(await importActual<typeof import("@connectrpc/connect-query")>()),
+  useQuery: () => ({
+    data: { games: mock.games },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../shared/usernameWithContext", () => ({
+  UsernameWithContext: (props: { username: string }) => (
+    <span>{props.username}</span>
+  ),
+}));
+
+vi.mock("../shared/corres_turn_indicator", () => ({
+  CorrespondenceTurnIndicator: (props: {
+    perspective: { playerName: string };
+  }) => <span data-testid="clock">clock:{props.perspective.playerName}</span>,
+}));
+
+const mkGame = (o: Record<string, unknown>) => ({
+  gameId: "g",
+  opponentUserId: "u",
+  opponentUsername: "Opp",
+  playerScore: 400,
+  opponentScore: 350,
+  result: "loss",
+  gameDate: timestampFromDate(new Date(2026, 6, 16, 14, 30)),
+  round: 0,
+  gameEndReason: GameEndReason.STANDARD,
+  mistakeIndex: undefined,
+  lastUpdate: undefined,
+  incrementSecs: 0,
+  onTurnTimeBankMs: BigInt(0),
+  ...o,
+});
+
+const mixed = [
+  mkGame({
+    gameId: "mine",
+    result: "turn",
+    lastUpdate: timestampFromDate(new Date(Date.now() - 1000)),
+    incrementSecs: 259200,
+    gameDate: timestampFromDate(new Date(2026, 6, 20, 10, 0)),
+  }),
+  mkGame({
+    gameId: "theirs",
+    result: "in_progress",
+    lastUpdate: timestampFromDate(new Date(Date.now() - 2000)),
+    incrementSecs: 259200,
+    gameDate: timestampFromDate(new Date(2026, 6, 19, 10, 0)),
+  }),
+  mkGame({
+    gameId: "beaten",
+    result: "loss",
+    mistakeIndex: 5.4,
+    gameDate: timestampFromDate(new Date(2026, 6, 18, 10, 0)),
+  }),
+  mkGame({
+    gameId: "perfect",
+    result: "win",
+    playerScore: 500,
+    opponentScore: 400,
+    mistakeIndex: 0,
+    gameDate: timestampFromDate(new Date(2026, 6, 17, 10, 0)),
+  }),
+  mkGame({
+    gameId: "level",
+    result: "draw",
+    playerScore: 400,
+    opponentScore: 400,
+    gameDate: timestampFromDate(new Date(2026, 6, 16, 10, 0)),
+  }),
+];
+
+const renderModal = (
+  mode: "default" | "dark",
+  games: unknown[],
+  seasonStartDate?: Timestamp,
+) => {
+  mock.games = games;
+  document.body.className = `mode--${mode}`;
+  return render(
+    <ConfigProvider
+      theme={mode === "dark" ? liwordsDarkTheme : liwordsDefaultTheme}
+    >
+      <PlayerGameHistoryModal
+        visible
+        onClose={() => {}}
+        userId="me"
+        username="Me"
+        seasonId="s"
+        seasonNumber={18}
+        seasonStartDate={seasonStartDate}
+      />
+    </ConfigProvider>,
+  );
+};
+
+describe.each(["default", "dark"] as const)(
+  "modal render in %s mode",
+  (mode) => {
+    it("uses the combined Time / Mistakes header when both kinds are present", () => {
+      renderModal(mode, mixed);
+      const headers = screen
+        .getAllByRole("columnheader")
+        .map((h) => h.textContent ?? "");
+      expect(headers.some((h) => h.includes("Time / Mistakes"))).toBe(true);
+    });
+
+    it("shows 0.0 for a perfect game and - for an unanalyzed one", () => {
+      renderModal(mode, mixed);
+      const text = screen.getByRole("table").textContent ?? "";
+      expect(text).toContain("0.0"); // perfect game is a real value, not hidden
+      expect(text).toContain("5.4"); // analyzed loss
+    });
+
+    it("shows the spread inline, +0 when level", () => {
+      renderModal(mode, mixed);
+      const text = screen.getByRole("table").textContent ?? "";
+      expect(text).toContain("(+0)"); // draw, 400-400
+      expect(text).toContain("(+100)"); // perfect win, 500-400
+    });
+
+    it("puts the season date range in the title", () => {
+      renderModal(mode, mixed);
+      const title =
+        document.querySelector(".ant-modal-title")?.textContent ?? "";
+      expect(title).toContain("Season 18 Games");
+      expect(title).toContain("2026");
+      expect(title).toMatch(/–/); // 16 - 20 Jul, a real range
+    });
+  },
+);
+
+it("header reads just Mistakes when the season has no live games", () => {
+  renderModal("default", [
+    mkGame({ gameId: "a", result: "loss", mistakeIndex: 3 }),
+  ]);
+  expect(screen.getAllByText("Mistakes").length).toBeGreaterThan(0);
+  expect(screen.queryByText("Time / Mistakes")).toBeNull();
+});
+
+it("extends the title range back to the season start", () => {
+  // Games run 16-20 Jul; a season start of 1 Jul should push the range's start
+  // back to 1 Jul (the games are all created then), not the earliest game date.
+  renderModal("default", mixed, timestampFromDate(new Date(2026, 6, 1)));
+  const title = document.querySelector(".ant-modal-title")?.textContent ?? "";
+  expect(title).toContain(
+    formatSeasonRange(new Date(2026, 6, 1), new Date(2026, 6, 20)),
+  );
+});
+
+it("renders the whole table (dumped for eyeballing)", () => {
+  renderModal("default", mixed);
+  const table = screen.getByRole("table");
+  const title = document.querySelector(".ant-modal-title")?.textContent ?? "";
+  const headers = [...table.querySelectorAll("thead th")]
+    .map((th) => th.textContent?.trim())
+    .filter(Boolean);
+  const rows = [...table.querySelectorAll("tbody tr")]
+    .filter((tr) => !tr.classList.contains("ant-table-measure-row"))
+    .map((tr) =>
+      [...tr.querySelectorAll("td")].map((td) => td.textContent?.trim()),
+    );
+  console.log("TITLE:", title);
+  console.log("HEADERS:", headers.join(" | "));
+  for (const r of rows) console.log("ROW:", r.join(" | "));
+  expect(rows).toHaveLength(mixed.length);
+});

--- a/liwords-ui/src/leagues/player_game_history_modal.test.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.test.tsx
@@ -8,16 +8,17 @@ import {
   dateSorter,
   formatSeasonRange,
   type GameRow,
+  mistakeSorter,
   opponentSorter,
   PlayerGameHistoryModal,
   resultSorter,
   scoreSorter,
-  timeMistakeSorter,
+  timeSorter,
 } from "./player_game_history_modal";
 
 // The modal has no local season data to render against, so the sort logic and
-// the display rules (combined column, spread sign, 0-vs-unanalyzed, title
-// range) are pinned here instead of by hand.
+// the display rules (the split Time/Mistakes columns, spread sign,
+// 0-vs-unanalyzed, title range) are pinned here instead of by hand.
 
 afterEach(cleanup);
 
@@ -99,31 +100,10 @@ describe("game-history sorters", () => {
     expect(order(rows, dateSorter)).toEqual(["a", "b", "c"]);
   });
 
-  it("time/mistakes: not-done first, then done; keyed within each band", () => {
+  it("time: live games by soonest deadline, finished games last", () => {
     const now = Date.now();
     const rows = [
-      mkRow({
-        gameId: "analyzed-2",
-        mistakeIndex: 2,
-        gameDate: new Date(2026, 6, 1),
-      }),
-      mkRow({
-        gameId: "analyzed-8",
-        mistakeIndex: 8,
-        gameDate: new Date(2026, 6, 1),
-      }),
-      mkRow({ gameId: "finished-old", gameDate: new Date(2026, 6, 10) }),
-      mkRow({ gameId: "finished-new", gameDate: new Date(2026, 6, 20) }),
-      mkRow({
-        gameId: "opp-old",
-        result: "in_progress",
-        gameDate: new Date(2026, 6, 10),
-      }),
-      mkRow({
-        gameId: "opp-new",
-        result: "in_progress",
-        gameDate: new Date(2026, 6, 20),
-      }),
+      mkRow({ gameId: "finished", gameDate: new Date(2026, 6, 10) }),
       mkRow({
         gameId: "turn-lots",
         result: "turn",
@@ -136,16 +116,36 @@ describe("game-history sorters", () => {
         lastUpdateMs: now,
         incrementSecs: 10,
       }),
+      mkRow({
+        gameId: "opp",
+        result: "in_progress",
+        lastUpdateMs: now,
+        incrementSecs: 50000,
+      }),
     ];
-    expect(order(rows, timeMistakeSorter)).toEqual([
-      "turn-soon", // band 0: soonest deadline first
+    expect(order(rows, timeSorter)).toEqual([
+      "turn-soon", // soonest deadline first
+      "opp",
       "turn-lots",
-      "opp-new", // band 1: most recent first
-      "opp-old",
-      "finished-new", // band 2: most recent first
-      "finished-old",
-      "analyzed-8", // band 3: worst mistake first
-      "analyzed-2",
+      "finished", // no clock -> last
+    ]);
+  });
+
+  it("mistakes: by score ascending, no-score games last", () => {
+    const rows = [
+      mkRow({ gameId: "m8", mistakeIndex: 8 }),
+      mkRow({ gameId: "m0", mistakeIndex: 0 }),
+      mkRow({ gameId: "live", result: "turn" }), // no score
+      mkRow({ gameId: "pending" }), // finished, unanalyzed -> no score
+      mkRow({ gameId: "m2", mistakeIndex: 2 }),
+    ];
+    // 0, 2, 8, then the two no-score rows (tied, stable input order).
+    expect(order(rows, mistakeSorter)).toEqual([
+      "m0",
+      "m2",
+      "m8",
+      "live",
+      "pending",
     ]);
   });
 });
@@ -282,12 +282,14 @@ const renderModal = (
 describe.each(["default", "dark"] as const)(
   "modal render in %s mode",
   (mode) => {
-    it("uses the combined Time / Mistakes header when both kinds are present", () => {
+    it("shows separate Time and Mistakes headers when both kinds are present", () => {
       renderModal(mode, mixed);
       const headers = screen
         .getAllByRole("columnheader")
         .map((h) => h.textContent ?? "");
-      expect(headers.some((h) => h.includes("Time / Mistakes"))).toBe(true);
+      expect(headers.some((h) => h.includes("Time"))).toBe(true);
+      expect(headers.some((h) => h.includes("Mistakes"))).toBe(true);
+      expect(headers.some((h) => h.includes("Time / Mistakes"))).toBe(false);
     });
 
     it("shows 0.0 for a perfect game and - for an unanalyzed one", () => {
@@ -315,12 +317,15 @@ describe.each(["default", "dark"] as const)(
   },
 );
 
-it("header reads just Mistakes when the season has no live games", () => {
+it("shows only the Mistakes column when the season has no live games", () => {
   renderModal("default", [
     mkGame({ gameId: "a", result: "loss", mistakeIndex: 3 }),
   ]);
-  expect(screen.getAllByText("Mistakes").length).toBeGreaterThan(0);
-  expect(screen.queryByText("Time / Mistakes")).toBeNull();
+  const headers = screen
+    .getAllByRole("columnheader")
+    .map((h) => h.textContent ?? "");
+  expect(headers.some((h) => h.includes("Mistakes"))).toBe(true);
+  expect(headers.some((h) => h.includes("Time"))).toBe(false);
 });
 
 it("extends the title range back to the season start", () => {

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -78,44 +78,65 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
     seasonId,
   });
 
-  // The "Time" column appears only when this season has live (in-progress)
-  // games -- past seasons are all finished, so it stays hidden there.
+  // These gate the combined "Time / Mistakes" column and pick its header. A
+  // season with live games has ticking clocks; a season with any analyzed game
+  // has mistake scores. The column is hidden only when the list has neither.
   const hasLiveClocks = (data?.games ?? []).some(
     (g) => (g.result === "turn" || g.result === "in_progress") && g.lastUpdate,
   );
-  const timeColumn = {
-    title: "Time",
-    key: "time",
+  const hasMistakeData = (data?.games ?? []).some(
+    (g) => g.mistakeIndex !== undefined,
+  );
+  // Time and Mistakes never apply to the same row -- a game is either live (show
+  // its clock) or finished (show its mistake score once analyzed) -- so they
+  // share one column. The just-finished-but-unanalyzed gap shows "-". The header
+  // names whichever kind(s) the current list actually has.
+  // Header label plus one explanatory tooltip on the header itself (reachable
+  // even when every row is "-"), rather than repeating the note on each cell.
+  const timeMistakeLabel = hasLiveClocks
+    ? hasMistakeData
+      ? "Time / Mistakes"
+      : "Time"
+    : "Mistakes";
+  const timeMistakeHint = hasLiveClocks
+    ? hasMistakeData
+      ? "Time until the on-turn player's clock forfeits for a live game; its BestBot Mistake Score once finished and analyzed (lower is better; 0 is a perfect game; - until analyzed)."
+      : "Time until the on-turn player's clock forfeits."
+    : "BestBot Mistake Score (lower is better; 0 is a perfect game; - until the game has been analyzed).";
+  const timeMistakeColumn: TableColumnsType<GameRow>[number] = {
+    title: (
+      <Tooltip title={timeMistakeHint}>
+        <span style={{ cursor: "help" }}>{timeMistakeLabel}</span>
+      </Tooltip>
+    ),
+    key: "timeMistake",
     align: "right" as const,
-    render: (
-      _: unknown,
-      record: {
-        result: string;
-        lastUpdateMs?: number;
-        incrementSecs: number;
-        onTurnTimeBankMs: number;
-        opponentUsername: string;
-      },
-    ) => {
+    render: (_, record) => {
       if (
-        (record.result !== "turn" && record.result !== "in_progress") ||
-        record.lastUpdateMs === undefined
+        (record.result === "turn" || record.result === "in_progress") &&
+        record.lastUpdateMs !== undefined
       ) {
-        return null;
+        // Bare view: just the ticking d:hh:mm:ss (the Result column already
+        // shows whose turn it is). The tooltip still names the on-turn player --
+        // this player when it is their turn, otherwise the opponent.
+        const onTurnName =
+          record.result === "turn" ? username : record.opponentUsername;
+        return (
+          <CorrespondenceTurnIndicator
+            perspective={{ kind: "bare", playerName: onTurnName }}
+            lastUpdateMs={record.lastUpdateMs}
+            incrementMs={record.incrementSecs * 1000}
+            bankMs={record.onTurnTimeBankMs}
+          />
+        );
       }
-      // Bare view: just the ticking d:hh:mm:ss (the Result column already shows
-      // whose turn it is). The tooltip still names the on-turn player -- this
-      // player when it is their turn, otherwise the opponent.
-      const onTurnName =
-        record.result === "turn" ? username : record.opponentUsername;
-      return (
-        <CorrespondenceTurnIndicator
-          perspective={{ kind: "bare", playerName: onTurnName }}
-          lastUpdateMs={record.lastUpdateMs}
-          incrementMs={record.incrementSecs * 1000}
-          bankMs={record.onTurnTimeBankMs}
-        />
-      );
+      // Finished games: the mistake score once analyzed, else "-". Absent (not
+      // 0) means unanalyzed, so 0 renders as a genuine perfect game. The column
+      // header carries the explanation, so the cell is just the number.
+      if (record.mistakeIndex === undefined) {
+        return "-";
+      }
+      return record.mistakeIndex.toFixed(1);
     },
   };
 
@@ -174,7 +195,6 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
         );
       },
     },
-    ...(hasLiveClocks ? [timeColumn] : []),
     {
       title: "Score",
       key: "score",
@@ -193,22 +213,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
         );
       },
     },
-    {
-      title: "Mistakes",
-      key: "mistakeIndex",
-      align: "right" as const,
-      render: (_: unknown, record: { mistakeIndex?: number }) =>
-        record.mistakeIndex === undefined ? (
-          "-"
-        ) : (
-          <Tooltip
-            placement="left"
-            title="Mistake Score from BestBot analysis (lower is better; 0 is a perfect game; - until the game has been analyzed)."
-          >
-            {record.mistakeIndex.toFixed(1)}
-          </Tooltip>
-        ),
-    },
+    ...(hasLiveClocks || hasMistakeData ? [timeMistakeColumn] : []),
     {
       title: "Date",
       dataIndex: "gameDate",

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -10,7 +10,7 @@ import {
 } from "antd";
 import { useQuery } from "@connectrpc/connect-query";
 import { getPlayerSeasonGames } from "../gen/api/proto/league_service/league_service-LeagueService_connectquery";
-import { timestampDate } from "@bufbuild/protobuf/wkt";
+import { timestampDate, type Timestamp } from "@bufbuild/protobuf/wkt";
 import { GameEndReason } from "../gen/api/proto/ipc/omgwords_pb";
 import { CorrespondenceTurnIndicator } from "../shared/corres_turn_indicator";
 import { UsernameWithContext } from "../shared/usernameWithContext";
@@ -50,6 +50,10 @@ type PlayerGameHistoryModalProps = {
   username: string;
   seasonId: string;
   seasonNumber: number;
+  // The season's start (all league games are created then). Passed in from the
+  // league page, which already has it, so the title's date range does not
+  // refetch it. When absent the range falls back to the games' own span.
+  seasonStartDate?: Timestamp;
   onChat?: (uuid: string, username: string) => void;
 };
 
@@ -154,6 +158,21 @@ export const timeMistakeSorter = (a: GameRow, b: GameRow): number => {
   }
 };
 
+// Formats the span of the season's games for the modal title. Intl's
+// formatRange collapses the shared parts locale-appropriately (e.g.
+// "16-30 Jul 2026", "30 Jul - 14 Aug 2026", "30 Dec 2025 - 14 Jan 2026"); a
+// single day shows once. The year lives here so the per-row Date cells can drop
+// it without a screenshot losing which season it was.
+const seasonRangeFormat = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+});
+export const formatSeasonRange = (start: Date, end: Date): string =>
+  start.toDateString() === end.toDateString()
+    ? seasonRangeFormat.format(start)
+    : seasonRangeFormat.formatRange(start, end);
+
 export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
   visible,
   onClose,
@@ -161,6 +180,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
   username,
   seasonId,
   seasonNumber,
+  seasonStartDate,
   onChat,
 }) => {
   const { data, isLoading, error } = useQuery(getPlayerSeasonGames, {
@@ -320,9 +340,17 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
       key: "date",
       render: (date?: Date) => {
         if (!date) return "—";
+        // Locale short date without the year (the season's year lives in the
+        // modal title) plus the time -- the part that actually varies row to
+        // row, previously buried in the hover. Full timestamp stays on hover.
         return (
           <Tooltip title={date.toLocaleString()}>
-            {date.toLocaleDateString()}
+            {date.toLocaleString(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
           </Tooltip>
         );
       },
@@ -349,6 +377,25 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
       onTurnTimeBankMs: Number(game.onTurnTimeBankMs),
     })) || [];
 
+  // Title range, shown once so the per-row Date cells can drop the year: from
+  // the season start (all league games are created then) to this player's
+  // latest activity. Min/max over the games' last-updated times plus the start,
+  // so it spans the whole season even if the earliest game was last touched
+  // well after it began; falls back to the games' own span if no start is given.
+  const rangeMs = dataSource
+    .map((row) => row.gameDate?.getTime())
+    .filter((t): t is number => t !== undefined);
+  if (seasonStartDate) {
+    rangeMs.push(timestampDate(seasonStartDate).getTime());
+  }
+  const seasonRange =
+    rangeMs.length === 0
+      ? null
+      : formatSeasonRange(
+          new Date(Math.min(...rangeMs)),
+          new Date(Math.max(...rangeMs)),
+        );
+
   const handleRowClick = (record: { gameId: string }) => {
     window.open(`/game/${record.gameId}`, "_blank");
   };
@@ -365,6 +412,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
             omitSendMessage={!onChat}
           />
           's Season {seasonNumber} Games
+          {seasonRange ? ` (${seasonRange})` : null}
         </React.Fragment>
       }
       open={visible}

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -97,16 +97,6 @@ export const resultRank = (result: string): number => {
   }
 };
 
-// Composite band for the combined Time/Mistakes column: not-done games first
-// (your turn, then opponent's), then done games (just-finished, then analyzed).
-// The band groups not-done vs done; the sorter orders within each band.
-export const timeMistakeBand = (record: GameRow): number => {
-  if (record.result === "turn") return 0;
-  if (record.result === "in_progress") return 1;
-  if (record.mistakeIndex === undefined) return 2; // finished, unanalyzed
-  return 3; // finished, analyzed
-};
-
 // Milliseconds until this player's on-turn game forfeits (per-turn allowance +
 // time bank - elapsed), matching the deadline the clock ticks toward. Only
 // meaningful for a live game with a clock anchor; unknown clocks sort last.
@@ -121,8 +111,7 @@ export const clockRemainingMs = (record: GameRow): number => {
 
 // Column sorters, pulled out as named functions so they can be unit-tested --
 // the modal has no local season data to exercise them by hand. All sort
-// ascending; antd's header toggle reverses. The direction each encodes (Result
-// live-first, timeMistake not-done-first) is the useful default.
+// ascending; antd's header toggle reverses.
 export const opponentSorter = (a: GameRow, b: GameRow): number =>
   a.opponentUsername.localeCompare(b.opponentUsername);
 
@@ -139,24 +128,16 @@ export const scoreSorter = (a: GameRow, b: GameRow): number =>
 export const dateSorter = (a: GameRow, b: GameRow): number =>
   (a.gameDate?.getTime() ?? 0) - (b.gameDate?.getTime() ?? 0);
 
-// Time/Mistakes: not-done games first (your turn by soonest deadline, then
-// opponent's by recency), then done games (just-finished by recency, then
-// analyzed by worst mistake first) -- so one click surfaces what needs a move,
-// and the reverse toggle surfaces the cleanest games.
-export const timeMistakeSorter = (a: GameRow, b: GameRow): number => {
-  const ba = timeMistakeBand(a);
-  const bb = timeMistakeBand(b);
-  if (ba !== bb) return ba - bb;
-  switch (ba) {
-    case 0:
-      return clockRemainingMs(a) - clockRemainingMs(b);
-    case 1:
-    case 2:
-      return (b.gameDate?.getTime() ?? 0) - (a.gameDate?.getTime() ?? 0);
-    default:
-      return (b.mistakeIndex ?? 0) - (a.mistakeIndex ?? 0);
-  }
-};
+// Time: by soonest forfeit deadline for live games; finished games have no
+// clock and sort to the bottom (clockRemainingMs returns MAX_SAFE_INTEGER).
+export const timeSorter = (a: GameRow, b: GameRow): number =>
+  clockRemainingMs(a) - clockRemainingMs(b);
+
+// Mistakes: by score, lowest (best) first; games with no score -- live (blank)
+// or finished-but-unanalyzed ("-") -- have no index and sort to the bottom.
+export const mistakeSorter = (a: GameRow, b: GameRow): number =>
+  (a.mistakeIndex ?? Number.MAX_SAFE_INTEGER) -
+  (b.mistakeIndex ?? Number.MAX_SAFE_INTEGER);
 
 // Formats the span of the season's games for the modal title. Intl's
 // formatRange collapses the shared parts locale-appropriately (e.g.
@@ -188,38 +169,23 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
     seasonId,
   });
 
-  // These gate the combined "Time / Mistakes" column and pick its header. A
-  // season with live games has ticking clocks; a season with any analyzed game
-  // has mistake scores. The column is hidden only when the list has neither.
+  // Gate the Time and Mistakes columns. A season with live games has ticking
+  // clocks (Time); a season with any analyzed game has mistake scores
+  // (Mistakes). Each column is blank for the other kind of game, so each hides
+  // when the list has none of its kind -- during an active season both show.
   const hasLiveClocks = (data?.games ?? []).some(
     (g) => (g.result === "turn" || g.result === "in_progress") && g.lastUpdate,
   );
   const hasMistakeData = (data?.games ?? []).some(
     (g) => g.mistakeIndex !== undefined,
   );
-  // Time and Mistakes never apply to the same row -- a game is either live (show
-  // its clock) or finished (show its mistake score once analyzed) -- so they
-  // share one column. The just-finished-but-unanalyzed gap shows "-". The header
-  // names whichever kind(s) the current list actually has.
-  // Header label plus one explanatory tooltip on the header itself (reachable
-  // even when every row is "-"), rather than repeating the note on each cell.
-  const timeMistakeLabel = hasLiveClocks
-    ? hasMistakeData
-      ? "Time / Mistakes"
-      : "Time"
-    : "Mistakes";
-  const timeMistakeHint = hasLiveClocks
-    ? hasMistakeData
-      ? "Time until the on-turn player's clock forfeits for a live game; its BestBot Mistake Score once finished and analyzed (lower is better; 0 is a perfect game; - until analyzed)."
-      : "Time until the on-turn player's clock forfeits."
-    : "BestBot Mistake Score (lower is better; 0 is a perfect game; - until the game has been analyzed).";
-  const timeMistakeColumn: TableColumnsType<GameRow>[number] = {
+  const timeColumn: TableColumnsType<GameRow>[number] = {
     title: (
-      <Tooltip title={timeMistakeHint}>
-        <span style={{ cursor: "help" }}>{timeMistakeLabel}</span>
+      <Tooltip title="Time until the on-turn player's clock forfeits.">
+        <span style={{ cursor: "help" }}>Time</span>
       </Tooltip>
     ),
-    key: "timeMistake",
+    key: "time",
     align: "right" as const,
     render: (_, record) => {
       if (
@@ -240,16 +206,32 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
           />
         );
       }
-      // Finished games: the mistake score once analyzed, else "-". Absent (not
-      // 0) means unanalyzed, so 0 renders as a genuine perfect game. The column
-      // header carries the explanation, so the cell is just the number.
+      // Finished games have no clock.
+      return null;
+    },
+    sorter: timeSorter,
+  };
+  const mistakeColumn: TableColumnsType<GameRow>[number] = {
+    title: (
+      <Tooltip title="BestBot Mistake Score (lower is better; 0 is a perfect game; - until the game has been analyzed).">
+        <span style={{ cursor: "help" }}>Mistakes</span>
+      </Tooltip>
+    ),
+    key: "mistakes",
+    align: "right" as const,
+    render: (_, record) => {
+      // Live games are not analyzed -- blank (not "-", which reads as pending).
+      if (record.result === "turn" || record.result === "in_progress") {
+        return null;
+      }
+      // Finished: the score once analyzed, else "-". Absent (not 0) means
+      // unanalyzed, so 0 renders as a genuine perfect game.
       if (record.mistakeIndex === undefined) {
         return "-";
       }
       return record.mistakeIndex.toFixed(1);
     },
-    // Click-sort by urgency then learnability (see timeMistakeSorter).
-    sorter: timeMistakeSorter,
+    sorter: mistakeSorter,
   };
 
   const columns: TableColumnsType<GameRow> = [
@@ -333,7 +315,8 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
       },
       sorter: scoreSorter,
     },
-    ...(hasLiveClocks || hasMistakeData ? [timeMistakeColumn] : []),
+    ...(hasLiveClocks ? [timeColumn] : []),
+    ...(hasMistakeData ? [mistakeColumn] : []),
     {
       title: "Date",
       dataIndex: "gameDate",

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -93,6 +93,28 @@ export const resultRank = (result: string): number => {
   }
 };
 
+// Composite band for the combined Time/Mistakes column: not-done games first
+// (your turn, then opponent's), then done games (just-finished, then analyzed).
+// The band groups not-done vs done; the sorter orders within each band.
+export const timeMistakeBand = (record: GameRow): number => {
+  if (record.result === "turn") return 0;
+  if (record.result === "in_progress") return 1;
+  if (record.mistakeIndex === undefined) return 2; // finished, unanalyzed
+  return 3; // finished, analyzed
+};
+
+// Milliseconds until this player's on-turn game forfeits (per-turn allowance +
+// time bank - elapsed), matching the deadline the clock ticks toward. Only
+// meaningful for a live game with a clock anchor; unknown clocks sort last.
+export const clockRemainingMs = (record: GameRow): number => {
+  if (record.lastUpdateMs === undefined) return Number.MAX_SAFE_INTEGER;
+  return (
+    record.incrementSecs * 1000 +
+    record.onTurnTimeBankMs -
+    (Date.now() - record.lastUpdateMs)
+  );
+};
+
 // Column sorters, pulled out as named functions so they can be unit-tested --
 // the modal has no local season data to exercise them by hand. All sort
 // ascending; antd's header toggle reverses. The direction each encodes (Result
@@ -112,6 +134,25 @@ export const scoreSorter = (a: GameRow, b: GameRow): number =>
 // Date: by last-updated timestamp.
 export const dateSorter = (a: GameRow, b: GameRow): number =>
   (a.gameDate?.getTime() ?? 0) - (b.gameDate?.getTime() ?? 0);
+
+// Time/Mistakes: not-done games first (your turn by soonest deadline, then
+// opponent's by recency), then done games (just-finished by recency, then
+// analyzed by worst mistake first) -- so one click surfaces what needs a move,
+// and the reverse toggle surfaces the cleanest games.
+export const timeMistakeSorter = (a: GameRow, b: GameRow): number => {
+  const ba = timeMistakeBand(a);
+  const bb = timeMistakeBand(b);
+  if (ba !== bb) return ba - bb;
+  switch (ba) {
+    case 0:
+      return clockRemainingMs(a) - clockRemainingMs(b);
+    case 1:
+    case 2:
+      return (b.gameDate?.getTime() ?? 0) - (a.gameDate?.getTime() ?? 0);
+    default:
+      return (b.mistakeIndex ?? 0) - (a.mistakeIndex ?? 0);
+  }
+};
 
 export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
   visible,
@@ -187,6 +228,8 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
       }
       return record.mistakeIndex.toFixed(1);
     },
+    // Click-sort by urgency then learnability (see timeMistakeSorter).
+    sorter: timeMistakeSorter,
   };
 
   const columns: TableColumnsType<GameRow> = [

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -1,11 +1,21 @@
 import React from "react";
-import { Modal, Spin, Table, type TableColumnsType, Tag, Tooltip } from "antd";
+import {
+  Modal,
+  Spin,
+  Table,
+  type TableColumnsType,
+  Tag,
+  Tooltip,
+  Typography,
+} from "antd";
 import { useQuery } from "@connectrpc/connect-query";
 import { getPlayerSeasonGames } from "../gen/api/proto/league_service/league_service-LeagueService_connectquery";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { GameEndReason } from "../gen/api/proto/ipc/omgwords_pb";
 import { CorrespondenceTurnIndicator } from "../shared/corres_turn_indicator";
 import { UsernameWithContext } from "../shared/usernameWithContext";
+
+const { Text } = Typography;
 
 export const endReasonLabel = (reason: GameEndReason): string => {
   switch (reason) {
@@ -198,18 +208,23 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
     {
       title: "Score",
       key: "score",
-      render: (
-        _: unknown,
-        record: { playerScore: number; opponentScore: number; result: string },
-      ) => {
+      render: (_, record) => {
         const spread = record.playerScore - record.opponentScore;
+        // Spread inline (was hover-only): green ahead, red behind, muted at
+        // level. The running margin while a game is live, the final one once
+        // it has finished.
         return (
-          <Tooltip
-            placement="left"
-            title={`${spread >= 0 ? "+" : ""}${spread}`}
-          >
-            {record.playerScore}-{record.opponentScore}
-          </Tooltip>
+          <span style={{ whiteSpace: "nowrap" }}>
+            {record.playerScore}-{record.opponentScore}{" "}
+            <Text
+              type={
+                spread > 0 ? "success" : spread < 0 ? "danger" : "secondary"
+              }
+            >
+              ({spread >= 0 ? "+" : ""}
+              {spread})
+            </Text>
+          </span>
         );
       },
     },

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Modal, Spin, Table, Tag, Tooltip } from "antd";
+import { Modal, Spin, Table, type TableColumnsType, Tag, Tooltip } from "antd";
 import { useQuery } from "@connectrpc/connect-query";
 import { getPlayerSeasonGames } from "../gen/api/proto/league_service/league_service-LeagueService_connectquery";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
@@ -41,6 +41,27 @@ type PlayerGameHistoryModalProps = {
   seasonId: string;
   seasonNumber: number;
   onChat?: (uuid: string, username: string) => void;
+};
+
+// One row of the season game list. Finished games carry scores, a result and an
+// optional mistake index (absent until the game has been analyzed); in-progress
+// games carry the live-clock anchor (lastUpdateMs / incrementSecs /
+// onTurnTimeBankMs) so the clock can tick. gameDate is the last-updated time for
+// both, and is what the list sorts by, by default.
+type GameRow = {
+  key: string;
+  gameId: string;
+  opponentUsername: string;
+  opponentUserId: string;
+  result: string;
+  playerScore: number;
+  opponentScore: number;
+  mistakeIndex?: number;
+  gameDate?: Date;
+  gameEndReason: GameEndReason;
+  lastUpdateMs?: number;
+  incrementSecs: number;
+  onTurnTimeBankMs: number;
 };
 
 export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
@@ -98,7 +119,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
     },
   };
 
-  const columns = [
+  const columns: TableColumnsType<GameRow> = [
     {
       title: "Opponent",
       key: "opponent",
@@ -203,7 +224,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
     },
   ];
 
-  const dataSource =
+  const dataSource: GameRow[] =
     data?.games.map((game) => ({
       key: game.gameId,
       gameId: game.gameId,

--- a/liwords-ui/src/leagues/player_game_history_modal.tsx
+++ b/liwords-ui/src/leagues/player_game_history_modal.tsx
@@ -58,7 +58,7 @@ type PlayerGameHistoryModalProps = {
 // games carry the live-clock anchor (lastUpdateMs / incrementSecs /
 // onTurnTimeBankMs) so the clock can tick. gameDate is the last-updated time for
 // both, and is what the list sorts by, by default.
-type GameRow = {
+export type GameRow = {
   key: string;
   gameId: string;
   opponentUsername: string;
@@ -73,6 +73,45 @@ type GameRow = {
   incrementSecs: number;
   onTurnTimeBankMs: number;
 };
+
+// Sort rank for the Result column: live games first (they are the actionable
+// ones), then wins, draws, losses. The sorter breaks ties by spread.
+export const resultRank = (result: string): number => {
+  switch (result) {
+    case "turn":
+      return 0;
+    case "in_progress":
+      return 1;
+    case "win":
+      return 2;
+    case "draw":
+      return 3;
+    case "loss":
+      return 4;
+    default:
+      return 5;
+  }
+};
+
+// Column sorters, pulled out as named functions so they can be unit-tested --
+// the modal has no local season data to exercise them by hand. All sort
+// ascending; antd's header toggle reverses. The direction each encodes (Result
+// live-first, timeMistake not-done-first) is the useful default.
+export const opponentSorter = (a: GameRow, b: GameRow): number =>
+  a.opponentUsername.localeCompare(b.opponentUsername);
+
+// Result: live games first (actionable), then win/draw/loss, ties by spread.
+export const resultSorter = (a: GameRow, b: GameRow): number =>
+  resultRank(a.result) - resultRank(b.result) ||
+  b.playerScore - b.opponentScore - (a.playerScore - a.opponentScore);
+
+// Score: by spread (player - opponent).
+export const scoreSorter = (a: GameRow, b: GameRow): number =>
+  a.playerScore - a.opponentScore - (b.playerScore - b.opponentScore);
+
+// Date: by last-updated timestamp.
+export const dateSorter = (a: GameRow, b: GameRow): number =>
+  (a.gameDate?.getTime() ?? 0) - (b.gameDate?.getTime() ?? 0);
 
 export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
   visible,
@@ -174,6 +213,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
           />
         </strong>
       ),
+      sorter: opponentSorter,
     },
     {
       title: "Result",
@@ -204,6 +244,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
           tag
         );
       },
+      sorter: resultSorter,
     },
     {
       title: "Score",
@@ -227,6 +268,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
           </span>
         );
       },
+      sorter: scoreSorter,
     },
     ...(hasLiveClocks || hasMistakeData ? [timeMistakeColumn] : []),
     {
@@ -241,6 +283,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
           </Tooltip>
         );
       },
+      sorter: dateSorter,
     },
   ];
 
@@ -312,6 +355,7 @@ export const PlayerGameHistoryModal: React.FC<PlayerGameHistoryModalProps> = ({
               dataSource={dataSource}
               pagination={false}
               size="small"
+              showSorterTooltip={false}
               scroll={{ x: "max-content" }}
               onRow={(record) => ({
                 onClick: () => handleRowClick(record),

--- a/liwords-ui/src/leagues/standings.tsx
+++ b/liwords-ui/src/leagues/standings.tsx
@@ -10,6 +10,7 @@ import {
   ClockCircleOutlined,
   ReloadOutlined,
 } from "@ant-design/icons";
+import type { Timestamp } from "@bufbuild/protobuf/wkt";
 import {
   Division,
   PromotionFormula,
@@ -98,6 +99,7 @@ type DivisionStandingsProps = {
   totalDivisions: number;
   seasonId: string;
   seasonNumber: number;
+  seasonStartDate?: Timestamp;
   currentUserId?: string;
   promotionFormula?: PromotionFormula;
   timeBankWarnings?: Map<string, number>; // Map of userId to count of low timebank games
@@ -112,6 +114,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
   totalDivisions,
   seasonId,
   seasonNumber,
+  seasonStartDate,
   currentUserId,
   promotionFormula = PromotionFormula.PROMO_N_DIV_6,
   timeBankWarnings,
@@ -893,6 +896,7 @@ export const DivisionStandings: React.FC<DivisionStandingsProps> = ({
           username={selectedPlayer.username}
           seasonId={seasonId}
           seasonNumber={seasonNumber}
+          seasonStartDate={seasonStartDate}
           onChat={onChat}
         />
       )}

--- a/liwords-ui/src/setupTests.ts
+++ b/liwords-ui/src/setupTests.ts
@@ -4,3 +4,19 @@ import ResizeObserver from "resize-observer-polyfill";
 // https://github.com/jsdom/jsdom/issues/3368#issuecomment-1396749033
 
 global.ResizeObserver = ResizeObserver;
+
+// antd's responsive Grid/Table reads window.matchMedia, which jsdom does not
+// implement. Stub it (no query ever matches) so those components can render.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}


### PR DESCRIPTION
## Summary

A pass over the per-player league game-history modal (opened from the standings). FE-only; depends on #1938 (the mistake index), which is merged.

- Time and Mistakes stay as two separate columns, now adjacent after Score (order: Opponent, Result, Score, Time, Mistakes, Date -- Time moves over from before Score). Each hides when the season has none of its kind -- Time when nothing is live, Mistakes when nothing is analyzed -- so a finished season shows only Mistakes and an all-live one only Time. A finished-but-unanalyzed game shows "-" in Mistakes and blank in Time. The Mistakes explanation moves from a per-cell tooltip to the column header.
- Surface the spread inline in the Score column (was hover-only), colored by sign via antd's semantic text types (theme-aware).
- Make every column click-sortable. Time sorts by soonest forfeit deadline; Mistakes by score, keeping finished games together (analyzed, then pending "-") with live games last. No column is highlighted by default -- rows already arrive most-recently-updated first from the backend.
- Date cells show the time and drop the now-redundant year; the season's date range goes in the title once, via Intl.formatRange, from the season start (prop-drilled from the league page -- no refetch) to the player's latest activity.

## Test plan

- tsc --noEmit, eslint, prettier: clean.
- vitest: new player_game_history_modal.test.tsx (sort comparators, formatSeasonRange, light/dark render pass) + full suite green.
