### PR TITLE
compute the phony report when the lexicon arrives late

### DIFF
--- a/liwords-ui/src/utils/hooks/definitions.test.tsx
+++ b/liwords-ui/src/utils/hooks/definitions.test.tsx
@@ -1,0 +1,80 @@
+import { create } from "@bufbuild/protobuf";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GameEventSchema } from "../../gen/api/proto/vendored/macondo/macondo_pb";
+import type { ChatEntityObj } from "../../store/constants";
+import type { GameState } from "../../store/reducers/game_reducer";
+import { useDefinitionAndPhonyChecker } from "./definitions";
+
+// The hook's only network call. An unknown lexicon is an error, the way the
+// real service answers one, so a request made before the lexicon is known
+// cannot stand in for the one made after.
+const mock = vi.hoisted(() => ({ defineWords: vi.fn() }));
+
+vi.mock("./connect", () => ({
+  useClient: () => ({ defineWords: mock.defineWords }),
+}));
+
+const PHONY = "UNCENSOR";
+
+// Only turns are read off the game context.
+const gameContext = {
+  turns: [
+    create(GameEventSchema, { wordsFormed: ["KOOLAHS", "FETTS"] }),
+    create(GameEventSchema, { wordsFormed: [PHONY] }),
+  ],
+} as unknown as GameState;
+
+const renderChecker = (
+  addChat: (chat: ChatEntityObj) => void,
+  lexicon: string,
+) =>
+  renderHook(
+    ({ lexicon }: { lexicon: string }) =>
+      useDefinitionAndPhonyChecker({
+        addChat,
+        enableHoverDefine: true,
+        gameContext,
+        gameDone: true,
+        gameID: "annogame",
+        lexicon,
+        variant: undefined,
+      }),
+    { initialProps: { lexicon } },
+  );
+
+describe("the phony checker", () => {
+  beforeEach(() => {
+    mock.defineWords.mockReset();
+    mock.defineWords.mockImplementation(
+      async ({ lexicon, words }: { lexicon: string; words: string[] }) => {
+        if (!lexicon) throw new Error("unknown lexicon");
+        return {
+          results: Object.fromEntries(
+            words.map((word) => [word, { v: word !== PHONY, d: "" }]),
+          ),
+        };
+      },
+    );
+  });
+
+  it("reports phonies when the lexicon is known from the start", async () => {
+    const addChat = vi.fn();
+    renderChecker(addChat, "CSW24");
+    await waitFor(() => expect(addChat).toHaveBeenCalled());
+    expect(addChat.mock.calls[0][0].message).toContain(`${PHONY}*`);
+  });
+
+  it("reports phonies when the lexicon arrives after the game", async () => {
+    // The metadata carrying the lexicon can land after the game document, which
+    // is what an annotated game does in production: the checker is set up
+    // against an empty lexicon, then told the real one.
+    const addChat = vi.fn();
+    const { rerender } = renderChecker(addChat, "");
+    await act(async () => {
+      rerender({ lexicon: "CSW24" });
+    });
+    await waitFor(() => expect(addChat).toHaveBeenCalled());
+    expect(addChat.mock.calls[0][0].message).toContain(`${PHONY}*`);
+  });
+});

--- a/liwords-ui/src/utils/hooks/definitions.tsx
+++ b/liwords-ui/src/utils/hooks/definitions.tsx
@@ -231,32 +231,48 @@ export const useDefinitionAndPhonyChecker = ({
     return words;
   }, [gameContext]);
 
-  useEffect(() => {
-    // forget everything if it goes to a new game
-    console.log(
-      "[phony-debug] RESET effect fire, gameID:",
-      gameID,
-      "lexicon:",
-      lexicon,
-    );
-    setWordInfo({});
-    // playedWords is derived from gameContext via the useMemo above -- there is
-    // nothing to clear here. The old setPlayedWords(new Set()) raced with that
-    // derivation and could leave playedWords stale-empty in production, which is
-    // why the phony report never computed.
-    setUnrace(new Unrace());
-    setPhonies(undefined);
-    setShowDefinitionHover(undefined);
-  }, [gameID, lexicon]);
+  // What everything below is about: the game being looked at, and the lexicon
+  // its words are judged against.
+  const resetKey = `${gameID ?? ""} ${lexicon}`;
+  const resetKeyRef = useRef(resetKey);
 
