### PR TITLE
show tournament standings by round and add a player scorecard

### DIFF
--- a/liwords-ui/src/setupTests.ts
+++ b/liwords-ui/src/setupTests.ts
@@ -4,3 +4,19 @@ import ResizeObserver from "resize-observer-polyfill";
 // https://github.com/jsdom/jsdom/issues/3368#issuecomment-1396749033
 
 global.ResizeObserver = ResizeObserver;
+
+// antd's responsive Grid/Table reads window.matchMedia, which jsdom does not
+// implement. Stub it (no query ever matches) so those components can render.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}

--- a/liwords-ui/src/tournament/actions_panel.tsx
+++ b/liwords-ui/src/tournament/actions_panel.tsx
@@ -346,7 +346,10 @@ export const ActionsPanel = React.memo((props: Props) => {
       return (
         <div className="standings-container">
           <div className="round-options">{renderDivisionSelector}</div>
-          <Standings selectedDivision={selectedDivision} />
+          <Standings
+            selectedDivision={selectedDivision}
+            selectedRound={selectedRound}
+          />
         </div>
       );
     }
@@ -447,9 +450,6 @@ export const ActionsPanel = React.memo((props: Props) => {
   ]);
 
   const actions = useMemo(() => {
-    if (selectedGameTab === "STANDINGS") {
-      return [];
-    }
     let matchButtonText = "Start tournament game";
     if (isClubType(tournamentContext.metadata?.type)) {
       matchButtonText = "Start club game";
@@ -523,7 +523,6 @@ export const ActionsPanel = React.memo((props: Props) => {
     tournamentContext,
     selectedDivision,
     selectedRound,
-    selectedGameTab,
   ]);
   return (
     <div className="game-lists">

--- a/liwords-ui/src/tournament/format.ts
+++ b/liwords-ui/src/tournament/format.ts
@@ -1,0 +1,3 @@
+// A spread reads as a margin rather than a count only when it carries its sign,
+// and a signed column cannot mistake a leading minus for the start of a digit.
+export const signed = (n: number) => `${n >= 0 ? "+" : ""}${n}`;

--- a/liwords-ui/src/tournament/player_scorecard_modal.test.tsx
+++ b/liwords-ui/src/tournament/player_scorecard_modal.test.tsx
@@ -1,0 +1,300 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { create, fromBinary } from "@bufbuild/protobuf";
+import { describe, expect, it, vi } from "vitest";
+import {
+  FullTournamentDivisionsSchema,
+  PlayerStandingSchema,
+  RoundStandingsSchema,
+  TournamentGameResult,
+  TournamentPerson,
+  TournamentPersonSchema,
+} from "../gen/api/proto/ipc/tournament_pb";
+import { GameEndReason } from "../gen/api/proto/ipc/omgwords_pb";
+import { ActionType } from "../actions/actions";
+import {
+  defaultTournamentState,
+  Division,
+  SinglePairing,
+  TournamentReducer,
+} from "../store/reducers/tournament_reducer";
+import { ftData } from "../store/reducers/testdata/tourney_1_divisions";
+import { PlayerScorecardModal } from "./player_scorecard_modal";
+
+vi.mock("../shared/usernameWithContext", () => ({
+  UsernameWithContext: (props: { username: string }) => (
+    <span>{props.username}</span>
+  ),
+}));
+
+const toArr = (s: string) => {
+  const bytes = new Uint8Array(Math.ceil(s.length / 2));
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(s.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+};
+
+const person = (id: string, suspended = false) =>
+  create(TournamentPersonSchema, { id, suspended });
+
+const standing = (
+  playerId: string,
+  wins: number,
+  losses: number,
+  spread: number,
+  draws = 0,
+) => create(PlayerStandingSchema, { playerId, wins, losses, spread, draws });
+
+const ALICE = "aa:alice";
+const BOB = "bb:bob";
+const CAROL = "cc:carol";
+const DAVE = "dd:dave";
+
+type PairingSpec = {
+  players: [string, string];
+  outcomes: [TournamentGameResult, TournamentGameResult];
+  scores?: [number, number];
+  gameEndReason?: GameEndReason;
+};
+
+// Dave is suspended so an opponent can be marked as removed.
+const people: Record<string, TournamentPerson> = {
+  [ALICE]: person(ALICE),
+  [BOB]: person(BOB),
+  [CAROL]: person(CAROL),
+  [DAVE]: person(DAVE, true),
+};
+
+const playerIndexMap: Record<string, number> = {
+  [ALICE]: 0,
+  [BOB]: 1,
+  [CAROL]: 2,
+  [DAVE]: 3,
+};
+
+// A round is written as the pairings it holds; each one is stored under both
+// players' indexes, the way the reducer stores them.
+const buildRound = (specs: PairingSpec[]) => {
+  const roundPairings: SinglePairing[] = new Array(4)
+    .fill(undefined)
+    .map(() => ({
+      players: [],
+      outcomes: [],
+      readyStates: [],
+      games: [],
+    }));
+  for (const spec of specs) {
+    const pairing = {
+      players: spec.players.map((id) => people[id]),
+      outcomes: spec.outcomes,
+      readyStates: ["", ""],
+      games: [
+        {
+          scores: spec.scores ?? [0, 0],
+          results: spec.outcomes,
+          gameEndReason: spec.gameEndReason ?? GameEndReason.NONE,
+          id: "",
+        },
+      ],
+    };
+    for (const id of spec.players) {
+      roundPairings[playerIndexMap[id]] = pairing;
+    }
+  }
+  return { roundPairings };
+};
+
+const { WIN, LOSS, DRAW, FORFEIT_WIN, FORFEIT_LOSS, NO_RESULT, VOID } =
+  TournamentGameResult;
+
+const madeUpDivision = (): Division =>
+  ({
+    tournamentID: "t",
+    divisionID: "A",
+    players: Object.values(people),
+    playerIndexMap,
+    numRounds: 4,
+    currentRound: 3,
+    divisionControls: undefined,
+    roundControls: [],
+    pairings: [
+      buildRound([
+        { players: [ALICE, BOB], outcomes: [WIN, LOSS], scores: [450, 400] },
+        { players: [CAROL, DAVE], outcomes: [WIN, LOSS], scores: [500, 300] },
+      ]),
+      buildRound([
+        {
+          players: [CAROL, ALICE],
+          outcomes: [WIN, LOSS],
+          scores: [420, 380],
+          gameEndReason: GameEndReason.RESIGNED,
+        },
+        { players: [BOB, DAVE], outcomes: [DRAW, DRAW], scores: [400, 400] },
+      ]),
+      buildRound([
+        { players: [ALICE, DAVE], outcomes: [FORFEIT_WIN, FORFEIT_LOSS] },
+        { players: [BOB, CAROL], outcomes: [NO_RESULT, NO_RESULT] },
+      ]),
+      buildRound([
+        { players: [ALICE, BOB], outcomes: [VOID, VOID] },
+        { players: [CAROL, DAVE], outcomes: [WIN, LOSS], scores: [410, 390] },
+      ]),
+    ],
+    standingsMap: {
+      0: create(RoundStandingsSchema, {
+        standings: [
+          standing(CAROL, 1, 0, 200),
+          standing(ALICE, 1, 0, 50),
+          standing(BOB, 0, 1, -50),
+          standing(DAVE, 0, 1, -200),
+        ],
+      }),
+      // Bob and Dave drew in round 2, so they carry a draw from there on.
+      1: create(RoundStandingsSchema, {
+        standings: [
+          standing(CAROL, 2, 0, 240),
+          standing(ALICE, 1, 1, 10),
+          standing(BOB, 0, 1, -50, 1),
+          standing(DAVE, 0, 1, -200, 1),
+        ],
+      }),
+      2: create(RoundStandingsSchema, {
+        standings: [
+          standing(CAROL, 2, 0, 240),
+          standing(ALICE, 2, 1, 10),
+          standing(BOB, 0, 1, -50, 1),
+          standing(DAVE, 0, 2, -200, 1),
+        ],
+      }),
+      3: create(RoundStandingsSchema, {
+        standings: [
+          standing(CAROL, 3, 0, 260),
+          standing(ALICE, 2, 1, 10),
+          standing(BOB, 0, 1, -50, 1),
+          standing(DAVE, 0, 3, -220, 1),
+        ],
+      }),
+    },
+  }) as unknown as Division;
+
+const showScorecard = (
+  division: Division,
+  playerId: string,
+  throughRound: number,
+  irlMode = true,
+) =>
+  render(
+    <PlayerScorecardModal
+      division={division}
+      playerId={playerId}
+      throughRound={throughRound}
+      irlMode={irlMode}
+      onClose={() => {}}
+    />,
+  );
+
+// Every row as [round, opponent, result, score, W, L, spread, rank].
+const rows = () =>
+  within(screen.getByRole("dialog"))
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) =>
+      within(row)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent?.trim()),
+    );
+
+describe("the player scorecard", () => {
+  it("lays out one row per round, through the round it was opened at", () => {
+    showScorecard(madeUpDivision(), ALICE, 3);
+    expect(rows()).toEqual([
+      ["1 1st", "bob", "Win", "450-400 (+50)", "1", "0", "+50", "2"],
+      ["2", "carol", "Loss (resigned)", "380-420 (-40)", "1", "1", "+10", "2"],
+      ["3", "dave Removed", "Forfeit win", "", "2", "1", "+10", "2"],
+      ["4", "bob", "Not playing", "", "2", "1", "+10", "2"],
+    ]);
+  });
+
+  it("stops at the round it was opened at", () => {
+    showScorecard(madeUpDivision(), ALICE, 1);
+    expect(rows()).toHaveLength(2);
+  });
+
+  it("shows a draw, and says nothing about a game still being played", () => {
+    showScorecard(madeUpDivision(), BOB, 2);
+    // The record folds a draw in as half a win and half a loss, which is what
+    // the standings table and the Games tab behind this both do. League writes
+    // the same record as 0-1-1 instead.
+    expect(rows()).toEqual([
+      ["1", "alice", "Loss", "400-450 (-50)", "0", "1", "-50", "3"],
+      [
+        "2 1st",
+        "dave Removed",
+        "Draw",
+        "400-400 (+0)",
+        "0.5",
+        "1.5",
+        "-50",
+        "3",
+      ],
+      ["3 1st", "carol", "", "", "0.5", "1.5", "-50", "3"],
+    ]);
+  });
+
+  it("averages only the rounds that produced a score", () => {
+    showScorecard(madeUpDivision(), ALICE, 3);
+    // Rounds 1 and 2: 450 and 380 against 400 and 420. The forfeit and the
+    // round nobody played stay out of it.
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      "Average score 415.00, average opponent score 410.00, over 2 games.",
+    );
+  });
+
+  it("hides the first-move tag outside in-real-life events", () => {
+    showScorecard(madeUpDivision(), ALICE, 0, false);
+    expect(rows()[0][0]).toBe("1");
+  });
+});
+
+describe("the player scorecard on real division data", () => {
+  // The NWL division of this fixture is three players over eight rounds, and
+  // every result in it is a bye.
+  const nwl = (): Division => {
+    const state = TournamentReducer(defaultTournamentState, {
+      actionType: ActionType.SetDivisionsData,
+      payload: {
+        fullDivisions: fromBinary(FullTournamentDivisionsSchema, toArr(ftData)),
+        loginState: {
+          username: "josh",
+          userID: "dcHy8DxjX3dmsCAaEMR5AH",
+          loggedIn: true,
+          connId: "conn-123",
+          connectedToSocket: true,
+        },
+      },
+    });
+    return state.divisions["NWL"];
+  };
+
+  it("gives a bye no opponent and no score, but still moves the spread", () => {
+    showScorecard(nwl(), "dcHy8DxjX3dmsCAaEMR5AH:josh", 2);
+    expect(rows()).toEqual([
+      ["1", "", "Bye", "", "1", "0", "+50", "1"],
+      // Round 2 leaves josh and lola both on 1-0 with the same spread.
+      ["2 1st", "thedirector", "", "", "1", "0", "+50", "=1"],
+      ["3", "", "Bye", "", "2", "0", "+100", "1"],
+    ]);
+  });
+
+  it("ends on the record and rank the standings row it came from shows", () => {
+    showScorecard(nwl(), "FFGUXhQd3B8F6EXJUvmn5a:thedirector", 7);
+    const last = rows()[7];
+    expect(last.slice(4)).toEqual(["2", "0", "+100", "2"]);
+  });
+
+  it("leaves the averages off when only byes have landed", () => {
+    showScorecard(nwl(), "dcHy8DxjX3dmsCAaEMR5AH:josh", 0);
+    expect(screen.queryByText(/Average score/)).toBeNull();
+  });
+});

--- a/liwords-ui/src/tournament/player_scorecard_modal.test.tsx
+++ b/liwords-ui/src/tournament/player_scorecard_modal.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { create, fromBinary } from "@bufbuild/protobuf";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -21,9 +22,30 @@ import {
 import { ftData } from "../store/reducers/testdata/tourney_1_divisions";
 import { PlayerScorecardModal } from "./player_scorecard_modal";
 
+// The real one is a dropdown needing the login, match and pet contexts. Its
+// "View scorecard" entry becomes a button so the wiring can still be clicked.
 vi.mock("../shared/usernameWithContext", () => ({
-  UsernameWithContext: (props: { username: string }) => (
-    <span>{props.username}</span>
+  UsernameWithContext: (props: {
+    username: string;
+    infoText?: string;
+    handleInfoText?: () => void;
+  }) => (
+    <span>
+      {props.username}
+      {props.infoText && (
+        <button
+          onClick={(e) => {
+            props.handleInfoText?.();
+            // The real menu is portalled outside the modal and unmounts on
+            // click, which drops focus onto the body. Reproduce that, since it
+            // is what stops Escape reaching the dialog wrapper.
+            e.currentTarget.blur();
+          }}
+        >
+          {props.infoText} for {props.username}
+        </button>
+      )}
+    </span>
   ),
 }));
 
@@ -183,6 +205,7 @@ const showScorecard = (
   playerId: string,
   throughRound: number,
   irlMode = true,
+  onSelectPlayer: (id: string) => void = () => {},
 ) =>
   render(
     <PlayerScorecardModal
@@ -191,19 +214,30 @@ const showScorecard = (
       throughRound={throughRound}
       irlMode={irlMode}
       onClose={() => {}}
+      onSelectPlayer={onSelectPlayer}
     />,
   );
+
+// A real Escape press lands on whatever holds focus.
+const pressEscape = () =>
+  fireEvent.keyDown(document.activeElement ?? document.body, {
+    key: "Escape",
+    keyCode: 27,
+  });
+
+// A cell's text without the stand-in scorecard button.
+const cellText = (cell: HTMLElement) => {
+  const clone = cell.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll("button").forEach((button) => button.remove());
+  return clone.textContent?.trim();
+};
 
 // Every row as [round, opponent, result, score, W, L, spread, rank].
 const rows = () =>
   within(screen.getByRole("dialog"))
     .getAllByRole("row")
     .slice(1)
-    .map((row) =>
-      within(row)
-        .getAllByRole("cell")
-        .map((cell) => cell.textContent?.trim()),
-    );
+    .map((row) => within(row).getAllByRole("cell").map(cellText));
 
 describe("the player scorecard", () => {
   it("lays out one row per round, through the round it was opened at", () => {
@@ -249,6 +283,65 @@ describe("the player scorecard", () => {
     expect(screen.getByRole("dialog")).toHaveTextContent(
       "Average score 415.00, average opponent score 410.00, over 2 games.",
     );
+  });
+
+  it("hands an opponent over so their scorecard can replace this one", async () => {
+    const selected: string[] = [];
+    showScorecard(madeUpDivision(), ALICE, 1, true, (id) => selected.push(id));
+    await userEvent.click(screen.getByText("View scorecard for carol"));
+    expect(selected).toEqual([CAROL]);
+  });
+
+  // jsdom never runs the motion callback rc-dialog focuses from, so without a
+  // focus target of our own nothing inside the modal holds focus here, even on
+  // first open. A browser does focus it -- this pins that the wrapper serves
+  // both paths.
+  it("closes on escape", () => {
+    const closed: string[] = [];
+    render(
+      <PlayerScorecardModal
+        division={madeUpDivision()}
+        playerId={ALICE}
+        throughRound={1}
+        irlMode
+        onClose={() => closed.push(ALICE)}
+        onSelectPlayer={() => {}}
+      />,
+    );
+    pressEscape();
+    expect(closed).toEqual([ALICE]);
+  });
+
+  it("still closes on escape after following an opponent", async () => {
+    // Switching players re-renders this modal rather than reopening it, so
+    // rc-dialog never re-runs its focus-on-open, and the click that switched
+    // came from a menu outside the modal. Escape is bound to the dialog
+    // wrapper, so it only works while focus is still inside.
+    const closed: string[] = [];
+    const Harness = () => {
+      const [playerId, setPlayerId] = React.useState(ALICE);
+      return (
+        <PlayerScorecardModal
+          division={madeUpDivision()}
+          playerId={playerId}
+          throughRound={1}
+          irlMode
+          onClose={() => closed.push(playerId)}
+          onSelectPlayer={setPlayerId}
+        />
+      );
+    };
+    render(<Harness />);
+
+    await userEvent.click(screen.getByText("View scorecard for carol"));
+    expect(screen.getByRole("dialog")).toHaveTextContent("carol");
+
+    // Escape has to be fired at whatever holds focus, since rc-dialog listens
+    // on the dialog wrapper and a keydown from the body never reaches it.
+    // user-event omits the deprecated keyCode that rc-dialog checks, so this
+    // goes through fireEvent.
+    pressEscape();
+    expect(closed).toEqual([CAROL]);
   });
 
   it("hides the first-move tag outside in-real-life events", () => {

--- a/liwords-ui/src/tournament/player_scorecard_modal.tsx
+++ b/liwords-ui/src/tournament/player_scorecard_modal.tsx
@@ -1,0 +1,351 @@
+import React, { useMemo } from "react";
+import { Modal, Table, Tag, Typography } from "antd";
+import { UsernameWithContext } from "../shared/usernameWithContext";
+import { Division, SinglePairing } from "../store/reducers/tournament_reducer";
+import { TournamentGameResult } from "../gen/api/proto/ipc/tournament_pb";
+import { GameEndReason } from "../gen/api/proto/ipc/omgwords_pb";
+import { signed } from "./format";
+import { competitionRanks, rankLabel } from "./ranks";
+
+const { Text } = Typography;
+
+type Props = {
+  division: Division;
+  // The full "uuid:username" key the standings and the player index map use.
+  playerId: string;
+  // Zero-indexed, and never past the round that is open: the last row then
+  // matches the standings row this was opened from.
+  throughRound: number;
+  irlMode: boolean;
+  onClose: () => void;
+};
+
+type ScorecardRow = {
+  key: number;
+  round: number;
+  wentFirst: boolean;
+  opponentId?: string;
+  opponentName?: string;
+  opponentRemoved: boolean;
+  outcome: TournamentGameResult;
+  gameEndReason: GameEndReason;
+  playerScore?: number;
+  opponentScore?: number;
+  // Running totals after this round, with a draw counted as half of each, the
+  // way the standings table counts them.
+  wins?: number;
+  losses?: number;
+  spread?: number;
+  rank?: string;
+};
+
+const splitPlayerId = (id: string) => {
+  const [uuid, username] = id.split(":");
+  return { uuid, username };
+};
+
+// Only the reasons worth a parenthetical. In-real-life results are entered by a
+// director and carry no end reason at all, so NONE stays silent rather than
+// tagging every row of an in-real-life event.
+const endReasonLabel = (reason: GameEndReason): string => {
+  switch (reason) {
+    case GameEndReason.TIME:
+      return "time";
+    case GameEndReason.CONSECUTIVE_ZEROES:
+      return "zeroes";
+    case GameEndReason.RESIGNED:
+      return "resigned";
+    case GameEndReason.TRIPLE_CHALLENGE:
+      return "triple";
+    case GameEndReason.FORCE_FORFEIT:
+      return "forfeit";
+    case GameEndReason.ADJUDICATED:
+      return "adjudicated";
+    case GameEndReason.ABORTED:
+      return "aborted";
+    case GameEndReason.CANCELLED:
+      return "canceled";
+    default:
+      return "";
+  }
+};
+
+// A game that two players actually finished. A forfeit or a void round carries
+// scores of 0-0, which is a placeholder rather than a result, so those are out.
+const isFinishedGame = (outcome: TournamentGameResult) =>
+  outcome === TournamentGameResult.WIN ||
+  outcome === TournamentGameResult.LOSS ||
+  outcome === TournamentGameResult.DRAW;
+
+// A round the players are meant to sit down for -- finished, or still running.
+const isRealGame = (outcome: TournamentGameResult) =>
+  isFinishedGame(outcome) || outcome === TournamentGameResult.NO_RESULT;
+
+// Only finished games count toward the averages.
+const isPlayedGame = (row: ScorecardRow) =>
+  row.playerScore !== undefined && isFinishedGame(row.outcome);
+
+export const buildScorecard = (
+  division: Division,
+  playerId: string,
+  throughRound: number,
+): ScorecardRow[] => {
+  const playerIndex = division.playerIndexMap[playerId];
+  const rows: ScorecardRow[] = [];
+
+  for (let round = 0; round <= throughRound; round++) {
+    const pairing: SinglePairing | undefined =
+      division.pairings[round]?.roundPairings[playerIndex];
+    const standing = division.standingsMap[round]?.standings;
+    const rankIndex = standing?.findIndex((s) => s.playerId === playerId) ?? -1;
+    const mine = rankIndex >= 0 ? standing[rankIndex] : undefined;
+
+    const row: ScorecardRow = {
+      key: round,
+      round,
+      wentFirst: false,
+      opponentRemoved: false,
+      outcome: TournamentGameResult.NO_RESULT,
+      gameEndReason: GameEndReason.NONE,
+      wins: mine ? mine.wins + mine.draws / 2 : undefined,
+      losses: mine ? mine.losses + mine.draws / 2 : undefined,
+      spread: mine?.spread,
+      rank:
+        rankIndex >= 0
+          ? rankLabel(
+              competitionRanks(standing)[rankIndex],
+              rankIndex + 1,
+              // The column is right-aligned, so the marker leads.
+              "leading",
+            )
+          : undefined,
+    };
+
+    if (pairing?.players?.length) {
+      // Each pairing is stored under both players' indexes, so the player is
+      // one of the two -- except for a bye, where they are both of them.
+      const seat = pairing.players[0].id === playerId ? 0 : 1;
+      const opponent = pairing.players[1 - seat];
+      const isBye = opponent.id === playerId;
+
+      row.outcome = pairing.outcomes[seat];
+      row.gameEndReason = pairing.games[0]?.gameEndReason ?? GameEndReason.NONE;
+
+      // Going first only means something for a round somebody sits down for.
+      // It survives an unfinished game, where it is the useful half of the row.
+      row.wentFirst = seat === 0 && !isBye && isRealGame(row.outcome);
+
+      if (!isBye) {
+        row.opponentId = opponent.id;
+        row.opponentName = splitPlayerId(opponent.id).username;
+        row.opponentRemoved =
+          division.players[division.playerIndexMap[opponent.id]]?.suspended ??
+          false;
+      }
+
+      // A score only means something once two players have finished a game.
+      // A bye, a forfeit and a void round all carry 0-0 or a stand-in spread,
+      // none of which anybody played.
+      const scores = pairing.games[0]?.scores;
+      if (!isBye && scores?.length === 2 && isFinishedGame(row.outcome)) {
+        row.playerScore = scores[seat];
+        row.opponentScore = scores[1 - seat];
+      }
+    }
+
+    rows.push(row);
+  }
+
+  return rows;
+};
+
+const resultTag = (row: ScorecardRow): React.ReactNode => {
+  switch (row.outcome) {
+    case TournamentGameResult.WIN:
+      return <Tag className="ant-tag-win">Win</Tag>;
+    case TournamentGameResult.LOSS:
+      return <Tag className="ant-tag-loss">Loss</Tag>;
+    case TournamentGameResult.DRAW:
+      return <Tag className="ant-tag-tie">Draw</Tag>;
+    case TournamentGameResult.BYE:
+      return <Tag className="ant-tag-bye">Bye</Tag>;
+    case TournamentGameResult.FORFEIT_WIN:
+      return <Tag className="ant-tag-forfeit">Forfeit win</Tag>;
+    case TournamentGameResult.FORFEIT_LOSS:
+      return <Tag className="ant-tag-forfeit">Forfeit loss</Tag>;
+    case TournamentGameResult.ELIMINATED:
+      return <Tag className="ant-tag-forfeit">Eliminated</Tag>;
+    case TournamentGameResult.VOID:
+      return <Tag className="ant-tag-bye">Not playing</Tag>;
+    default:
+      // Paired, but the game has not finished. Say nothing rather than claim a
+      // state the round has not reached.
+      return null;
+  }
+};
+
+export const PlayerScorecardModal = (props: Props) => {
+  const { division, playerId, throughRound, irlMode } = props;
+  const { username } = splitPlayerId(playerId);
+
+  const rows = useMemo(
+    () => buildScorecard(division, playerId, throughRound),
+    [division, playerId, throughRound],
+  );
+
+  const averages = useMemo(() => {
+    const played = rows.filter(isPlayedGame);
+    if (!played.length) {
+      return undefined;
+    }
+    const total = (pick: (row: ScorecardRow) => number) =>
+      played.reduce((sum, row) => sum + pick(row), 0) / played.length;
+    return {
+      games: played.length,
+      score: total((row) => row.playerScore ?? 0),
+      opponentScore: total((row) => row.opponentScore ?? 0),
+    };
+  }, [rows]);
+
+  const columns = [
+    {
+      title: "Round",
+      key: "round",
+      render: (_: unknown, row: ScorecardRow) => (
+        <span style={{ whiteSpace: "nowrap" }}>
+          {row.round + 1}{" "}
+          {irlMode && row.wentFirst && <Tag className="ant-tag-first">1st</Tag>}
+        </span>
+      ),
+    },
+    {
+      title: "Opponent",
+      key: "opponent",
+      render: (_: unknown, row: ScorecardRow) =>
+        row.opponentId ? (
+          <span style={{ whiteSpace: "nowrap" }}>
+            <UsernameWithContext
+              username={row.opponentName ?? ""}
+              userID={splitPlayerId(row.opponentId).uuid}
+              omitSendMessage
+              omitBlock
+            />{" "}
+            {row.opponentRemoved && (
+              <Tag className="ant-tag-removed">Removed</Tag>
+            )}
+          </span>
+        ) : null,
+    },
+    {
+      title: "Result",
+      key: "result",
+      render: (_: unknown, row: ScorecardRow) => {
+        const tag = resultTag(row);
+        const reason = endReasonLabel(row.gameEndReason);
+        if (!tag) {
+          return null;
+        }
+        return (
+          <span style={{ whiteSpace: "nowrap" }}>
+            {tag}
+            {reason ? ` (${reason})` : ""}
+          </span>
+        );
+      },
+    },
+    {
+      title: "Score",
+      key: "score",
+      render: (_: unknown, row: ScorecardRow) => {
+        if (row.playerScore === undefined || row.opponentScore === undefined) {
+          return null;
+        }
+        // Same shape as the league game history: the round's own margin lives
+        // inline here, so it needs no column of its own.
+        const spread = row.playerScore - row.opponentScore;
+        return (
+          <span style={{ whiteSpace: "nowrap" }}>
+            {row.playerScore}-{row.opponentScore}{" "}
+            <Text
+              type={
+                spread > 0 ? "success" : spread < 0 ? "danger" : "secondary"
+              }
+            >
+              ({signed(spread)})
+            </Text>
+          </span>
+        );
+      },
+    },
+    // The running totals, split and right-aligned the way the standings table
+    // this opens from lays them out. A drawn round puts a half in the record,
+    // and 1.5 only lines up under 0 if the two are their own columns.
+    {
+      title: "W",
+      key: "wins",
+      align: "right" as const,
+      render: (_: unknown, row: ScorecardRow) => row.wins ?? null,
+    },
+    {
+      title: "L",
+      key: "losses",
+      align: "right" as const,
+      render: (_: unknown, row: ScorecardRow) => row.losses ?? null,
+    },
+    {
+      // Signed, so a minus sign cannot be mistaken for the start of a digit.
+      // The spread inline in the Score cell is signed for the same reason.
+      title: "Spread",
+      key: "spread",
+      align: "right" as const,
+      render: (_: unknown, row: ScorecardRow) =>
+        row.spread === undefined ? null : signed(row.spread),
+    },
+    {
+      title: "#",
+      key: "rank",
+      align: "right" as const,
+      render: (_: unknown, row: ScorecardRow) => row.rank ?? null,
+    },
+  ];
+
+  return (
+    <Modal
+      className="custom-tags"
+      title={
+        <>
+          {username}
+          <Text type="secondary" style={{ fontWeight: "normal" }}>
+            {" "}
+            -- rounds 1 to {throughRound + 1}
+          </Text>
+        </>
+      }
+      open
+      onCancel={props.onClose}
+      footer={null}
+      width={720}
+    >
+      <div style={{ overflowX: "auto" }}>
+        <Table
+          className="player-scorecard"
+          columns={columns}
+          dataSource={rows}
+          pagination={false}
+          size="small"
+          rowKey="key"
+          locale={{ emptyText: "No rounds have been played yet." }}
+        />
+      </div>
+      {averages && (
+        <p>
+          <Text type="secondary">
+            Average score {averages.score.toFixed(2)}, average opponent score{" "}
+            {averages.opponentScore.toFixed(2)}, over {averages.games}{" "}
+            {averages.games === 1 ? "game" : "games"}.
+          </Text>
+        </p>
+      )}
+    </Modal>
+  );
+};

--- a/liwords-ui/src/tournament/player_scorecard_modal.tsx
+++ b/liwords-ui/src/tournament/player_scorecard_modal.tsx
@@ -242,6 +242,8 @@ export const PlayerScorecardModal = (props: Props) => {
               userID={splitPlayerId(row.opponentId).uuid}
               omitSendMessage
               omitBlock
+              omitProfileLink={irlMode}
+              omitFriend={irlMode}
               infoText="View scorecard"
               handleInfoText={() => props.onSelectPlayer(row.opponentId!)}
             />{" "}

--- a/liwords-ui/src/tournament/player_scorecard_modal.tsx
+++ b/liwords-ui/src/tournament/player_scorecard_modal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { Modal, Table, Tag, Typography } from "antd";
 import { UsernameWithContext } from "../shared/usernameWithContext";
 import { Division, SinglePairing } from "../store/reducers/tournament_reducer";
@@ -18,6 +18,9 @@ type Props = {
   throughRound: number;
   irlMode: boolean;
   onClose: () => void;
+  // Swaps the modal over to another player's scorecard, so an opponent can be
+  // followed without going back to the standings.
+  onSelectPlayer: (playerId: string) => void;
 };
 
 type ScorecardRow = {
@@ -193,6 +196,16 @@ export const PlayerScorecardModal = (props: Props) => {
     [division, playerId, throughRound],
   );
 
+  // Following an opponent re-renders this modal rather than reopening it, so
+  // rc-dialog never re-runs the focus-on-open it does from onDialogVisibleChanged.
+  // The click that got us here came from a menu antd portals outside the modal,
+  // which leaves focus on the body once it unmounts -- and Escape is a keydown
+  // handler on the dialog wrapper, so it stops reaching it. Put focus back.
+  const bodyRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    bodyRef.current?.focus();
+  }, [playerId]);
+
   const averages = useMemo(() => {
     const played = rows.filter(isPlayedGame);
     if (!played.length) {
@@ -229,6 +242,8 @@ export const PlayerScorecardModal = (props: Props) => {
               userID={splitPlayerId(row.opponentId).uuid}
               omitSendMessage
               omitBlock
+              infoText="View scorecard"
+              handleInfoText={() => props.onSelectPlayer(row.opponentId!)}
             />{" "}
             {row.opponentRemoved && (
               <Tag className="ant-tag-removed">Removed</Tag>
@@ -326,26 +341,28 @@ export const PlayerScorecardModal = (props: Props) => {
       footer={null}
       width={720}
     >
-      <div style={{ overflowX: "auto" }}>
-        <Table
-          className="player-scorecard"
-          columns={columns}
-          dataSource={rows}
-          pagination={false}
-          size="small"
-          rowKey="key"
-          locale={{ emptyText: "No rounds have been played yet." }}
-        />
+      <div ref={bodyRef} tabIndex={-1} style={{ outline: "none" }}>
+        <div style={{ overflowX: "auto" }}>
+          <Table
+            className="player-scorecard"
+            columns={columns}
+            dataSource={rows}
+            pagination={false}
+            size="small"
+            rowKey="key"
+            locale={{ emptyText: "No rounds have been played yet." }}
+          />
+        </div>
+        {averages && (
+          <p>
+            <Text type="secondary">
+              Average score {averages.score.toFixed(2)}, average opponent score{" "}
+              {averages.opponentScore.toFixed(2)}, over {averages.games}{" "}
+              {averages.games === 1 ? "game" : "games"}.
+            </Text>
+          </p>
+        )}
       </div>
-      {averages && (
-        <p>
-          <Text type="secondary">
-            Average score {averages.score.toFixed(2)}, average opponent score{" "}
-            {averages.opponentScore.toFixed(2)}, over {averages.games}{" "}
-            {averages.games === 1 ? "game" : "games"}.
-          </Text>
-        </p>
-      )}
     </Modal>
   );
 };

--- a/liwords-ui/src/tournament/ranks.test.ts
+++ b/liwords-ui/src/tournament/ranks.test.ts
@@ -1,0 +1,83 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+import { PlayerStandingSchema } from "../gen/api/proto/ipc/tournament_pb";
+import { competitionRanks, rankLabel } from "./ranks";
+
+const standing = (wins: number, losses: number, spread: number, draws = 0) =>
+  create(PlayerStandingSchema, {
+    playerId: `p${wins}${losses}${spread}${draws}`,
+    wins,
+    losses,
+    draws,
+    spread,
+  });
+
+const labels = (...rows: ReturnType<typeof standing>[]) => {
+  const ranks = competitionRanks(rows);
+  return rows.map((_, i) => rankLabel(ranks[i], i + 1));
+};
+
+const leadingLabels = (...rows: ReturnType<typeof standing>[]) => {
+  const ranks = competitionRanks(rows);
+  return rows.map((_, i) => rankLabel(ranks[i], i + 1, "leading"));
+};
+
+describe("competition ranks", () => {
+  it("leaves an untied table alone", () => {
+    expect(labels(standing(3, 0, 300), standing(2, 1, 100))).toEqual([
+      "1",
+      "2",
+    ]);
+  });
+
+  it("shares a place and skips the next one", () => {
+    expect(
+      labels(standing(3, 0, 100), standing(3, 0, 100), standing(1, 2, 50)),
+    ).toEqual(["1=", "1=", "3"]);
+  });
+
+  it("splits players who differ only on spread", () => {
+    expect(labels(standing(3, 0, 200), standing(3, 0, 100))).toEqual([
+      "1",
+      "2",
+    ]);
+  });
+
+  it("ties on the half a draw is worth, not on the raw counts", () => {
+    // 2.5-0.5 either way: two wins and a draw, or two and a half wins.
+    expect(
+      labels(standing(2, 0, 100, 1), standing(2, 0, 100, 1), standing(1, 2, 0)),
+    ).toEqual(["1=", "1=", "3"]);
+  });
+
+  it("shares a place in the middle of the table", () => {
+    expect(
+      labels(
+        standing(4, 0, 400),
+        standing(2, 2, 100),
+        standing(2, 2, 100),
+        standing(0, 4, -500),
+      ),
+    ).toEqual(["1", "2=", "2=", "4"]);
+  });
+
+  it("leads with the marker where the column is right-aligned", () => {
+    expect(
+      leadingLabels(
+        standing(3, 0, 100),
+        standing(3, 0, 100),
+        standing(1, 2, 50),
+      ),
+    ).toEqual(["=1", "=1", "3"]);
+  });
+
+  it("says nothing before anybody has played", () => {
+    expect(labels(standing(0, 0, 0), standing(0, 0, 0))).toEqual(["1", "2"]);
+  });
+
+  it("marks a tie at the bottom once one game has landed", () => {
+    expect(
+      labels(standing(1, 0, 50), standing(0, 0, 0), standing(0, 0, 0)),
+    ).toEqual(["1", "2=", "2="]);
+  });
+});

--- a/liwords-ui/src/tournament/ranks.ts
+++ b/liwords-ui/src/tournament/ranks.ts
@@ -1,0 +1,71 @@
+import { PlayerStanding } from "../gen/api/proto/ipc/tournament_pb";
+
+export type CompetitionRank = { rank: number; tied: boolean };
+
+// Players who read identically share a place, and the place after a shared one
+// skips: 1=, 1=, 3.
+//
+// The tie is on what the row shows -- W, L and spread -- not on the comparator
+// the server sorts by, which is win rate, then losses, then spread. Those
+// disagree: equal rate with equal losses and equal spread admits 1-0 sitting
+// next to 2-0 once byes leave players on different game counts, and marking
+// those two as sharing a place would read as a bug. The "=" is a claim about
+// the row in front of you.
+//
+// Before anybody has played, every row is 0-0 with no spread. That is a tie in
+// the arithmetic and noise on the screen, so it goes unmarked.
+export const competitionRanks = (
+  standings: readonly PlayerStanding[],
+): CompetitionRank[] => {
+  const plain = standings.map((_, index) => ({
+    rank: index + 1,
+    tied: false,
+  }));
+
+  const played = standings.some((s) => s.wins + s.losses + s.draws > 0);
+  if (!played) {
+    return plain;
+  }
+
+  // Doubled so the half a draw is worth stays an integer.
+  const key = (s: PlayerStanding) =>
+    `${s.wins * 2 + s.draws}/${s.losses * 2 + s.draws}/${s.spread}`;
+
+  const ranks: CompetitionRank[] = [];
+  let currentRank = 1;
+  for (let i = 0; i < standings.length; i++) {
+    if (i > 0 && key(standings[i]) !== key(standings[i - 1])) {
+      currentRank = i + 1;
+    }
+    // A rank that has fallen behind its own position is one an earlier row
+    // already holds.
+    ranks.push({ rank: currentRank, tied: currentRank <= i });
+  }
+  // Mark the first row of each shared place too.
+  for (let i = 1; i < ranks.length; i++) {
+    if (ranks[i].tied) {
+      ranks[i - 1].tied = true;
+    }
+  }
+  return ranks;
+};
+
+// Which side the shared-place marker sits on follows how the column is
+// aligned, so that the digits stay in a line either way: a left-aligned column
+// trails it (1=, as the league standings write it), a right-aligned one leads
+// with it (=1, as tournament archives write it).
+export type TieMarker = "trailing" | "leading";
+
+export const rankLabel = (
+  rank: CompetitionRank | undefined,
+  fallback: number,
+  marker: TieMarker = "trailing",
+) => {
+  if (!rank) {
+    return `${fallback}`;
+  }
+  if (!rank.tied) {
+    return `${rank.rank}`;
+  }
+  return marker === "leading" ? `=${rank.rank}` : `${rank.rank}=`;
+};

--- a/liwords-ui/src/tournament/standings.test.tsx
+++ b/liwords-ui/src/tournament/standings.test.tsx
@@ -78,27 +78,27 @@ describe("standings for the selected round", () => {
   it("shows a past round rather than the current one", () => {
     renderAt(7, 2);
     expect(rows()).toEqual([
-      ["1", "josh", "2", "0", "100"],
-      ["2", "lola", "1", "0", "50"],
-      ["3", "thedirector", "0", "0", "0"],
+      ["1", "josh", "2", "0", "+100"],
+      ["2", "lola", "1", "0", "+50"],
+      ["3", "thedirector", "0", "0", "+0"],
     ]);
   });
 
   it("shows a different past round", () => {
     renderAt(7, 5);
     expect(rows()).toEqual([
-      ["1", "josh", "5", "0", "250"],
-      ["2", "lola", "1", "0", "50"],
-      ["3", "thedirector", "0", "0", "0"],
+      ["1", "josh", "5", "0", "+250"],
+      ["2", "lola", "1", "0", "+50"],
+      ["3", "thedirector", "0", "0", "+0"],
     ]);
   });
 
   it("shows the round that is open, whose games may still be running", () => {
     renderAt(7, 7);
     expect(rows()).toEqual([
-      ["1", "josh", "5", "0", "250"],
-      ["2", "thedirector", "2", "0", "100"],
-      ["3", "lola", "1", "0", "50"],
+      ["1", "josh", "5", "0", "+250"],
+      ["2", "thedirector", "2", "0", "+100"],
+      ["3", "lola", "1", "0", "+50"],
     ]);
   });
 
@@ -116,9 +116,9 @@ describe("standings for the selected round", () => {
     // After round 2 both josh and lola are 1-0 with a spread of 50.
     renderAt(7, 1);
     expect(rows()).toEqual([
-      ["1=", "lola", "1", "0", "50"],
-      ["1=", "josh", "1", "0", "50"],
-      ["3", "thedirector", "0", "0", "0"],
+      ["1=", "lola", "1", "0", "+50"],
+      ["1=", "josh", "1", "0", "+50"],
+      ["3", "thedirector", "0", "0", "+0"],
     ]);
   });
 
@@ -126,9 +126,9 @@ describe("standings for the selected round", () => {
     // Round 1 gave josh a bye, and left the other two on nothing at all.
     renderAt(7, 0);
     expect(rows()).toEqual([
-      ["1", "josh", "1", "0", "50"],
-      ["2=", "lola", "0", "0", "0"],
-      ["2=", "thedirector", "0", "0", "0"],
+      ["1", "josh", "1", "0", "+50"],
+      ["2=", "lola", "0", "0", "+0"],
+      ["2=", "thedirector", "0", "0", "+0"],
     ]);
   });
 });

--- a/liwords-ui/src/tournament/standings.test.tsx
+++ b/liwords-ui/src/tournament/standings.test.tsx
@@ -111,4 +111,24 @@ describe("standings for the selected round", () => {
     renderAt(-1, 0);
     expect(screen.getByText("Standings are not yet available.")).toBeVisible();
   });
+
+  it("shares a place between players the table cannot tell apart", () => {
+    // After round 2 both josh and lola are 1-0 with a spread of 50.
+    renderAt(7, 1);
+    expect(rows()).toEqual([
+      ["1=", "lola", "1", "0", "50"],
+      ["1=", "josh", "1", "0", "50"],
+      ["3", "thedirector", "0", "0", "0"],
+    ]);
+  });
+
+  it("shares a place below the leader too", () => {
+    // Round 1 gave josh a bye, and left the other two on nothing at all.
+    renderAt(7, 0);
+    expect(rows()).toEqual([
+      ["1", "josh", "1", "0", "50"],
+      ["2=", "lola", "0", "0", "0"],
+      ["2=", "thedirector", "0", "0", "0"],
+    ]);
+  });
 });

--- a/liwords-ui/src/tournament/standings.test.tsx
+++ b/liwords-ui/src/tournament/standings.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, within } from "@testing-library/react";
+import { fromBinary } from "@bufbuild/protobuf";
+import { describe, expect, it, vi } from "vitest";
+import { FullTournamentDivisionsSchema } from "../gen/api/proto/ipc/tournament_pb";
+import { ActionType } from "../actions/actions";
+import {
+  defaultTournamentState,
+  Division,
+  TournamentReducer,
+} from "../store/reducers/tournament_reducer";
+import { ftData } from "../store/reducers/testdata/tourney_1_divisions";
+import { Standings } from "./standings";
+
+// The standings table reads whichever round the picker is on. Rounds it must
+// not render are the ones that have not been opened yet: the server computes
+// standings cumulatively, so it answers for a future round with a copy of the
+// current one, and rendering that would repeat the current numbers under the
+// wrong heading.
+
+vi.mock("../shared/usernameWithContext", () => ({
+  UsernameWithContext: (props: { username: string }) => (
+    <span>{props.username}</span>
+  ),
+}));
+
+const divisions = vi.hoisted(() => ({ value: {} as Record<string, Division> }));
+
+vi.mock("../store/store", () => ({
+  useTournamentStoreContext: () => ({
+    tournamentContext: { divisions: divisions.value, metadata: {} },
+  }),
+}));
+
+const toArr = (s: string) => {
+  const bytes = new Uint8Array(Math.ceil(s.length / 2));
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(s.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+};
+
+// The NWL division of this fixture has eight rounds of standings for three
+// players, josh, lola and thedirector, and it includes byes.
+const nwlDivision = (): Division => {
+  const state = TournamentReducer(defaultTournamentState, {
+    actionType: ActionType.SetDivisionsData,
+    payload: {
+      fullDivisions: fromBinary(FullTournamentDivisionsSchema, toArr(ftData)),
+      loginState: {
+        username: "josh",
+        userID: "dcHy8DxjX3dmsCAaEMR5AH",
+        loggedIn: true,
+        connId: "conn-123",
+        connectedToSocket: true,
+      },
+    },
+  });
+  return state.divisions["NWL"];
+};
+
+const renderAt = (currentRound: number, selectedRound: number) => {
+  divisions.value = { NWL: { ...nwlDivision(), currentRound } };
+  render(<Standings selectedDivision="NWL" selectedRound={selectedRound} />);
+};
+
+// Every row as [rank, player, W, L, spread].
+const rows = () =>
+  screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) =>
+      within(row)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent?.trim()),
+    );
+
+describe("standings for the selected round", () => {
+  it("shows a past round rather than the current one", () => {
+    renderAt(7, 2);
+    expect(rows()).toEqual([
+      ["1", "josh", "2", "0", "100"],
+      ["2", "lola", "1", "0", "50"],
+      ["3", "thedirector", "0", "0", "0"],
+    ]);
+  });
+
+  it("shows a different past round", () => {
+    renderAt(7, 5);
+    expect(rows()).toEqual([
+      ["1", "josh", "5", "0", "250"],
+      ["2", "lola", "1", "0", "50"],
+      ["3", "thedirector", "0", "0", "0"],
+    ]);
+  });
+
+  it("shows the round that is open, whose games may still be running", () => {
+    renderAt(7, 7);
+    expect(rows()).toEqual([
+      ["1", "josh", "5", "0", "250"],
+      ["2", "thedirector", "2", "0", "100"],
+      ["3", "lola", "1", "0", "50"],
+    ]);
+  });
+
+  it("declines a round that has not been opened", () => {
+    renderAt(5, 6);
+    expect(screen.getByText("Standings are not yet available.")).toBeVisible();
+  });
+
+  it("declines every round before the tournament starts", () => {
+    renderAt(-1, 0);
+    expect(screen.getByText("Standings are not yet available.")).toBeVisible();
+  });
+});

--- a/liwords-ui/src/tournament/standings.test.tsx
+++ b/liwords-ui/src/tournament/standings.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { fromBinary } from "@bufbuild/protobuf";
 import { describe, expect, it, vi } from "vitest";
 import { FullTournamentDivisionsSchema } from "../gen/api/proto/ipc/tournament_pb";
@@ -17,9 +18,23 @@ import { Standings } from "./standings";
 // current one, and rendering that would repeat the current numbers under the
 // wrong heading.
 
+// The real one is a dropdown that needs the login, match and pet contexts. Its
+// "View scorecard" entry becomes a button here so the wiring can still be
+// clicked.
 vi.mock("../shared/usernameWithContext", () => ({
-  UsernameWithContext: (props: { username: string }) => (
-    <span>{props.username}</span>
+  UsernameWithContext: (props: {
+    username: string;
+    infoText?: string;
+    handleInfoText?: () => void;
+  }) => (
+    <span>
+      {props.username}
+      {props.infoText && (
+        <button onClick={props.handleInfoText}>
+          {props.infoText} for {props.username}
+        </button>
+      )}
+    </span>
   ),
 }));
 
@@ -63,16 +78,19 @@ const renderAt = (currentRound: number, selectedRound: number) => {
   render(<Standings selectedDivision="NWL" selectedRound={selectedRound} />);
 };
 
+// A cell's text without the stand-in scorecard button.
+const cellText = (cell: HTMLElement) => {
+  const clone = cell.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll("button").forEach((button) => button.remove());
+  return clone.textContent?.trim();
+};
+
 // Every row as [rank, player, W, L, spread].
 const rows = () =>
   screen
     .getAllByRole("row")
     .slice(1)
-    .map((row) =>
-      within(row)
-        .getAllByRole("cell")
-        .map((cell) => cell.textContent?.trim()),
-    );
+    .map((row) => within(row).getAllByRole("cell").map(cellText));
 
 describe("standings for the selected round", () => {
   it("shows a past round rather than the current one", () => {
@@ -130,5 +148,11 @@ describe("standings for the selected round", () => {
       ["2=", "lola", "0", "0", "+0"],
       ["2=", "thedirector", "0", "0", "+0"],
     ]);
+  });
+
+  it("opens a scorecard covering the rounds up to the one on screen", async () => {
+    renderAt(7, 2);
+    await userEvent.click(screen.getByText("View scorecard for lola"));
+    expect(screen.getByRole("dialog")).toHaveTextContent("rounds 1 to 3");
   });
 });

--- a/liwords-ui/src/tournament/standings.test.tsx
+++ b/liwords-ui/src/tournament/standings.test.tsx
@@ -26,8 +26,17 @@ vi.mock("../shared/usernameWithContext", () => ({
     username: string;
     infoText?: string;
     handleInfoText?: () => void;
+    omitProfileLink?: boolean;
+    omitFriend?: boolean;
   }) => (
-    <span>
+    <span
+      data-omits={[
+        props.omitProfileLink ? "profile" : "",
+        props.omitFriend ? "friend" : "",
+      ]
+        .filter(Boolean)
+        .join(",")}
+    >
       {props.username}
       {props.infoText && (
         <button onClick={props.handleInfoText}>
@@ -39,10 +48,11 @@ vi.mock("../shared/usernameWithContext", () => ({
 }));
 
 const divisions = vi.hoisted(() => ({ value: {} as Record<string, Division> }));
+const metadata = vi.hoisted(() => ({ value: {} as { irlMode?: boolean } }));
 
 vi.mock("../store/store", () => ({
   useTournamentStoreContext: () => ({
-    tournamentContext: { divisions: divisions.value, metadata: {} },
+    tournamentContext: { divisions: divisions.value, metadata: metadata.value },
   }),
 }));
 
@@ -73,10 +83,18 @@ const nwlDivision = (): Division => {
   return state.divisions["NWL"];
 };
 
-const renderAt = (currentRound: number, selectedRound: number) => {
+const renderAt = (
+  currentRound: number,
+  selectedRound: number,
+  irlMode = false,
+) => {
   divisions.value = { NWL: { ...nwlDivision(), currentRound } };
+  metadata.value = { irlMode };
   render(<Standings selectedDivision="NWL" selectedRound={selectedRound} />);
 };
+
+const omitsFor = (username: string) =>
+  screen.getByText(username).closest("span")?.getAttribute("data-omits");
 
 // A cell's text without the stand-in scorecard button.
 const cellText = (cell: HTMLElement) => {
@@ -148,6 +166,18 @@ describe("standings for the selected round", () => {
       ["2=", "lola", "0", "0", "+0"],
       ["2=", "thedirector", "0", "0", "+0"],
     ]);
+  });
+
+  it("offers no profile or friend for a name that is not an account", () => {
+    // An in-real-life division holds real names, and /profile/Some%20Name is a
+    // 404.
+    renderAt(7, 2, true);
+    expect(omitsFor("josh")).toBe("profile,friend");
+  });
+
+  it("keeps both for an online division", () => {
+    renderAt(7, 2);
+    expect(omitsFor("josh")).toBe("");
   });
 
   it("opens a scorecard covering the rounds up to the one on screen", async () => {

--- a/liwords-ui/src/tournament/standings.tsx
+++ b/liwords-ui/src/tournament/standings.tsx
@@ -1,8 +1,9 @@
-import React, { ReactNode, useMemo } from "react";
+import React, { ReactNode, useMemo, useState } from "react";
 import { useTournamentStoreContext } from "../store/store";
 import { UsernameWithContext } from "../shared/usernameWithContext";
 import { Table } from "antd";
 import { signed } from "./format";
+import { PlayerScorecardModal } from "./player_scorecard_modal";
 import { competitionRanks, rankLabel } from "./ranks";
 // import { PlayerTag } from './player_tags';
 
@@ -26,6 +27,7 @@ type StandingsTableData = {
 export const Standings = (props: Props) => {
   const { tournamentContext } = useTournamentStoreContext();
   const { divisions } = tournamentContext;
+  const [scorecardPlayer, setScorecardPlayer] = useState<string>();
   const currentRound = useMemo(
     () =>
       divisions.hasOwnProperty(props.selectedDivision)
@@ -64,6 +66,8 @@ export const Standings = (props: Props) => {
                 userID={playerId}
                 omitSendMessage
                 omitBlock
+                infoText="View scorecard"
+                handleInfoText={() => setScorecardPlayer(standing.playerId)}
               />{" "}
               {/* <PlayerTag
                 username={playerName}
@@ -75,7 +79,6 @@ export const Standings = (props: Props) => {
           wins: standing.wins + standing.draws / 2,
           losses: standing.losses + standing.draws / 2,
           spread: standing.spread,
-          //actions: null, //scorecard button goes here
         };
       },
     );
@@ -122,17 +125,28 @@ export const Standings = (props: Props) => {
     },*/
   ];
   return (
-    <Table
-      className="standings"
-      columns={columns}
-      rowKey={(record) => {
-        return `${record.rank}`;
-      }}
-      locale={{
-        emptyText: "Standings are not yet available.",
-      }}
-      dataSource={formatStandings}
-      pagination={false}
-    />
+    <>
+      <Table
+        className="standings"
+        columns={columns}
+        rowKey={(record) => {
+          return `${record.rank}`;
+        }}
+        locale={{
+          emptyText: "Standings are not yet available.",
+        }}
+        dataSource={formatStandings}
+        pagination={false}
+      />
+      {scorecardPlayer && (
+        <PlayerScorecardModal
+          division={division}
+          playerId={scorecardPlayer}
+          throughRound={props.selectedRound}
+          irlMode={tournamentContext.metadata?.irlMode ?? false}
+          onClose={() => setScorecardPlayer(undefined)}
+        />
+      )}
+    </>
   );
 };

--- a/liwords-ui/src/tournament/standings.tsx
+++ b/liwords-ui/src/tournament/standings.tsx
@@ -6,6 +6,7 @@ import { Table } from "antd";
 
 type Props = {
   selectedDivision: string;
+  selectedRound: number;
 };
 
 type StandingsTableData = {
@@ -36,8 +37,13 @@ export const Standings = (props: Props) => {
   }
 
   let formatStandings;
-  if (currentRound > -1) {
-    formatStandings = division.standingsMap[currentRound]?.standings.map(
+  // Standings accumulate the results so far, so the server will happily compute
+  // them for a round that has not been opened yet -- they come back as a copy
+  // of the current round's. Gate on the round rather than on the map, or the
+  // tentative next round would silently repeat the current standings under its
+  // own heading.
+  if (currentRound > -1 && props.selectedRound <= currentRound) {
+    formatStandings = division.standingsMap[props.selectedRound]?.standings.map(
       (standing, index): StandingsTableData => {
         const [playerId, playerName] = standing.playerId.split(":");
         return {

--- a/liwords-ui/src/tournament/standings.tsx
+++ b/liwords-ui/src/tournament/standings.tsx
@@ -145,6 +145,7 @@ export const Standings = (props: Props) => {
           throughRound={props.selectedRound}
           irlMode={tournamentContext.metadata?.irlMode ?? false}
           onClose={() => setScorecardPlayer(undefined)}
+          onSelectPlayer={setScorecardPlayer}
         />
       )}
     </>

--- a/liwords-ui/src/tournament/standings.tsx
+++ b/liwords-ui/src/tournament/standings.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useMemo } from "react";
 import { useTournamentStoreContext } from "../store/store";
 import { UsernameWithContext } from "../shared/usernameWithContext";
 import { Table } from "antd";
+import { competitionRanks, rankLabel } from "./ranks";
 // import { PlayerTag } from './player_tags';
 
 type Props = {
@@ -10,7 +11,10 @@ type Props = {
 };
 
 type StandingsTableData = {
+  // The row's position, which the table needs as a key, and its rank as a
+  // competition scores it, which ties can share.
   rank: number;
+  displayRank: string;
   player: ReactNode;
   //rating: number;
   wins: number;
@@ -43,11 +47,15 @@ export const Standings = (props: Props) => {
   // tentative next round would silently repeat the current standings under its
   // own heading.
   if (currentRound > -1 && props.selectedRound <= currentRound) {
-    formatStandings = division.standingsMap[props.selectedRound]?.standings.map(
+    const roundStandings =
+      division.standingsMap[props.selectedRound]?.standings;
+    const ranks = competitionRanks(roundStandings ?? []);
+    formatStandings = roundStandings?.map(
       (standing, index): StandingsTableData => {
         const [playerId, playerName] = standing.playerId.split(":");
         return {
           rank: index + 1,
+          displayRank: rankLabel(ranks[index], index + 1),
           player: (
             <>
               <UsernameWithContext
@@ -74,7 +82,7 @@ export const Standings = (props: Props) => {
   const columns = [
     {
       title: "",
-      dataIndex: "rank",
+      dataIndex: "displayRank",
       key: "rank",
       className: "rank",
     },

--- a/liwords-ui/src/tournament/standings.tsx
+++ b/liwords-ui/src/tournament/standings.tsx
@@ -28,6 +28,9 @@ export const Standings = (props: Props) => {
   const { tournamentContext } = useTournamentStoreContext();
   const { divisions } = tournamentContext;
   const [scorecardPlayer, setScorecardPlayer] = useState<string>();
+  // An in-real-life division holds names rather than accounts, so its "players"
+  // have no profile to open and cannot be befriended.
+  const irlMode = tournamentContext.metadata?.irlMode ?? false;
   const currentRound = useMemo(
     () =>
       divisions.hasOwnProperty(props.selectedDivision)
@@ -66,6 +69,8 @@ export const Standings = (props: Props) => {
                 userID={playerId}
                 omitSendMessage
                 omitBlock
+                omitProfileLink={irlMode}
+                omitFriend={irlMode}
                 infoText="View scorecard"
                 handleInfoText={() => setScorecardPlayer(standing.playerId)}
               />{" "}
@@ -143,7 +148,7 @@ export const Standings = (props: Props) => {
           division={division}
           playerId={scorecardPlayer}
           throughRound={props.selectedRound}
-          irlMode={tournamentContext.metadata?.irlMode ?? false}
+          irlMode={irlMode}
           onClose={() => setScorecardPlayer(undefined)}
           onSelectPlayer={setScorecardPlayer}
         />

--- a/liwords-ui/src/tournament/standings.tsx
+++ b/liwords-ui/src/tournament/standings.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useMemo } from "react";
 import { useTournamentStoreContext } from "../store/store";
 import { UsernameWithContext } from "../shared/usernameWithContext";
 import { Table } from "antd";
+import { signed } from "./format";
 import { competitionRanks, rankLabel } from "./ranks";
 // import { PlayerTag } from './player_tags';
 
@@ -105,10 +106,13 @@ export const Standings = (props: Props) => {
       className: "losses",
     },
     {
+      // Signed, so a spread of 50 cannot be read as a bare count. Already
+      // right-aligned.
       title: "Spread",
       dataIndex: "spread",
       key: "spread",
       className: "spread",
+      render: (spread: number) => signed(spread),
     },
     /*    {
       title: '',


### PR DESCRIPTION
## Summary

A director running an in-real-life event asked to see a player's round-by-round record on screen. Today the only route is regenerating the printable scorecards and reading the PDFs, which go stale the moment a result lands.

The browser already holds everything needed — `standingsMap` is populated for every round, not just the current one, and pairings carry opponents, outcomes and scores. Frontend only: no proto, no backend, no new queries.

**The Standings tab honors the round picker.** The Games tab has had one all along; on Standings it was suppressed by a three-line early return, so the table always rendered the current round.

**Clicking a player opens their scorecard** — one row per round through the round on screen: round, opponent, result, score with its margin inline, and the running W, L, spread and rank. It ends on the numbers of the standings row it was opened from, and an opponent's name opens theirs.

Three smaller commits ride along: tied players share a rank, the standings spread is signed, and the player menu drops View profile for in-real-life tournaments.

Shares its `matchMedia` test-setup fix with #1942 — identical, and a trial merge of master plus both branches is clean with the polyfill landing once.

## Changes

The shape is [toucanet's](https://www.toucanet.com/) player-tournament page — one row per round with a running record, margin and rank. The columns land close to what liwords's own printable scorecards emit (Round | Opponent | Won | Lost | Your Score | Opp Score | Spread), repacked into forms liwords already uses elsewhere. Your Score, Opp Score and the round's margin fold into `450-400 (+50)` from the league game history; W and L stay split and right-aligned like the standings table, since a drawn round puts a half in the record and 1.5 only lines up under 0 in its own column. The rank column is new — the printable scorecard doesn't have one, and neither did the standings.

Standings for an unopened round are not absent: they accumulate results so far, so the server answers for the tentative next round with a copy of the current one. The tab gates on the round rather than on the map, or that round would silently repeat the current table under its own heading. The round that *is* open is never gated, so standings stay live as its games finish.

A bye, a forfeit and a void round carry 0-0 or a stand-in spread. None of that is a score anybody played, so those rows show no score, stay out of the averages, and carry no first-move tag.

Ranks mark a shared place on the side the column is aligned to: `1=` in the left-aligned standings, `=1` in the right-aligned scorecard, so the digits stay in a line either way. The tie is on what the row shows — W, L, spread — not on the server's comparator, which sorts by win rate and would call 1-0 and 2-0 tied once byes leave players on different game counts.

## Bug

Following an opponent from inside a scorecard left escape dead. rc-dialog binds escape to a keydown handler on the dialog wrapper and refocuses only on the open transition; switching players re-renders rather than reopens, and the click came from a menu portalled outside the modal, so focus sat on the body. Fixed by refocusing the modal body whenever the player changes.

Separately, an in-real-life division holds real names against a hashed stand-in id that is never looked up, so the player menu's View profile pointed at `/profile/Some%20Real%20Name` — a 404 — and Add friend pointed at nobody. Both omitted in in-real-life mode. That one predates this branch.

## Deferred

- **Gibsonization** stays on the Games tab pairing rows. It is a pairing concept — a runaway leader paired against non-contenders — already per-round and reachable by walking rounds, so repeating it on every scorecard row is noise.
- **Auto-advancing the round picker** when a director opens a round. A player mid-round may want to finish looking at the current one, and the existing behavior is what muscle memory expects.
- Anything needing a backend change or a turn-level scan: high word, high-score leaderboards, cross-event head-to-head, lifetime records, score distributions, per-round ratings.
- Making the **Games tab** player names clickable. They are bare text today, so it means introducing a context menu into a cell that already stacks two names and up to four tags.

## Test plan

- `vitest` — 29 new tests across `standings.test.tsx`, `player_scorecard_modal.test.tsx` and `ranks.test.ts`, driven by the existing eight-round fixture plus a hand-built division covering byes, forfeits, void rounds, draws, an unfinished game and a removed opponent
- checked in a browser against locally seeded tournaments, both in-real-life and online: the picker across past, live and unopened rounds, a shared first place, a draw, the scorecard including following an opponent, and the player menu keeping its profile link in the online case
- `tsc --noEmit`, eslint, prettier — verified on each of the seven commits individually, not just the tip

`userEvent.keyboard("{Escape}")` cannot close an antd modal in tests: user-event omits the deprecated `keyCode` that rc-dialog checks. The escape tests fire at `document.activeElement` with an explicit keyCode, which also exercises the focus routing that was the bug.
