### PR TITLE
count a perfect game as analyzed

### DIFF
--- a/db/queries/leagues.sql
+++ b/db/queries/leagues.sql
@@ -589,15 +589,17 @@ SELECT DISTINCT ON (aj.game_id)
     aj.game_id,
     g.player0_id,
     g.player1_id,
-    (aj.result->'playerSummaries'->0->>'mistakeIndex')::DOUBLE PRECISION as player0_mistake_index,
-    (aj.result->'playerSummaries'->1->>'mistakeIndex')::DOUBLE PRECISION as player1_mistake_index
+    -- Stored as protojson, which drops a field that holds its zero value, so a
+    -- perfect game has no mistakeIndex key at all. A game counts as analyzed
+    -- when both summaries are there; a summary without the key means 0.
+    COALESCE(aj.result->'playerSummaries'->0->>'mistakeIndex', '0')::DOUBLE PRECISION as player0_mistake_index,
+    COALESCE(aj.result->'playerSummaries'->1->>'mistakeIndex', '0')::DOUBLE PRECISION as player1_mistake_index
 FROM analysis_jobs aj
 JOIN games g ON g.uuid = aj.game_id
 WHERE g.league_division_id = $1
   AND aj.status = 'completed'
-  AND aj.result IS NOT NULL
-  AND aj.result->'playerSummaries'->0->>'mistakeIndex' IS NOT NULL
-  AND aj.result->'playerSummaries'->1->>'mistakeIndex' IS NOT NULL
+  AND aj.result->'playerSummaries'->0 IS NOT NULL
+  AND aj.result->'playerSummaries'->1 IS NOT NULL
 ORDER BY aj.game_id, aj.completed_at DESC;
 
 -- name: GetGameLeagueInfo :one
@@ -641,14 +643,18 @@ FROM game_players gp_player
 INNER JOIN games g ON gp_player.game_uuid = g.uuid
 INNER JOIN users u_opponent ON gp_player.opponent_id = u_opponent.id
 LEFT JOIN LATERAL (
-    SELECT (CASE gp_player.player_index
-        WHEN 0 THEN aj.result->'playerSummaries'->0->>'mistakeIndex'
-        ELSE aj.result->'playerSummaries'->1->>'mistakeIndex'
-    END)::DOUBLE PRECISION AS mistake_index
+    -- The result is stored as protojson, which drops a field that holds its
+    -- zero value, so a perfect game has no mistakeIndex key at all. Presence
+    -- is therefore this player's summary, not the key inside it, and a
+    -- summary without the key means 0.
+    SELECT COALESCE(
+        aj.result->'playerSummaries'->gp_player.player_index::INT->>'mistakeIndex',
+        '0'
+    )::DOUBLE PRECISION AS mistake_index
     FROM analysis_jobs aj
     WHERE aj.game_id = gp_player.game_uuid
       AND aj.status = 'completed'
-      AND aj.result IS NOT NULL
+      AND aj.result->'playerSummaries'->gp_player.player_index::INT IS NOT NULL
     ORDER BY aj.completed_at DESC
     LIMIT 1
 ) mi ON true

--- a/pkg/analysis/league_analysis_test.go
+++ b/pkg/analysis/league_analysis_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/matryer/is"
+	"google.golang.org/protobuf/encoding/protojson"
 
+	macondopb "github.com/domino14/macondo/gen/api/proto/macondo"
 	"github.com/woogles-io/liwords/pkg/analysis"
 	"github.com/woogles-io/liwords/pkg/entity"
 	"github.com/woogles-io/liwords/pkg/stores/common"
