### PR TITLE
scale the chat input text with the chat font-size setting

### DIFF
--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -528,6 +528,10 @@ p {
   left: 0;
   width: calc(100% - 12px);
   margin: 6px;
+  // Scale the input text with the same chat font-size setting the messages use
+  // (1 = default, so no change unless the user picks a larger size), so what you
+  // type matches what you read.
+  font-size: calc(1em * var(--chat-font-scale, 1));
   // Auto-sizes up to a few rows so a full message can be read while typing;
   // it grows upward from the bottom over the most recent messages and
   // collapses back to one row after sending.

--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -206,6 +206,18 @@ export const Chat = React.memo((props: Props) => {
   useApplyChatPrefs();
   const chatFontControl = useChatFontScaleControl();
 
+  // The chat input scales with the chat font-size setting, but antd only
+  // re-measures the auto-sized textarea on input or an element resize. When the
+  // size changes (in-chat A-/A+, Settings, or another tab), nudge the height by
+  // a pixel so antd's resize observer fires and re-measures the height for the
+  // new font -- it reads the content and ignores this value. No remount, so the
+  // caret and any selection stay put.
+  const chatInputRef = useRef<React.ComponentRef<typeof Input.TextArea>>(null);
+  useEffect(() => {
+    const ta = chatInputRef.current?.resizableTextArea?.textArea;
+    if (ta) ta.style.height = `${ta.offsetHeight + 1}px`;
+  }, [chatFontControl.scale]);
+
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       // Collapse any newlines (e.g. from a paste) into spaces so messages
@@ -979,6 +991,7 @@ export const Chat = React.memo((props: Props) => {
                   </div>
                   <form>
                     <Input.TextArea
+                      ref={chatInputRef}
                       autoFocus={!defaultChannel.startsWith("chat.game")}
                       autoComplete="off"
                       autoSize={{ minRows: 1, maxRows: 6 }}

--- a/liwords-ui/src/chat/chat_prefs.ts
+++ b/liwords-ui/src/chat/chat_prefs.ts
@@ -56,6 +56,7 @@ export const useApplyChatPrefs = (): void => {
 // pref, so it stays in sync with the Settings dropdown and every open tab, and
 // steps through the discrete sizes.
 export const useChatFontScaleControl = (): {
+  scale: string;
   atMin: boolean;
   atMax: boolean;
   decrease: () => void;
@@ -65,6 +66,7 @@ export const useChatFontScaleControl = (): {
   const values = CHAT_FONT_SCALE_OPTIONS.map((o) => o.value);
   const idx = Math.max(0, values.indexOf(scale));
   return {
+    scale,
     atMin: idx <= 0,
     atMax: idx >= values.length - 1,
     decrease: () => setScale(values[Math.max(0, idx - 1)]),


### PR DESCRIPTION
## Summary

The chat font-size control (the in-chat A-/A+ and the Settings dropdown, added in #1937) scaled only the message text. Apply the same `--chat-font-scale` to the chat input textarea, so the text you type matches the size of the text you read. No new setting or state -- it reuses the existing CSS variable.

antd only re-measures the auto-sized textarea on input or an element resize, not when the font changes via the CSS variable, so the box height went stale after a size change (A-/A+, Settings, or another tab). On a size change we nudge the textarea height by a pixel so antd's resize observer re-measures for the new font -- no remount, so the caret and any selection stay put.

Follows up #1937.

## Test plan

- tsc --noEmit, eslint, prettier: clean.
- Visual: A-/A+ and the Settings dropdown scale the input text; the box grows/shrinks to fit; the caret and any selection are preserved; a change in another tab updates live.
