### PR TITLE
ci: diff feature branches against master, not against the last push

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,11 +25,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so a feature branch can be diffed against master.
+          fetch-depth: 0
+
+      # Pick what we diff against, explicitly.
+      #
+      # On master, `github.event.before` is the previous master commit, which is
+      # what the deploy jobs want: "what did this push change".
+      #
+      # On any other branch we instead diff against the merge-base with master,
+      # i.e. "what does this branch change". The default per-push behaviour was
+      # wrong for branches in two ways:
+      #   - the FIRST push of a new branch has an all-zeros before-SHA, so
+      #     nothing was detected and every build job skipped;
+      #   - detection only saw the most recent push, so a branch that touched
+      #     liwords-ui and then landed a docs-only commit would skip build_fe.
+      #     The last push decided what got built, not the branch.
+      - name: Compute comparison base
+        id: base
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            base="${{ github.event.before }}"
+          else
+            base="$(git merge-base origin/master HEAD)"
+          fi
+          echo "Comparing against $base"
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
 
       - name: Get changed files
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         id: filter
         with:
+          base_sha: ${{ steps.base.outputs.sha }}
           files_yaml: |
             backend:
               - "api/**"


### PR DESCRIPTION
`detect_changes` decides whether `build_fe` and `build_api_srv` run at all. Its default per-push comparison is wrong for branches in two ways, and the second one is the bad one.

## Bug 1 — the first push of a new branch is never validated

On a new branch, the push event's before-SHA is all zeros, so `changed-files` finds nothing and every build job skips. #1953 opened with **zero CI coverage** because of this.

## Bug 2 — the last push decides what gets built

Detection only ever looked at the most recent push, not the branch as a whole. So a branch that changes `liwords-ui/` and then lands a docs-only commit **skips `build_fe`** on that second push. Whether a PR gets built depends on what its final commit happens to touch, which is not a property anyone reasons about when they push a typo fix.

Both were observed live on #1953 — first push detected nothing, then a `docs/`-only follow-up commit also detected nothing, so the frontend build never ran despite 9 changed files under `liwords-ui/`.

## The fix

Diff against the **merge-base with master** on non-master refs, which asks the question a PR actually poses: *what does this branch change?* Needs `fetch-depth: 0` so the merge-base is reachable.

```yaml
if [ "${{ github.ref }}" = "refs/heads/master" ]; then
  base="${{ github.event.before }}"
else
  base="$(git merge-base origin/master HEAD)"
fi
```

## Deploy path is deliberately untouched

Master still compares against `github.event.before`, so `deploy_fe`, `deploy_api_docker`, and `run_db_migration` see exactly what they see today — "what did this push change". The change is scoped to non-master refs, so there is no new risk to deploys.

## Verification

Against `mantine-00-cascade-hygiene`, the current logic detects **0** changed files; the merge-base detects all **9** under `liwords-ui/`:

```
$ git diff --name-only $(git merge-base origin/master mantine-00-cascade-hygiene) mantine-00-cascade-hygiene
docs/mantine_migration_plan.md
liwords-ui/package-lock.json
liwords-ui/package.json
liwords-ui/scripts/cascade-diff.mjs
liwords-ui/src/base.scss
liwords-ui/src/collections/collections.scss
liwords-ui/src/color_modes.scss
liwords-ui/src/leagues/leagues.scss
liwords-ui/src/lobby/lobby.scss
liwords-ui/src/settings/settings.scss
```

Note that this branch only touches `.github/`, which matches no filter, so its own `build_*` jobs correctly skip. The `detect_changes` log line `Comparing against <sha>` confirms a real merge-base is computed rather than an all-zeros SHA. Full end-to-end effect lands once this is on master.

## Possibly worth a follow-up

`.github/**` is in neither the `backend` nor `frontend` filter, so workflow changes never get a build to validate them against. Left alone here to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)