### PR TITLE
Simplify new developer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,29 +61,37 @@ You can do `docker compose up app` and `docker compose up frontend` in two diffe
 
 <summary>Using a hybrid stack on Docker</summary>
 
-**NOTE: These instructions need to be updated and might not work currently.**
-
+In this setup, Docker runs only the long-running services (postgres, Redis, NATS, via `dc-local-services.yml`), and the Go servers and frontend run natively on your machine. The frontend dev server (port 3000) proxies `/api` and `/ws`.
 
 1. Download Docker for your operating system
 2. Download the latest stable version of Node.js for your operating system and install it
 3. Download and install Go from golang.org
-4. Copy the `local_skeleton.env` file in this directory to `local.env`, and modify the copy to match your local paths. (See all the variables ending in _PATH).
-5. Open up a few tabs or panels in your terminal so you can bring up the services separately. In each tab, you can do `source local.env`, or alternatively you can put this command in your profile to do it automatically.
-6. Bring up the `dc-local-services.yml` file with `docker compose -f dc-local-services.yml up` in one tab.
-7. You can bring up the other services in your other tabs:
+4. Clone the `macondo` repository from `https://github.com/domino14/macondo`, and place it at the same level as this repo.
+5. Copy the `local_skeleton.env` file in this directory to `local.env`, and modify the copy to match your local paths. (See all the variables ending in \_PATH).
+6. Run `./scripts/dev-hybrid.sh`. It brings up the Docker services, waits for postgres, and then runs the API server, socket server, and frontend together in one terminal, with prefixed logs. Add `--bot` to also run the macondo bot. Ctrl-C stops the local processes (the Docker services are left running; stop them with `docker compose -f dc-local-services.yml stop`).
+7. Go to `http://localhost:3000` to see Woogles.
+8. You can register a user by clicking on `SIGN UP` at the top right.
+
+To have two players play each other you must have one browser window in incognito mode, or use another browser.
+
+9. To register a bot, register a user the regular way. Then run the following, replacing the `$1` with the bot username you just registered.
+
+`docker compose -f dc-local-services.yml exec db psql -U postgres liwords -c "UPDATE users SET internal_bot='t' WHERE username = '$1';"`
+
+**Running the services by hand**
+
+If you'd rather run the services in separate terminal tabs instead of using the script, do `source local.env` in each tab, bring up `docker compose -f dc-local-services.yml up` in one of them, and then:
+
 - For the api server, do `go run cmd/liwords-api/*.go`
 - For the socket server, do `go run cmd/socketsrv/main.go`
 - For the frontend, do `npm start` in the `liwords-ui` directory.
 - For the bot, do `go run cmd/bot/*.go` in the `macondo` directory.
 
-8. Go to `http://localhost:3000` to see Woogles.
-9. You can register a user by clicking on `SIGN UP` at the top right.
+**Notes and troubleshooting**
 
-To have two players play each other you must have one browser window in incognito mode, or use another browser.
-
-10. To register a bot, register a user the regular way. Then run this following script, replacing the `$1` with the bot username you just registered.
-
-`docker compose exec db psql -U postgres liwords -c "UPDATE users SET internal_bot='t' WHERE username = '$1';"`
+- Both `docker-compose.yml` and `dc-local-services.yml` run under the same Docker compose project name, so they share the same postgres data volume. Keep the `db` service definitions (especially the pinned image version) in sync between the two files — a newer postgres major version will refuse to start on a data volume initialized by an older one. For the same reason, don't run both stacks at the same time (they also both publish NATS on port 4222).
+- _ERROR: relation "users" does not exist_: migrations haven't run. Make sure `RUN_MIGRATIONS=1` is in your `local.env` (see `local_skeleton.env`) and restart the API server.
+- _"Please verify your email address" on login_: the user was registered while the API server was running without `SKIP_EMAIL_VERIFICATION=1`. Add it and restart, then mark the existing user verified: `docker compose -f dc-local-services.yml exec db psql -U postgres liwords -c "UPDATE users SET verified='t' WHERE username='<name>';"`
 
 </details>
 

--- a/dc-local-services.yml
+++ b/dc-local-services.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   nats:
     image: "nats"
@@ -19,7 +17,7 @@ services:
       - aeronet
 
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       POSTGRES_PASSWORD: pass

