### PR TITLE
fix macondo version tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.4
 	github.com/aws/smithy-go v1.27.2
-	github.com/domino14/macondo v0.13.2-0.20260604044832-13b729b9830c
+	github.com/domino14/macondo v0.13.3
 	github.com/domino14/word-golib v0.2.24
 	github.com/exaring/otelpgx v0.11.1
 	github.com/gdamore/tcell/v2 v2.13.10

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pM
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/domino14/macondo v0.13.2-0.20260604044832-13b729b9830c h1:3vMzl2SMJGz9HSYqPXPTabY8/GiSt//Wj0FdW3TkwMQ=
-github.com/domino14/macondo v0.13.2-0.20260604044832-13b729b9830c/go.mod h1:XOSpXAiZQQHi4MMn5SsZVPoaqrLzAWdJQMtDmO7G6Mk=
+github.com/domino14/macondo v0.13.3 h1:PQRFXpWNa/vEhthuAg53SPf03ol5tcy/DnX+esvBgK8=
+github.com/domino14/macondo v0.13.3/go.mod h1:+l3Jp2pJiTgIblrcszITpH+Hkij9QNDKiqcWuRtcnaE=
 github.com/domino14/word-golib v0.2.24 h1:qe1rldyIvGJ7KoE7wniznZTvU+vvhNZs1A/uuIKVmO8=
 github.com/domino14/word-golib v0.2.24/go.mod h1:VSQ0N9ORWxc0ZKVZq0UfqaGu/uCJOF/7BA/ptil8tW0=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/pkg/analysis/service.go
+++ b/pkg/analysis/service.go
@@ -31,7 +31,7 @@ import (
 
 // MinMacondoVersion is the minimum macondo worker version accepted.
 // Workers older than this are rejected at ClaimJob.
-const MinMacondoVersion = "v0.13.4"
+const MinMacondoVersion = "v0.13.3"
 
 const (
 	dailyAnalysisLimitRegular   = int64(15)


### PR DESCRIPTION
Bumps the macondo dependency to the corrected version tag and updates the corresponding usage in `pkg/analysis/service.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)