### PR TITLE
recall tiles when our own play is challenged off

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -393,6 +393,7 @@ export const BoardPanel = React.memo((props: Props) => {
 
   const clearBackupRef = useRef<boolean>(false);
   const lastLettersRef = useRef<Array<MachineLetter>>(undefined);
+  const lastNumEventsRef = useRef<number>(undefined);
   const lastRackRef = useRef<Array<MachineLetter>>(undefined);
   const lastIsExaminingRef = useRef<boolean>(undefined);
   const readOnlyEffectDependenciesRef = useRef<{
@@ -427,6 +428,10 @@ export const BoardPanel = React.memo((props: Props) => {
     let fullReset = false;
     const lastLetters = lastLettersRef.current;
     const dep = readOnlyEffectDependenciesRef.current!;
+    // Several events can arrive in the same packet, in which case the board
+    // never renders in between them. Watching the board alone is therefore
+    // not enough to tell a move apart from a mere refresher.
+    const numEventsChanged = lastNumEventsRef.current !== props.events.length;
     if (lastLetters === undefined) {
       // First load.
       fullReset = true;
@@ -455,6 +460,11 @@ export const BoardPanel = React.memo((props: Props) => {
     } else if (isExamining) {
       // Prevent stuck tiles.
       fullReset = true;
+    } else if (numEventsChanged && clearBackupRef.current) {
+      // We have committed a move and the game has moved on since. Whatever is
+      // still placed is a leftover of that move, even when the board looks
+      // untouched, so recall it.
+      fullReset = true;
     } else if (!dep.isMyTurn) {
       // Opponent's turn usually means we have just made a move. (Assumption:
       // there are only two players.) But a GameHistoryRefresher can also
@@ -464,7 +474,7 @@ export const BoardPanel = React.memo((props: Props) => {
       const lettersChanged =
         lastLetters.length !== props.board.letters.length ||
         lastLetters.some((ml, idx) => ml !== props.board.letters[idx]);
-      if (lettersChanged) {
+      if (lettersChanged || numEventsChanged) {
         fullReset = true;
       }
     } else {
@@ -574,6 +584,7 @@ export const BoardPanel = React.memo((props: Props) => {
       }
     }
     lastLettersRef.current = props.board.letters;
+    lastNumEventsRef.current = props.events.length;
     lastRackRef.current = props.currentRack;
   }, [
     isExamining,
@@ -581,6 +592,7 @@ export const BoardPanel = React.memo((props: Props) => {
     props.board.letters,
     props.boardEditingMode,
     props.currentRack,
+    props.events.length,
     props.puzzleMode,
     setArrowProperties,
     setDisplayedRack,

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -78,7 +78,12 @@ import { useClient } from "../utils/hooks/connect";
 import { GameMetadataService } from "../gen/api/proto/game_service/game_service_pb";
 
 import { RackEditor } from "./rack_editor";
-import { shuffleLetters, gcgExport, backupKey } from "./board_panel_utils";
+import {
+  shuffleLetters,
+  gcgExport,
+  backupKey,
+  needsFullReset,
+} from "./board_panel_utils";
 import { handleBlindfoldKeydown } from "./blindfold_mode";
 import { useBoardPanelState } from "./useBoardPanelState";
 import { useTilePlacement } from "./useTilePlacement";
@@ -425,106 +430,26 @@ export const BoardPanel = React.memo((props: Props) => {
       lastIsExaminingRef.current = isExamining;
       backupStatesRef.current.clear();
     }
-    let fullReset = false;
     const lastLetters = lastLettersRef.current;
     const dep = readOnlyEffectDependenciesRef.current!;
-    // Several events can arrive in the same packet, in which case the board
-    // never renders in between them. Watching the board alone is therefore
-    // not enough to tell a move apart from a mere refresher.
-    const numEventsChanged = lastNumEventsRef.current !== props.events.length;
-    if (lastLetters === undefined) {
-      // First load.
-      fullReset = true;
-    } else if (props.puzzleMode) {
-      // XXX: Without this, when exiting from examining an earlier turn on
-      // puzzle mode, it does not reset the rack to the latest rack. Why?
-      fullReset = true;
-    } else if (props.boardEditingMode) {
-      // See comment above. I don't know why it doesn't show the latest rack
-      // when we edit more than once.
-      fullReset = true;
-    } else if (
-      JSON.stringify(
-        [
-          ...[...dep.placedTiles].map((ephemeralTile) => {
-            const ml = ephemeralTile.letter;
-            return (ml & 0x80) !== 0 ? 0 : ml;
-          }),
-          ...dep.displayedRack.filter((ml) => ml !== 0x80),
-        ].sort(),
-      ) !== JSON.stringify([...props.currentRack].sort())
-    ) {
-      // First load after receiving rack.
-      // Or other cases where the tiles don't match up.
-      fullReset = true;
-    } else if (isExamining) {
-      // Prevent stuck tiles.
-      fullReset = true;
-    } else if (numEventsChanged && clearBackupRef.current) {
-      // We have committed a move and the game has moved on since. Whatever is
-      // still placed is a leftover of that move, even when the board looks
-      // untouched, so recall it.
-      fullReset = true;
-    } else if (!dep.isMyTurn) {
-      // Opponent's turn usually means we have just made a move. (Assumption:
-      // there are only two players.) But a GameHistoryRefresher can also
-      // arrive mid-turn without any move being made (e.g. the opponent's
-      // clock was given more time), in which case the board is unchanged and
-      // tentatively placed tiles should be left alone.
-      const lettersChanged =
-        lastLetters.length !== props.board.letters.length ||
-        lastLetters.some((ml, idx) => ml !== props.board.letters[idx]);
-      if (lettersChanged || numEventsChanged) {
-        fullReset = true;
-      }
-    } else {
-      // Opponent just did something. Check if it affects any premove.
-      // TODO: revisit when supporting non-square boards.
-      const letterAt = (
-        row: number,
-        col: number,
-        letters: Array<MachineLetter>,
-      ) =>
-        row < 0 || row >= dep.dim || col < 0 || col >= dep.dim
-          ? null
-          : letters[row * dep.dim + col];
-      const letterChanged = (row: number, col: number) =>
-        letterAt(row, col, lastLetters) !==
-        letterAt(row, col, props.board.letters);
-      const hookChanged = (
-        row: number,
-        col: number,
-        drow: number,
-        dcol: number,
-      ) => {
-        while (true) {
-          row += drow;
-          col += dcol;
-          if (letterChanged(row, col)) return true;
-          const letter = letterAt(row, col, props.board.letters);
-          if (letter === null || letter === EmptyBoardSpaceMachineLetter) {
-            return false;
-          }
-        }
-      };
-      const placedTileAffected = (row: number, col: number) =>
-        letterChanged(row, col) ||
-        hookChanged(row, col, -1, 0) ||
-        hookChanged(row, col, +1, 0) ||
-        hookChanged(row, col, 0, -1) ||
-        hookChanged(row, col, 0, +1);
-      // If no tiles have been placed, but placement arrow is shown,
-      // reset based on if that position is affected.
-      // This avoids having the placement arrow behind a tile.
-      if (
-        (dep.placedTiles.size === 0 && dep.arrowProperties.show
-          ? [dep.arrowProperties as { row: number; col: number }]
-          : Array.from(dep.placedTiles)
-        ).some(({ row, col }) => placedTileAffected(row, col))
-      ) {
-        fullReset = true;
-      }
-    }
+    const fullReset = needsFullReset({
+      lastLetters,
+      letters: props.board.letters,
+      dim: dep.dim,
+      currentRack: props.currentRack,
+      displayedRack: dep.displayedRack,
+      placedTiles: dep.placedTiles,
+      arrowProperties: dep.arrowProperties,
+      isMyTurn: dep.isMyTurn,
+      isExamining,
+      puzzleMode: props.puzzleMode,
+      boardEditingMode: props.boardEditingMode,
+      // Several events can arrive in the same packet, in which case the board
+      // never renders in between them. Watching the board alone is therefore
+      // not enough to tell a move apart from a mere refresher.
+      numEventsChanged: lastNumEventsRef.current !== props.events.length,
+      justCommitted: clearBackupRef.current,
+    });
     const bak = backupStatesRef.current.get(
       backupKey(props.board.letters, props.currentRack),
     );

--- a/liwords-ui/src/gameroom/board_panel_utils.test.ts
+++ b/liwords-ui/src/gameroom/board_panel_utils.test.ts
@@ -135,3 +135,32 @@ it("resets when the opponent plays where the placement arrow is", () => {
     ),
   ).toBe(true);
 });
+
+// The premove backed up when the opponent's phony displaced it (the hooking
+// case above) is reinstated by the caller once the board and the rack are back
+// at their backed up values. That only happens while we say no reset is
+// needed, so the rest of the sequence has to keep saying no: clock changes
+// either way, then challenging the phony off.
+describe("reinstating a premove the opponent's phony displaced", () => {
+  const displaced = () =>
+    inputs({
+      lastLetters: withWord(emptyBoard(), 6, 7, "QIS"),
+      letters: withWord(emptyBoard(), 6, 7, "QIS"),
+      placedTiles: new Set<EphemeralTile>(),
+      displayedRack: [3, 1, 20, 5, 19, 9, 14],
+    });
+
+  it("keeps out of the way when either player is given time", () => {
+    expect(needsFullReset(displaced())).toBe(false);
+  });
+
+  it("keeps out of the way when the phony is challenged off", () => {
+    expect(
+      needsFullReset({
+        ...displaced(),
+        letters: emptyBoard(),
+        numEventsChanged: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/liwords-ui/src/gameroom/board_panel_utils.test.ts
+++ b/liwords-ui/src/gameroom/board_panel_utils.test.ts
@@ -1,0 +1,137 @@
+import { FullResetInputs, needsFullReset } from "./board_panel_utils";
+import { EphemeralTile, MachineLetter } from "../utils/cwgame/common";
+
+const dim = 15;
+
+const emptyBoard = () => new Array<MachineLetter>(dim * dim).fill(0);
+
+// Place a word on a copy of the given board, going across.
+const withWord = (
+  letters: Array<MachineLetter>,
+  row: number,
+  col: number,
+  word: string,
+) => {
+  const newLetters = [...letters];
+  for (let i = 0; i < word.length; ++i) {
+    newLetters[row * dim + col + i] = word.charCodeAt(i) - 64;
+  }
+  return newLetters;
+};
+
+// CAT tentatively placed at the star, ESIN still on the rack.
+const placedCat = () =>
+  new Set<EphemeralTile>([
+    { row: 7, col: 7, letter: 3 },
+    { row: 7, col: 8, letter: 1 },
+    { row: 7, col: 9, letter: 20 },
+  ]);
+
+const inputs = (overrides: Partial<FullResetInputs> = {}): FullResetInputs => ({
+  lastLetters: emptyBoard(),
+  letters: emptyBoard(),
+  dim,
+  currentRack: [3, 1, 20, 5, 19, 9, 14],
+  displayedRack: [5, 19, 9, 14],
+  placedTiles: placedCat(),
+  arrowProperties: { row: 0, col: 0, show: false },
+  isMyTurn: true,
+  isExamining: false,
+  puzzleMode: false,
+  boardEditingMode: false,
+  numEventsChanged: false,
+  justCommitted: false,
+  ...overrides,
+});
+
+it("resets on first load", () => {
+  expect(needsFullReset(inputs({ lastLetters: undefined }))).toBe(true);
+});
+
+it("resets when the tiles do not add up to the rack", () => {
+  expect(needsFullReset(inputs({ currentRack: [1, 2, 3, 4, 5, 6, 7] }))).toBe(
+    true,
+  );
+});
+
+it("resets while examining", () => {
+  expect(needsFullReset(inputs({ isExamining: true }))).toBe(true);
+});
+
+// A GameHistoryRefresher for a clock change adds no events and leaves the
+// board alone, so a premove placed while off turn must survive it.
+it("keeps placed tiles when clock time is added off turn", () => {
+  expect(needsFullReset(inputs({ isMyTurn: false }))).toBe(false);
+});
+
+// Our play and the challenge that took it off can arrive in the same packet,
+// leaving the board and the rack exactly as they were before we played.
+it("resets when our play is challenged off without the board ever changing", () => {
+  expect(
+    needsFullReset(
+      inputs({ isMyTurn: false, numEventsChanged: true, justCommitted: true }),
+    ),
+  ).toBe(true);
+});
+
+it("resets when we are off turn because the game gained events", () => {
+  expect(
+    needsFullReset(inputs({ isMyTurn: false, numEventsChanged: true })),
+  ).toBe(true);
+});
+
+// Same packet again, this time also carrying the opponent's reply, so we are
+// back on turn with our committed tiles still sitting there.
+it("resets when the game moves on from a move we committed", () => {
+  expect(
+    needsFullReset(inputs({ numEventsChanged: true, justCommitted: true })),
+  ).toBe(true);
+});
+
+// The premove backup exists precisely to survive this, so leave it be.
+it("keeps a premove when a play elsewhere is challenged off", () => {
+  expect(
+    needsFullReset(
+      inputs({
+        lastLetters: withWord(emptyBoard(), 0, 0, "QIS"),
+        numEventsChanged: true,
+      }),
+    ),
+  ).toBe(false);
+});
+
+it("keeps a premove the opponent's play does not touch", () => {
+  expect(
+    needsFullReset(
+      inputs({
+        letters: withWord(emptyBoard(), 0, 0, "QIS"),
+        numEventsChanged: true,
+      }),
+    ),
+  ).toBe(false);
+});
+
+it("resets a premove the opponent's play hooks onto", () => {
+  expect(
+    needsFullReset(
+      inputs({
+        letters: withWord(emptyBoard(), 6, 7, "QIS"),
+        numEventsChanged: true,
+      }),
+    ),
+  ).toBe(true);
+});
+
+it("resets when the opponent plays where the placement arrow is", () => {
+  expect(
+    needsFullReset(
+      inputs({
+        currentRack: [5, 19, 9, 14],
+        placedTiles: new Set<EphemeralTile>(),
+        arrowProperties: { row: 7, col: 7, show: true },
+        letters: withWord(emptyBoard(), 7, 7, "QIS"),
+        numEventsChanged: true,
+      }),
+    ),
+  ).toBe(true);
+});

--- a/liwords-ui/src/gameroom/board_panel_utils.ts
+++ b/liwords-ui/src/gameroom/board_panel_utils.ts
@@ -1,6 +1,8 @@
 import {
   MachineLetter,
+  EmptyBoardSpaceMachineLetter,
   EmptyRackSpaceMachineLetter,
+  EphemeralTile,
 } from "../utils/cwgame/common";
 import { PlayerInfo } from "../gen/api/proto/ipc/omgwords_pb";
 import { Client } from "@connectrpc/connect";
@@ -92,4 +94,130 @@ export function backupKey(
   rack: Array<MachineLetter>,
 ) {
   return JSON.stringify({ letters, rack });
+}
+
+export type FullResetInputs = {
+  // Board letters as of the last time the board was synced, undefined on the
+  // first load.
+  lastLetters: Array<MachineLetter> | undefined;
+  letters: Array<MachineLetter>;
+  dim: number;
+  currentRack: Array<MachineLetter>;
+  displayedRack: Array<MachineLetter>;
+  placedTiles: Set<EphemeralTile>;
+  arrowProperties: { row: number; col: number; show: boolean };
+  isMyTurn: boolean;
+  isExamining: boolean;
+  puzzleMode: boolean | undefined;
+  boardEditingMode: boolean | undefined;
+  // Whether the game gained or lost events since the last sync.
+  numEventsChanged: boolean;
+  // Whether we have committed a move that has not been synced yet.
+  justCommitted: boolean;
+};
+
+// Decide whether the tentatively placed tiles and the displayed rack must be
+// resynced from the game state.
+export function needsFullReset(inputs: FullResetInputs): boolean {
+  const {
+    lastLetters,
+    letters,
+    dim,
+    currentRack,
+    displayedRack,
+    placedTiles,
+    arrowProperties,
+    isMyTurn,
+    isExamining,
+    puzzleMode,
+    boardEditingMode,
+    numEventsChanged,
+    justCommitted,
+  } = inputs;
+  if (lastLetters === undefined) {
+    // First load.
+    return true;
+  }
+  if (puzzleMode) {
+    // XXX: Without this, when exiting from examining an earlier turn on
+    // puzzle mode, it does not reset the rack to the latest rack. Why?
+    return true;
+  }
+  if (boardEditingMode) {
+    // See comment above. I don't know why it doesn't show the latest rack
+    // when we edit more than once.
+    return true;
+  }
+  if (
+    JSON.stringify(
+      [
+        ...[...placedTiles].map((ephemeralTile) => {
+          const ml = ephemeralTile.letter;
+          return (ml & 0x80) !== 0 ? 0 : ml;
+        }),
+        ...displayedRack.filter((ml) => ml !== EmptyRackSpaceMachineLetter),
+      ].sort(),
+    ) !== JSON.stringify([...currentRack].sort())
+  ) {
+    // First load after receiving rack.
+    // Or other cases where the tiles don't match up.
+    return true;
+  }
+  if (isExamining) {
+    // Prevent stuck tiles.
+    return true;
+  }
+  if (numEventsChanged && justCommitted) {
+    // We have committed a move and the game has moved on since. Whatever is
+    // still placed is a leftover of that move, even when the board looks
+    // untouched, so recall it.
+    return true;
+  }
+  if (!isMyTurn) {
+    // Opponent's turn usually means we have just made a move. (Assumption:
+    // there are only two players.) But a GameHistoryRefresher can also
+    // arrive mid-turn without any move being made (e.g. the opponent's
+    // clock was given more time), in which case the board is unchanged and
+    // tentatively placed tiles should be left alone.
+    const lettersChanged =
+      lastLetters.length !== letters.length ||
+      lastLetters.some((ml, idx) => ml !== letters[idx]);
+    return lettersChanged || numEventsChanged;
+  }
+  // Opponent just did something. Check if it affects any premove.
+  // TODO: revisit when supporting non-square boards.
+  const letterAt = (row: number, col: number, of: Array<MachineLetter>) =>
+    row < 0 || row >= dim || col < 0 || col >= dim ? null : of[row * dim + col];
+  const letterChanged = (row: number, col: number) =>
+    letterAt(row, col, lastLetters) !== letterAt(row, col, letters);
+  const hookChanged = (
+    row: number,
+    col: number,
+    drow: number,
+    dcol: number,
+  ) => {
+    while (true) {
+      row += drow;
+      col += dcol;
+      if (letterChanged(row, col)) return true;
+      const letter = letterAt(row, col, letters);
+      if (letter === null || letter === EmptyBoardSpaceMachineLetter) {
+        return false;
+      }
+    }
+  };
+  const placedTileAffected = (row: number, col: number) =>
+    letterChanged(row, col) ||
+    hookChanged(row, col, -1, 0) ||
+    hookChanged(row, col, +1, 0) ||
+    hookChanged(row, col, 0, -1) ||
+    hookChanged(row, col, 0, +1);
+  // If no tiles have been placed, but placement arrow is shown,
+  // reset based on if that position is affected.
+  // This avoids having the placement arrow behind a tile.
+  return (
+    placedTiles.size === 0 && arrowProperties.show
+      ? [arrowProperties as { row: number; col: number }]
+      : Array.from(placedTiles)
+  ).some(({ row, col }) => placedTileAffected(row, col));
 }


### PR DESCRIPTION
## Summary

A play that is challenged off could stay on the board as tentatively placed tiles, with the turn back on us, so pressing play again resubmitted the same phony and wasted a turn. [Reported on Discord](https://discord.com/channels/741321677828522035/778469677588283403/1526429429511884823) on 14 July, and [still happening on 28 July](https://discord.com/channels/741321677828522035/778469677588283403/1531467601065017404), on iOS as well as on Android. Fixes issues in #1907.

## Root cause

Several socket messages can arrive in the same packet: `parseMsgs` returns them all and `msgs.forEach` dispatches them in one synchronous callback, so React commits a single render and the intermediate board never exists on screen. When the opponent challenges immediately, as bots do, our play and the `PHONY_TILES_RETURNED` that undoes it land together. The reducer unplaces the play and restores our rack, so the board letters and the rack are exactly what they were before we played, and the turn has gone to the opponent. The board carrying our play is never rendered, which is why ["i don't see a flicker or anything, it just stays put"](https://discord.com/channels/741321677828522035/778469677588283403/1526454428289470535).

#1907 narrowed the off-turn full reset to fire only when the board letters changed, so that adding clock time would no longer recall placed tiles (#1906). In this sequence the letters never appear to change, so nothing was recalled and the tiles stayed put.

## Fix

Compare the number of game events as well as the board letters. Off turn, a changed event count means we really did move; a bare refresher never changes it, since adding time only touches `Timers.TimeRemaining` and leaves the history alone. Separately, once we have committed a move and the game has gained events since, recall whatever is still placed. That also covers the packet that carries the opponent's reply as well and hands the turn straight back to us, which was wrong before #1907 too.

The rule deciding this has now broken twice and lived inside an effect that also does the resyncing and the premove bookkeeping, where no test could reach it. It moves unchanged into `needsFullReset` in `board_panel_utils.ts`.

## Guarantees

- Adding clock time still leaves tentatively placed tiles alone (#1906).
- A premove displaced by the opponent's phony is still reinstated once we challenge the phony off, including when either player was given clock time in between.

## Test plan

- `npx vitest run src/gameroom/board_panel_utils.test.ts`: 13 tests. Three of them fail against the rule this PR replaces; the clock-time one fails against the rule as it stood before #1907.
- `npx vitest run`: 162 passed, 5 skipped.
- `tsc --noEmit`, `eslint`, `prettier --check` clean.
- Not reproduced in a live game: the trigger is two messages coalescing into one packet, which wants a bot opponent on a slow link. The diagnosis and the fix are verified at code-path and unit level only.