@@ -429,6 +431,138 @@ func TestQueuePosition(t *testing.T) {
 	pos3, err := queries.GetQueuePosition(ctx, jobID3)
 	is.NoErr(err)
 	is.Equal(pos3, int32(2))
+}
+
+// insertLeagueGame adds a finished league game between users 1 and 2, with the
+// game_players rows the season queries read, and returns its id.
+func insertLeagueGame(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	leagueID, seasonID, divisionID uuid.UUID, playedAt time.Time,
+	player0Score, player1Score int) string {
+	is := is.New(t)
+
+	// Game ids are at most 24 characters.
+	gameID := "leaguegame" + uuid.New().String()[:10]
+	_, err := pool.Exec(ctx, `
+		INSERT INTO games(uuid, created_at, updated_at, player0_id, player1_id, started,
+		                  game_end_reason, type, game_request, history, quickdata, timers,
+		                  league_id, season_id, league_division_id)
+		VALUES ($1, $2, $2, 1, 2, true, $3, 0, '{}', '', '{}', '{}', $4, $5, $6)`,
+		gameID, playedAt, int(ipc.GameEndReason_STANDARD), leagueID, seasonID, divisionID)
+	is.NoErr(err)
+
+	for _, p := range []struct {
+		playerID, index, score, opponentID, opponentScore int
+	}{
+		{1, 0, player0Score, 2, player1Score},
+		{2, 1, player1Score, 1, player0Score},
+	} {
+		_, err = pool.Exec(ctx, `
+			INSERT INTO game_players(game_uuid, player_id, player_index, score, won,
+			                         game_end_reason, created_at, game_type, opponent_id,
+			                         opponent_score, league_season_id)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, 0, $8, $9, $10)`,
+			gameID, p.playerID, p.index, p.score, p.score > p.opponentScore,
+			int(ipc.GameEndReason_STANDARD), playedAt, p.opponentID, p.opponentScore, seasonID)
+		is.NoErr(err)
+	}
+
+	return gameID
+}
+
+// completeAnalysis stores result against gameID the way the worker path does,
+// through protojson.
+func completeAnalysis(t *testing.T, ctx context.Context, queries *models.Queries,
+	gameID string, result *macondopb.GameAnalysisResult) []byte {
+	is := is.New(t)
+
+	err := analysis.EnqueueGameForAnalysis(ctx, queries, gameID, 0)
+	is.NoErr(err)
+
+	workerUUID := pgtype.Text{String: "test-uuid-3", Valid: true}
+	job, err := queries.ClaimNextJob(ctx, workerUUID)
+	is.NoErr(err)
+
+	resultJSON, err := protojson.Marshal(result)
+	is.NoErr(err)
+
+	_, err = queries.CompleteJob(ctx, models.CompleteJobParams{
+		Result:            resultJSON,
+		ID:                job.ID,
+		ClaimedByUserUuid: workerUUID,
+	})
+	is.NoErr(err)
+
+	return resultJSON
+}
+
+// TestPerfectGameReadsBackAsAnalyzed covers a mistake index of 0 -- a perfect
+// game. protojson drops a field holding its zero value, so the stored result
+// has no mistakeIndex key at all, and reading presence off that key reported
+// the game as unanalyzed: the game history modal showed "-" and the season
+// recalculation dropped the game from both players' analyzed counts.
+func TestPerfectGameReadsBackAsAnalyzed(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	pool, queries := setupTestDB(t)
+	defer pool.Close()
+
+	createTestUsers(t, pool)
+	leagueID, seasonID, divisionID := createMinimalLeague(t, ctx, queries)
+
+	now := time.Now()
+	analyzed := insertLeagueGame(t, ctx, pool, leagueID, seasonID, divisionID,
+		now.Add(-time.Hour), 500, 288)
+	insertLeagueGame(t, ctx, pool, leagueID, seasonID, divisionID,
+		now.Add(-2*time.Hour), 400, 380)
+
+	resultJSON := completeAnalysis(t, ctx, queries, analyzed, &macondopb.GameAnalysisResult{
+		AnalysisVersion: 2,
+		PlayerSummaries: []*macondopb.PlayerSummary{
+			{PlayerName: "testuser1", MistakeIndex: 0},
+			{PlayerName: "testuser2", MistakeIndex: 2.2},
+		},
+	})
+
+	// The premise: the perfect player's summary carries no mistakeIndex key.
+	var stored struct {
+		PlayerSummaries []map[string]any `json:"playerSummaries"`
+	}
+	is.NoErr(json.Unmarshal(resultJSON, &stored))
+	_, present := stored.PlayerSummaries[0]["mistakeIndex"]
+	is.True(!present)
+
+	seasonUUID := pgtype.UUID{Bytes: seasonID, Valid: true}
+	// The perfect game is analyzed, and its index is 0 rather than missing.
+	// Games are newest first, so the unanalyzed one is second.
+	perfect, err := queries.GetPlayerSeasonGames(ctx, models.GetPlayerSeasonGamesParams{
+		UserUuid: "test-uuid-1",
+		SeasonID: seasonUUID,
+	})
+	is.NoErr(err)
+	is.Equal(len(perfect), 2)
+	is.Equal(perfect[0].GameUuid, analyzed)
+	is.Equal(perfect[0].HasMistakeIndex, true)
+	is.Equal(perfect[0].PlayerMistakeIndex, float64(0))
+	is.Equal(perfect[1].HasMistakeIndex, false)
+
+	// The opponent's own index still comes from their own summary.
+	opponent, err := queries.GetPlayerSeasonGames(ctx, models.GetPlayerSeasonGamesParams{
+		UserUuid: "test-uuid-2",
+		SeasonID: seasonUUID,
+	})
+	is.NoErr(err)
+	is.Equal(len(opponent), 2)
+	is.Equal(opponent[0].HasMistakeIndex, true)
+	is.Equal(opponent[0].PlayerMistakeIndex, 2.2)
+
+	// The season recalculation counts the game for both players.
+	games, err := queries.GetDivisionAnalyzedGames(ctx, pgtype.UUID{Bytes: divisionID, Valid: true})
+	is.NoErr(err)
+	is.Equal(len(games), 1)
+	is.Equal(games[0].GameID, analyzed)
+	is.Equal(games[0].Player0MistakeIndex, float64(0))
+	is.Equal(games[0].Player1MistakeIndex, 2.2)
 }
 
 // NOTE: Integration test for "league game finishes -> gets enqueued"

--- a/pkg/stores/models/leagues.sql.go
+++ b/pkg/stores/models/leagues.sql.go
@@ -425,15 +425,17 @@ SELECT DISTINCT ON (aj.game_id)
     aj.game_id,
     g.player0_id,
     g.player1_id,
