### PR TITLE
Seed the POINTS puzzle tag, and name unknown tags

### DIFF
--- a/db/migrations/202607300001_puzzle_tag_points.down.sql
+++ b/db/migrations/202607300001_puzzle_tag_points.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- puzzle_tags.tag_id references puzzle_tag_titles(id), so drop the taggings
+-- before the title itself.
+DELETE FROM puzzle_tags
+WHERE tag_id IN (SELECT id FROM puzzle_tag_titles WHERE tag_title = 'POINTS');
+
+DELETE FROM puzzle_tag_titles WHERE tag_title = 'POINTS';
+
+COMMIT;

--- a/db/migrations/202607300001_puzzle_tag_points.up.sql
+++ b/db/migrations/202607300001_puzzle_tag_points.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- macondo v0.13.3 added a ninth PuzzleTag, POINTS (enum value 8), which fires
+-- when the answer is the top-scoring play by at least score_margin points.
+--
+-- Puzzle tags are stored by *name*: StorePuzzles resolves tag.String() against
+-- puzzle_tag_titles to get an id. A tag with no row here makes that lookup
+-- return NULL, and puzzle_tags.tag_id is NOT NULL -- so puzzle generation dies
+-- with a 23502 rather than skipping the unknown tag.
+--
+-- puzzle_tag_titles.tag_title has no unique constraint, so this is guarded with
+-- NOT EXISTS rather than ON CONFLICT DO NOTHING (which would only catch a
+-- primary-key collision on the serial id, and never fire).
+INSERT INTO puzzle_tag_titles (tag_title)
+SELECT 'POINTS'
+WHERE NOT EXISTS (
+    SELECT 1 FROM puzzle_tag_titles WHERE tag_title = 'POINTS'
+);
+
+COMMIT;

--- a/pkg/stores/puzzles/db.go
+++ b/pkg/stores/puzzles/db.go
@@ -3,6 +3,7 @@ package puzzles
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -170,7 +171,20 @@ func (s *DBStore) CreatePuzzle(ctx context.Context, gameUUID string, turnNumber 
 	}
 
 	for _, tag := range tags {
-		_, err := tx.Exec(ctx, `INSERT INTO puzzle_tags(tag_id, puzzle_id) VALUES ((SELECT id FROM puzzle_tag_titles WHERE tag_title = $1), $2)`, tag.String(), id)
+		// Resolve the tag id first rather than inlining the lookup as a
+		// subquery in the INSERT. A subquery that matches nothing yields NULL,
+		// which surfaces as an opaque NOT NULL violation on puzzle_tags.tag_id
+		// and gives no hint as to which tag is missing. macondo adds PuzzleTag
+		// values from time to time, so name the culprit instead.
+		var tagID int
+		err := tx.QueryRow(ctx, `SELECT id FROM puzzle_tag_titles WHERE tag_title = $1`, tag.String()).Scan(&tagID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("unknown puzzle tag %q; add it to puzzle_tag_titles in a migration", tag.String())
+		}
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(ctx, `INSERT INTO puzzle_tags(tag_id, puzzle_id) VALUES ($1, $2)`, tagID, id)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes `TestPuzzleGeneration` on master. Not related to the analyzer work in #1957.

## Root cause

macondo `v0.13.3` added a ninth `PuzzleTag`, `POINTS` (enum value 8) — "answer is the top-scoring play by at least `score_margin` points", emitted from `puzzles/puzzles.go:241`. `puzzle_tag_titles` has been seeded with exactly eight titles (`EQUITY`…`CEL_ONLY`, enum 0–7) since `202203290430_create_puzzle_tables.up.sql`, so there's no row for the new tag.

`StorePuzzles` resolved the tag id with an inline subquery:

```sql
INSERT INTO puzzle_tags(tag_id, puzzle_id)
VALUES ((SELECT id FROM puzzle_tag_titles WHERE tag_title = $1), $2)
```

A scalar subquery matching nothing yields `NULL`, and `puzzle_tags.tag_id` is `NOT NULL`, so puzzle generation died with:

```
ERROR: null value in column "tag_id" of relation "puzzle_tags"
violates not-null constraint (SQLSTATE 23502)
```

which names only the column, not the tag.

## Changes

1. **Migration** seeding `POINTS`. Guarded with `NOT EXISTS` rather than `ON CONFLICT DO NOTHING` — `tag_title` has no unique constraint, so `ON CONFLICT` would only catch a collision on the serial primary key and never fire. (The original seed migration uses `ON CONFLICT DO NOTHING` for the same reason it never mattered there: fresh inserts.)

2. **Resolve the tag id in its own statement**, so an unrecognized tag reports itself. macondo adds tag values periodically and this would otherwise recur with the same opaque error each time.

## Verification

Ran against a real postgres, both directions.

With the migration removed, the failure reproduces — but now says what's wrong:

```
--- FAIL: TestPuzzleGeneration (0.50s)
panic: unknown puzzle tag "POINTS"; add it to puzzle_tag_titles in a migration
```

With it in place:

```
ok  github.com/woogles-io/liwords/pkg/puzzles  21.572s
```

Full `./pkg/stores/...` also passes.

## Note

`puzzle_tag_titles.tag_title` having no unique constraint is a latent hazard beyond this fix: duplicate titles would make the id lookup ambiguous (`more than one row returned by a subquery`). Adding `UNIQUE (tag_title)` seemed like scope creep here, but it's worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)