+  // Forgetting the old game and listing the current one's words to define are
+  // one effect on purpose. They used to be two, and the listing one re-ran only
+  // when playedWords, gameDone or showDefinitionHover changed. So a reset
+  // landing after it -- an annotated game whose metadata, and with it the
+  // lexicon, arrives after the game document -- cleared the list with nothing
+  // left to rebuild it, and the phony report never computed. Opening a
+  // definition was the way out, since that moved showDefinitionHover.
   useEffect(() => {
+    const isReset = resetKeyRef.current !== resetKey;
+    if (isReset) {
+      // forget everything if it goes to a new game
+      console.log(
+        "[phony-debug] RESET effect fire, gameID:",
+        gameID,
+        "lexicon:",
+        lexicon,
+      );
+      resetKeyRef.current = resetKey;
+      setWordInfo({});
+      // playedWords is derived from gameContext via the useMemo above -- there
+      // is nothing to clear here. The old setPlayedWords(new Set()) raced with
+      // that derivation and could leave playedWords stale-empty in production,
+      // which is why the phony report never computed.
+      setUnrace(new Unrace());
+      setPhonies(undefined);
+      setShowDefinitionHover(undefined);
+    }
+    // A reset clears the hover too, so this render's one is on its way out --
+    // its words belong to the game being left behind.
+    const hover = isReset ? undefined : showDefinitionHover;
     console.log(
       "[phony-debug] compute-wordInfo effect, gameDone:",
       gameDone,
       "playedWords.size:",
       playedWords.size,
     );
-    if (gameDone || showDefinitionHover) {
+    if (gameDone || hover) {
       // when definition is requested, get definitions for all words (up to
       // that point) that have not yet been defined. this is an intentional
       // design decision to improve usability and responsiveness.
@@ -268,9 +284,9 @@ export const useDefinitionAndPhonyChecker = ({
             wordInfo[word] = undefined;
           }
         });
-        if (showDefinitionHover) {
+        if (hover) {
           // also define tentative words (mostly from examiner) if no undesignated blanks.
-          for (const word of showDefinitionHover.words) {
+          for (const word of hover.words) {
             if (!word.includes(Blank)) {
               const uppercasedWord = word.toUpperCase();
               if (!(uppercasedWord in wordInfo)) {
@@ -284,7 +300,7 @@ export const useDefinitionAndPhonyChecker = ({
         return wordInfo;
       });
     }
-  }, [playedWords, gameDone, showDefinitionHover]);
+  }, [resetKey, gameID, lexicon, playedWords, gameDone, showDefinitionHover]);
 
   const wordClient = useClient(WordService);
 


### PR DESCRIPTION
## Summary

An annotated game posted no phony report. Opening any definition posted it
immediately, which is the shape of the bug: the report was never computed, not
computed and lost.

Follows #1939, which fixed a different way the same report could strand, and
keeps the instrumentation from #1919 in place -- see Deferred.

## Root cause

`useDefinitionAndPhonyChecker` had two effects sharing one piece of state:

- reset, on `[gameID, lexicon]`: clears `wordInfo` and `phonies`
- seed, on `[playedWords, gameDone, showDefinitionHover]`: lists the game's words
  into `wordInfo` as undefined, which is what starts the definition fetch and,
  through it, the report

`table.tsx` passes `gameInfo.gameRequest?.lexicon ?? ""`, so the lexicon is `""`
until the metadata request lands, and on an annotated game that can land after
the game document. The reset then runs last, clears the seeded list, and the
seed cannot re-run: `playedWords` is the same memoized Set, `gameDone` is still
true, `showDefinitionHover` is still undefined. Two resets show up in the console
for one page load, the second with the real lexicon, after which `wordInfo keys`
sits at 0 for good.

Opening a definition moves `showDefinitionHover` -- the only one of those three a
reader can move -- so the seed re-ran and the whole chain fired at once.

## Changes

Reset and seed become one effect keyed on `gameID|lexicon`, so a reset always
rebuilds in the same commit rather than depending on a later dependency change to
put the words back. A reset also drops the hover, so the pass that carries one
out ignores the hover it still holds: those words belong to the game being left.

## Test plan

- `vitest src/utils/hooks/definitions.test.tsx` -- new. Drives the hook the way
  production orders it: set up against an empty lexicon, whose lookups fail the
  way the service answers an unknown one, then handed the real lexicon. Fails on
  the two-effect version, passes here. A control case with the lexicon known at
  mount passes either way, so the test pins the ordering rather than the feature.
- `tsc --noEmit`, eslint and prettier clean; full frontend suite green.
- Not reproduced in a browser: no annotated game exists locally, and local
  timing does not produce the ordering on its own -- it takes an artificial
  delay on the lexicon prop. The console from the reported game is what the test
  encodes.

## Deferred

- The `[phony-debug]` logs from #1919 stay until this is confirmed in
  production. With no interaction, the fix reads as `wordInfo keys` going 0 ->
  59 after the last RESET, followed by `post effect, phonies: [...]`. If the
  keys stay at 0, this fix missed and something else is resetting.
- A channel load still replaces the whole chat array (`addChats` does
  `setChat([...entities])`), so client-posted entries -- the phony report,
  challenge results -- do not survive one. On a normal load the history is a
  single round trip from mount while the report needs the game document, the
  metadata and `defineWords` in sequence, so the report lands after it;
  switching chat channels and coming back still drops it. Separate fix, and it
  needs a decision: keeping `channel: "server"` entries across a load would also
  carry them into whatever channel you switch to.