-    (aj.result->'playerSummaries'->0->>'mistakeIndex')::DOUBLE PRECISION as player0_mistake_index,
-    (aj.result->'playerSummaries'->1->>'mistakeIndex')::DOUBLE PRECISION as player1_mistake_index
+    -- Stored as protojson, which drops a field that holds its zero value, so a
+    -- perfect game has no mistakeIndex key at all. A game counts as analyzed
+    -- when both summaries are there; a summary without the key means 0.
+    COALESCE(aj.result->'playerSummaries'->0->>'mistakeIndex', '0')::DOUBLE PRECISION as player0_mistake_index,
+    COALESCE(aj.result->'playerSummaries'->1->>'mistakeIndex', '0')::DOUBLE PRECISION as player1_mistake_index
 FROM analysis_jobs aj
 JOIN games g ON g.uuid = aj.game_id
 WHERE g.league_division_id = $1
   AND aj.status = 'completed'
-  AND aj.result IS NOT NULL
-  AND aj.result->'playerSummaries'->0->>'mistakeIndex' IS NOT NULL
-  AND aj.result->'playerSummaries'->1->>'mistakeIndex' IS NOT NULL
+  AND aj.result->'playerSummaries'->0 IS NOT NULL
+  AND aj.result->'playerSummaries'->1 IS NOT NULL
 ORDER BY aj.game_id, aj.completed_at DESC
 `
 
@@ -1431,14 +1433,18 @@ FROM game_players gp_player
 INNER JOIN games g ON gp_player.game_uuid = g.uuid
 INNER JOIN users u_opponent ON gp_player.opponent_id = u_opponent.id
 LEFT JOIN LATERAL (
-    SELECT (CASE gp_player.player_index
-        WHEN 0 THEN aj.result->'playerSummaries'->0->>'mistakeIndex'
-        ELSE aj.result->'playerSummaries'->1->>'mistakeIndex'
-    END)::DOUBLE PRECISION AS mistake_index
+    -- The result is stored as protojson, which drops a field that holds its
+    -- zero value, so a perfect game has no mistakeIndex key at all. Presence
+    -- is therefore this player's summary, not the key inside it, and a
+    -- summary without the key means 0.
+    SELECT COALESCE(
+        aj.result->'playerSummaries'->gp_player.player_index::INT->>'mistakeIndex',
+        '0'
+    )::DOUBLE PRECISION AS mistake_index
     FROM analysis_jobs aj
     WHERE aj.game_id = gp_player.game_uuid
       AND aj.status = 'completed'
-      AND aj.result IS NOT NULL
+      AND aj.result->'playerSummaries'->gp_player.player_index::INT IS NOT NULL
     ORDER BY aj.completed_at DESC
     LIMIT 1
 ) mi ON true


### PR DESCRIPTION
## Summary

A mistake index of 0 is a perfect game, but the league game history showed `-` for
it -- the placeholder that means "not analyzed yet" -- while the game screen shows
0.0 for the same game.

## Root cause

The analysis result is stored as protojson (`pkg/analysis/service.go`), and
`mistake_index` is a plain proto3 `double`, so a value of 0 is dropped from the
JSON entirely: a perfect player's summary carries no `mistakeIndex` key at all.
Both league queries took presence from that key.

## Impact

- `GetPlayerSeasonGames`: `has_mistake_index` came back false, so the game history
  showed `-`.
- `GetDivisionAnalyzedGames`: the game was skipped outright, so
  `RecalculateSeasonMistakeIndex` docked **both** players one game from
  `games_analyzed` and so raised their average. That recalculation is the last
  step of `CancelPlayerResults`, so canceling a cheater's results quietly
  worsened the MiAV of anyone holding a perfect game.
- The live path (`IncrementStandingMistakeIndex` when an analysis completes) reads
  the number off the proto and was always counting these, so standings only went
  wrong once a recalculation ran.

## Changes

Presence now comes from the player's summary object, which is there whenever the
game has a completed analysis, and a missing `mistakeIndex` key reads as the 0 it
stands for. Read-side only, so it repairs the rows already stored: no migration,
no backfill. Seasons already docked by an earlier recalculation come right the
next time one runs.

sqlc note: `COALESCE(x::DOUBLE PRECISION, 0)` makes sqlc emit `interface{}`.
Coalescing the text and casting the result keeps `float64`, so no Go caller
changes.

## Test plan

- `go test ./pkg/analysis/ -run TestPerfectGameReadsBackAsAnalyzed` -- new and
  DB-backed: stores a result through protojson with one player at 0, then asserts
  the game history query reports it analyzed with 0 while an unanalyzed game still
  reports nothing, and that the recalculation query counts the game for both
  players. Confirmed it fails with the query change reverted.
- `go test ./pkg/analysis/ ./pkg/league/`
- On a local stack with a seeded perfect game: `GetPlayerSeasonGames` returns
  `"mistake_index": 0`, and over the same season the old predicate matched 111 of
  112 analyzed games where the new one matches all 112.