--- a/liwords-ui/rsbuild.config.ts
+++ b/liwords-ui/rsbuild.config.ts
@@ -13,7 +13,17 @@ export default {
   dev: { client: { overlay: false } },
   // rsbuild 2's dev server binds localhost only by default; expose it on all
   // interfaces so the docker-compose proxy (frontend service) can reach it.
-  server: { host: "0.0.0.0" },
+  server: {
+    host: "0.0.0.0",
+    proxy: {
+      "/api": "http://localhost:8001",
+      "/gameimg": "http://localhost:8001",
+      "/debug": "http://localhost:8001",
+      "/integrations": "http://localhost:8001",
+      "/embed": "http://localhost:8001",
+      "/ws": { target: "http://localhost:8087", ws: true },
+    },
+  },
   html: {
     template: "./index.html",
   },

--- a/local_skeleton.env
+++ b/local_skeleton.env
@@ -21,6 +21,9 @@ export DEBUG=1
 export REGISTRATION_CODE=foobar
 export ARGON_MEMORY=1024
 
-export WDS_SOCKET_PORT=0
-export WDS_SOCKET_PATH=/wds-socket
-export WDS_PROXY=true
+# Run database migrations when the API server starts up.
+export RUN_MIGRATIONS=1
+# Create new users pre-verified instead of requiring an email verification
+# link, and print outgoing emails to stdout instead of sending them via SES.
+export SKIP_EMAIL_VERIFICATION=1
+export EMAIL_DEBUG=true

--- a/scripts/dev-hybrid.sh
+++ b/scripts/dev-hybrid.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Runs the entire hybrid dev stack in a single terminal:
+#   - docker services (postgres, redis, NATS) via dc-local-services.yml
+#   - the liwords API server (go)
+#   - the socket server (go)
+#   - the frontend dev server (rsbuild, port 3000)
+#   - optionally, the macondo bot (pass --bot)
+#
+# Ctrl-C stops the local processes; the docker services are left running
+# (stop them with `docker compose -f dc-local-services.yml stop`).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -f local.env ]]; then
+  echo "local.env not found." >&2
+  echo "Copy local_skeleton.env to local.env and adjust the _PATH variables first." >&2
+  exit 1
+fi
+source local.env
+
+WITH_BOT=0
+for arg in "$@"; do
+  case "$arg" in
+    --bot) WITH_BOT=1 ;;
+    *) echo "unknown argument: $arg (supported: --bot)" >&2; exit 1 ;;
+  esac
+done
+
+if [[ "$WITH_BOT" == 1 && ! -d ../macondo ]]; then
+  echo "--bot requires the macondo repo checked out next to liwords." >&2
+  exit 1
+fi
+
+echo "==> Starting docker services (postgres, redis, NATS)..."
+docker compose -f dc-local-services.yml up -d nats redis db
+
+printf "==> Waiting for postgres to be ready"
+until docker compose -f dc-local-services.yml exec -T db pg_isready -U postgres -q 2>/dev/null; do
+  printf "."
+  sleep 1
+done
+echo " ready."
+
+if [[ ! -d liwords-ui/node_modules ]]; then
+  echo "==> Installing frontend dependencies (first run)..."
+  (cd liwords-ui && npm install)
+fi
+
+CYAN=$'\033[36m'; MAGENTA=$'\033[35m'; YELLOW=$'\033[33m'; GREEN=$'\033[32m'; RESET=$'\033[0m'
+label() { sed -e "s/^/$1 /"; }
+
+echo "==> Starting api, socket, and frontend. Ctrl-C stops everything."
+
+go run cmd/liwords-api/*.go 2>&1 | label "${CYAN}[api]${RESET}   " &
+go run cmd/socketsrv/main.go 2>&1 | label "${MAGENTA}[socket]${RESET}" &
+(cd liwords-ui && npm start) 2>&1 | label "${YELLOW}[fe]${RESET}    " &
+
+if [[ "$WITH_BOT" == 1 ]]; then
+  (cd ../macondo && MACONDO_NATS_URL=nats://localhost:4222 go run cmd/bot/*.go) \
+    2>&1 | label "${GREEN}[bot]${RESET}   " &
+fi
+
+cleanup() {
+  trap - INT TERM
+  echo
+  echo "==> Shutting down local processes..."
+  # Kill our whole process group (api, socket, frontend, bot, and the sed
+  # labelers). Docker services stay up.
+  kill 0
+}
+trap cleanup INT TERM
+
+echo "==> Woogles will be at http://localhost:3000 once the frontend compiles."
+wait


### PR DESCRIPTION
- Update README with lessons learned from getting this working.
- Add shell script to start the whole hybrid stack
- Add proxy config to node for hybrid stack
- Pin postgres to v17, since it shares schema with the full stack
- Add RUN_MIGRATIONS and SKIP_EMAIL_VERIFICATION to local config