### PR TITLE
Resolve theme tokens at runtime via CSS custom properties

### DIFF
--- a/docs/mantine_migration_plan.md
+++ b/docs/mantine_migration_plan.md
@@ -13,8 +13,8 @@
 | # | Phase | Branch | Status | Notes |
 |---|---|---|---|---|
 | 0.5 | Cascade hygiene + `cascade-diff` script | `mantine-00-cascade-hygiene` | [#1953](https://github.com/woogles-io/liwords/pull/1953) | 34/38 stylesheets proven cascade-neutral; 4 blocked pending derived tokens. Fixed 4 latent dark-mode bugs. Also declares `postcss` explicitly. |
-| 1a | Derived tokens + token bridge | `mantine-01-token-bridge` | next | Unblocks the 4 files calling Sass colour fns on `m()` |
-| 1b | Unwrap `colorModed()` entirely | — | todo | Mechanical codemod; deletes the mixin and `m()` |
+| 1a | Derived tokens + token bridge | `mantine-01-token-bridge` | **done** | CSS 356.7 → 277.6 kB. `.mode--*` selectors 1710 → 34. 77 tokens on `:root`, 765 `var()` uses. `cascade-diff` repointed at a git ref. |
+| 1b | Unwrap `colorModed()` entirely | — | next | Mechanical codemod over ~620 call sites; deletes the passthrough mixin and `m()`/`d()` |
 | 0 | Mantine boot: deps, PostCSS, CSS layers, providers | — | todo | Includes `<StyleProvider layer>` for antd |
 | 2 | Global component theme | — | todo | From `base.scss`'s reskin mixins |
 | 3 | Notifications / modals / confirms façade | — | todo | Deletes `HookAPI` prop threading |

--- a/liwords-ui/scripts/cascade-diff.mjs
+++ b/liwords-ui/scripts/cascade-diff.mjs
@@ -1,51 +1,47 @@
 #!/usr/bin/env node
 /**
- * cascade-diff — proves that turning `colorModed()` into a passthrough does not
- * change which declaration wins anywhere in the stylesheet.
+ * cascade-diff — compares the compiled CSS cascade against another git ref and
+ * reports every declaration that changes which value wins.
  *
- * Background: `src/color_modes.scss` currently emits every themed rule twice,
- * under `.mode--default &` and `.mode--dark &`. The Mantine migration replaces
- * that with runtime CSS custom properties, which means every themed rule loses
- * one class of specificity. Rules that only win today because of that extra
- * class would silently flip.
+ *   node scripts/cascade-diff.mjs                 # vs origin/master
+ *   node scripts/cascade-diff.mjs master          # vs a specific ref
+ *   node scripts/cascade-diff.mjs --verbose       # also list unchanged files
  *
- * This script compiles every stylesheet twice — once as-is ("before"), once with
- * `colorModed()` reduced to `@content` and `m()` returning `var(--woogles-*)`
- * ("after") — projects both into a single color mode, resolves the cascade, and
- * reports any (selector, property) whose winning value changes.
+ * Exits non-zero if anything changed, so it works as a CI gate or a pre-merge
+ * check. This is the safety net for the antd -> Mantine migration: each phase
+ * rewrites stylesheets, and "did any element end up a different colour?" is
+ * exactly the question that manual QA is worst at answering.
  *
- * Scope: it compares declarations competing on the *same* normalized selector,
- * which is where the mixin change actually bites. It will not catch a flip
- * between two different selectors that happen to match the same element; an
- * earlier rightmost-compound heuristic did, but produced far more noise than
- * signal (every `.anticon` rule in the codebase against every other).
+ * How it compares:
+ *  - Both trees are compiled per entry point, the same way rsbuild does it.
+ *  - Selectors are projected into a single colour mode, stripping any
+ *    `.mode--default ` / `.mode--dark ` prefix, so a tree that predates the
+ *    CSS-custom-property bridge compares directly against one that follows it.
+ *  - var(--woogles-*) is resolved back to a literal using each tree's own token
+ *    values, so `#707070` on one side and `var(--woogles-color-gray-medium)` on
+ *    the other are recognised as the same colour.
  *
- *   node scripts/cascade-diff.mjs            # diff, exit 1 on any change
- *   node scripts/cascade-diff.mjs --verbose  # also list blocked files in full
- *
- * Files that cannot compile in "after" mode are reported separately: those are
- * the ones calling Sass color functions on `m()` output, which must be converted
- * to precomputed derived tokens before the bridge can land.
+ * Scope: it compares declarations competing on the same normalised selector.
+ * It will not catch a flip between two different selectors that happen to match
+ * the same element; an earlier rightmost-compound heuristic did, but produced
+ * far more noise than signal (every `.anticon` rule against every other).
  */
 import * as sass from "sass";
 import postcss from "postcss";
-import {
-  cpSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 
-const SRC = resolve(import.meta.dirname, "..", "src");
+const UI = resolve(import.meta.dirname, "..");
+const SRC = join(UI, "src");
 const MODES = ["default", "dark"];
-const VERBOSE = process.argv.includes("--verbose");
 
-/** Definition-only files: no CSS output of their own worth diffing. */
+const args = process.argv.slice(2).filter((a) => a !== "--verbose");
+const VERBOSE = process.argv.includes("--verbose");
+const REF = args[0] ?? "origin/master";
+
+/** Definition-only; no CSS output of its own worth diffing. */
 const SKIP = new Set(["base.module.scss"]);
 
 function findScss(dir, out = []) {
@@ -58,66 +54,68 @@ function findScss(dir, out = []) {
 }
 
 // ---------------------------------------------------------------------------
-// Compilation
+// Materialise the base tree
 // ---------------------------------------------------------------------------
 
 /**
- * Builds a shadow copy of the source tree with color_modes.scss patched to the
- * "after" world. A custom Sass importer will not do: Sass gives the containing
- * file's importer first crack at a load, so filesystem-relative `@use` never
- * reaches a custom one. Shadowing the whole tree sidesteps that entirely.
+ * Extracts liwords-ui/src at `ref` into a temp dir. git archive rather than a
+ * worktree: no index or bookkeeping to clean up, and it cannot disturb the
+ * working tree if the process dies.
  */
-function makeShadowTree() {
+function checkoutBase(ref) {
   const dir = mkdtempSync(join(tmpdir(), "cascade-diff-"));
-  const root = join(dir, "src");
-  cpSync(SRC, root, {
-    recursive: true,
-    filter: (s) => statSync(s).isDirectory() || s.endsWith(".scss"),
-  });
-
-  // Everything from `@mixin colorModed()` onward is replaced with the bridge
-  // versions. emitTokens(), $derived and -derive() are defined above that point
-  // and survive, which is what lets tokenTable() resolve derived tokens.
-  const patched =
-    readFileSync(join(SRC, "color_modes.scss"), "utf8").replace(
-      /@mixin colorModed\(\)[\s\S]*$/,
-      "",
-    ) +
-    `
-@mixin colorModed() { @content; }
-@function m($key) { @return var(--woogles-#{$key}); }
-@function d($name) { @return var(--woogles-d-#{$name}); }
-`;
-  writeFileSync(join(root, "color_modes.scss"), patched);
-  return { dir, root };
+  try {
+    const tar = execFileSync("git", ["archive", ref, "--", "liwords-ui/src"], {
+      cwd: resolve(UI, ".."),
+      maxBuffer: 512 * 1024 * 1024,
+    });
+    execFileSync("tar", ["-x", "-C", dir], { input: tar });
+  } catch (e) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error(`could not read ${ref}: ${e.message.split("\n")[0]}`);
+  }
+  return { dir, root: join(dir, "liwords-ui", "src") };
 }
 
-const shadow = makeShadowTree();
-process.on("exit", () => rmSync(shadow.dir, { recursive: true, force: true }));
-
-function compile(file, passthrough) {
-  const root = passthrough ? shadow.root : SRC;
-  const target = passthrough ? join(root, relative(SRC, file)) : file;
-  return sass.compile(target, {
+function compile(file, root) {
+  return sass.compile(file, {
     loadPaths: [root],
     silenceDeprecations: ["import", "global-builtin"],
     quietDeps: true,
   }).css;
 }
 
-/** Builds `--woogles-<key>` → literal value, per mode, straight from $modes. */
-function tokenTable() {
+/**
+ * --woogles-<key> -> literal, per mode, from a tree's own colour definitions.
+ * Prefers the emitTokens() mixin; falls back to walking $modes directly so that
+ * refs predating the token bridge still resolve.
+ */
+function tokenTable(root) {
   const table = {};
   for (const mode of MODES) {
-    const css = sass.compileString(
-      `@use "color_modes" as cm;
-       :root { @include cm.emitTokens(${mode}); }`,
-      {
-        loadPaths: [SRC],
-        silenceDeprecations: ["import", "global-builtin"],
-        quietDeps: true,
-      },
-    ).css;
+    const opts = {
+      loadPaths: [root],
+      silenceDeprecations: ["import", "global-builtin"],
+      quietDeps: true,
+    };
+    let css = "";
+    try {
+      css = sass.compileString(
+        `@use "color_modes" as cm; :root { @include cm.emitTokens(${mode}); }`,
+        opts,
+      ).css;
+    } catch {
+      try {
+        css = sass.compileString(
+          `@use "sass:map";
+           @use "color_modes" as cm;
+           :root { @each $k, $v in map.get(cm.$modes, ${mode}) { --woogles-#{$k}: #{$v}; } }`,
+          opts,
+        ).css;
+      } catch {
+        css = "";
+      }
+    }
     const m = {};
     postcss.parse(css).walkDecls((d) => {
       if (d.prop.startsWith("--woogles-")) m[d.prop] = d.value.trim();
@@ -131,10 +129,8 @@ function tokenTable() {
 // Selector analysis
 // ---------------------------------------------------------------------------
 
-/** Approximate specificity. Adequate for this codebase — no ids, no :is()/:where(). */
+/** Approximate specificity. Adequate here — no ids, no :is()/:where(). */
 function specificity(sel) {
-  // Pseudo-elements carry element weight; strip them first so the class-level
-  // pseudo-class pattern below does not also match them.
   const pseudoElements = (sel.match(/::[\w-]+/g) || []).length;
   const s = sel.replace(/::[\w-]+/g, "");
   const ids = (s.match(/#[\w-]+/g) || []).length;
@@ -150,8 +146,8 @@ function specificity(sel) {
 const MODE_PREFIX = /^\.mode--(default|dark)\s+/;
 
 /**
- * Projects a rule set into one color mode: keeps unprefixed rules and rules for
- * this mode, stripping the prefix so both worlds are directly comparable.
+ * Projects a rule set into one colour mode: keeps unprefixed rules and rules for
+ * this mode, stripping the prefix so both trees are directly comparable.
  */
 function projectMode(rules, mode) {
   const out = [];
@@ -165,10 +161,6 @@ function projectMode(rules, mode) {
   }
   return out;
 }
-
-// ---------------------------------------------------------------------------
-// Flatten CSS → rules
-// ---------------------------------------------------------------------------
 
 function flatten(css) {
   const rules = [];
@@ -205,8 +197,8 @@ function flatten(css) {
   return rules;
 }
 
-/** Resolve the cascade: key → winning declaration. */
-function resolve_(rules, tokens) {
+/** Resolve the cascade: key -> winning declaration. */
+function resolveCascade(rules, tokens) {
   const winners = new Map();
   for (const r of rules) {
     r.decls.forEach((d, i) => {
@@ -217,7 +209,6 @@ function resolve_(rules, tokens) {
       const pos = r.order * 1000 + i;
       const prev = winners.get(key);
       if (!prev || rank > prev.rank || (rank === prev.rank && pos > prev.pos)) {
-        // Substitute var() so "before" hex and "after" var() compare equal.
         const value = d.value.replace(
           /var\((--woogles-[\w-]+)\)/g,
           (whole, name) => tokens[name] ?? whole,
@@ -233,93 +224,147 @@ function resolve_(rules, tokens) {
 // Main
 // ---------------------------------------------------------------------------
 
-const tokens = tokenTable();
-const files = findScss(SRC).sort();
-const blocked = [];
+const base = checkoutBase(REF);
+process.on("exit", () => rmSync(base.dir, { recursive: true, force: true }));
+
+const headTokens = tokenTable(SRC);
+const baseTokens = tokenTable(base.root);
+
+const headFiles = new Set(findScss(SRC).map((f) => relative(SRC, f)));
+const baseFiles = new Set(
+  findScss(base.root).map((f) => relative(base.root, f)),
+);
+
+const added = [...headFiles].filter((f) => !baseFiles.has(f)).sort();
+const removed = [...baseFiles].filter((f) => !headFiles.has(f)).sort();
+const shared = [...headFiles].filter((f) => baseFiles.has(f)).sort();
+
+const errors = [];
+
+/**
+ * Resolve every stylesheet in a tree. Returns per-file winners plus a tree-wide
+ * index of (mode, selector, property) -> every value that wins somewhere.
+ *
+ * The tree-wide index is what makes moving a rule between files a non-event.
+ * Each .scss is its own Sass compilation, so a rule living in a shared partial
+ * is emitted once per entry point; relocating it to a single file reads as
+ * "declaration gone" in dozens of files even though the bundle is unchanged.
+ */
+function resolveTree(root, files, sideLabel, tokens) {
+  const perFile = new Map();
+  const index = new Map();
+  for (const rel of files) {
+    let css;
+    try {
+      css = compile(join(root, rel), root);
+    } catch (e) {
+      errors.push({ rel, side: sideLabel, message: e.message.split("\n")[0] });
+      continue;
+    }
+    const rules = flatten(css);
+    const byMode = {};
+    for (const mode of MODES) {
+      const winners = resolveCascade(projectMode(rules, mode), tokens[mode]);
+      byMode[mode] = winners;
+      for (const [key, w] of winners) {
+        const gk = `${mode}|${key}`;
+        if (!index.has(gk)) index.set(gk, new Set());
+        index.get(gk).add(w.value);
+      }
+    }
+    perFile.set(rel, byMode);
+  }
+  return { perFile, index };
+}
+
+// Added/removed files are compiled too: they belong in the tree-wide index even
+// though there is no counterpart to diff them against file-by-file.
+const headTree = resolveTree(SRC, [...shared, ...added], "HEAD", headTokens);
+const baseTree = resolveTree(
+  base.root,
+  [...shared, ...removed],
+  REF,
+  baseTokens,
+);
+
 const changes = [];
+let compared = 0;
 
-for (const file of files) {
-  const rel = relative(SRC, file);
-  let before, after;
-  try {
-    before = compile(file, false);
-  } catch (e) {
-    console.error(
-      `  !! ${rel} fails to compile as-is: ${e.message.split("\n")[0]}`,
-    );
-    process.exitCode = 1;
-    continue;
-  }
-  try {
-    after = compile(file, true);
-  } catch (e) {
-    blocked.push({ rel, message: e.message.split("\n").slice(0, 3).join(" ") });
-    continue;
-  }
-
-  const beforeRules = flatten(before);
-  const afterRules = flatten(after);
+for (const rel of shared) {
+  const h = headTree.perFile.get(rel);
+  const b = baseTree.perFile.get(rel);
+  if (!h || !b) continue;
+  compared++;
 
   for (const mode of MODES) {
-    const b = resolve_(projectMode(beforeRules, mode), tokens[mode]);
-    const a = resolve_(projectMode(afterRules, mode), tokens[mode]);
-    for (const [key, bw] of b) {
-      const aw = a.get(key);
-      if (!aw) {
+    const gk = (key) => `${mode}|${key}`;
+    for (const [key, bw] of b[mode]) {
+      const hw = h[mode].get(key);
+      if (!hw) {
+        // Only a real loss if nothing anywhere in HEAD still wins this value.
+        if (!headTree.index.get(gk(key))?.has(bw.value)) {
+          changes.push({
+            rel,
+            mode,
+            key,
+            from: bw.value,
+            to: "(declaration gone)",
+          });
+        }
+      } else if (hw.value !== bw.value) {
+        changes.push({ rel, mode, key, from: bw.value, to: hw.value });
+      }
+    }
+    for (const [key, hw] of h[mode]) {
+      if (!b[mode].has(key) && !baseTree.index.get(gk(key))?.has(hw.value)) {
         changes.push({
           rel,
           mode,
           key,
-          from: bw.value,
-          to: "(declaration disappeared)",
-        });
-      } else if (aw.value !== bw.value) {
-        changes.push({
-          rel,
-          mode,
-          key,
-          from: bw.value,
-          to: aw.value,
-          was: bw.selector,
-          now: aw.selector,
+          from: "(new declaration)",
+          to: hw.value,
         });
       }
     }
   }
 }
 
-console.log(
-  `\ncascade-diff — ${files.length} stylesheets, modes: ${MODES.join(", ")}\n`,
-);
+console.log(`\ncascade-diff — HEAD vs ${REF}`);
+console.log(`${compared} stylesheets compared, modes: ${MODES.join(", ")}\n`);
 
-if (blocked.length) {
-  console.log(
-    `BLOCKED (${blocked.length}) — cannot compile with colorModed() as a passthrough.`,
-  );
-  console.log(
-    `These call Sass color functions on m() output and need derived tokens first:\n`,
-  );
-  for (const b of blocked)
-    console.log(`  ${b.rel}${VERBOSE ? `\n      ${b.message}` : ""}`);
+if (added.length) console.log(`Added (not compared):   ${added.join(", ")}`);
+if (removed.length)
+  console.log(`Removed (not compared): ${removed.join(", ")}`);
+if (added.length || removed.length) console.log("");
+
+if (errors.length) {
+  console.log(`COMPILE ERRORS (${errors.length}):\n`);
+  for (const e of errors)
+    console.log(`  [${e.side}] ${e.rel}\n      ${e.message}`);
   console.log("");
+  process.exitCode = 1;
 }
 
 if (changes.length) {
   console.log(
-    `CASCADE CHANGES (${changes.length}) — a different declaration wins:\n`,
+    `CASCADE CHANGES (${changes.length}) — a different value wins:\n`,
   );
   for (const c of changes) {
-    const [media, compound, prop] = c.key.split("|");
+    const [media, selector, prop] = c.key.split("|");
     console.log(
-      `  ${c.rel} [${c.mode}] ${compound} { ${prop} }${media ? `  @media ${media}` : ""}`,
+      `  ${c.rel} [${c.mode}] ${selector} { ${prop} }${media ? `  @media ${media}` : ""}`,
     );
-    console.log(`      before: ${c.from}   (${c.was ?? "?"})`);
-    console.log(`      after:  ${c.to}   (${c.now ?? "?"})`);
+    console.log(`      ${REF}: ${c.from}`);
+    console.log(`      HEAD:   ${c.to}`);
   }
   console.log("");
   process.exitCode = 1;
-} else if (!blocked.length) {
-  console.log("No cascade changes. The bridge is behaviour-neutral.\n");
-} else {
-  console.log("No cascade changes among the files that compiled.\n");
+} else if (!errors.length) {
+  console.log(
+    "No cascade changes. Every declaration resolves to the same value.\n",
+  );
+}
+
+if (VERBOSE && !changes.length) {
+  console.log(`Unchanged: ${shared.join(", ")}\n`);
 }

--- a/liwords-ui/scripts/cascade-diff.mjs
+++ b/liwords-ui/scripts/cascade-diff.mjs
@@ -75,6 +75,9 @@ function makeShadowTree() {
     filter: (s) => statSync(s).isDirectory() || s.endsWith(".scss"),
   });
 
+  // Everything from `@mixin colorModed()` onward is replaced with the bridge
+  // versions. emitTokens(), $derived and -derive() are defined above that point
+  // and survive, which is what lets tokenTable() resolve derived tokens.
   const patched =
     readFileSync(join(SRC, "color_modes.scss"), "utf8").replace(
       /@mixin colorModed\(\)[\s\S]*$/,
@@ -83,6 +86,7 @@ function makeShadowTree() {
     `
 @mixin colorModed() { @content; }
 @function m($key) { @return var(--woogles-#{$key}); }
+@function d($name) { @return var(--woogles-d-#{$name}); }
 `;
   writeFileSync(join(root, "color_modes.scss"), patched);
   return { dir, root };
@@ -106,9 +110,8 @@ function tokenTable() {
   const table = {};
   for (const mode of MODES) {
     const css = sass.compileString(
-      `@use "sass:map";
-       @use "color_modes" as cm;
-       :root { @each $k, $v in map.get(cm.$modes, ${mode}) { --woogles-#{$k}: #{$v}; } }`,
+      `@use "color_modes" as cm;
+       :root { @include cm.emitTokens(${mode}); }`,
       {
         loadPaths: [SRC],
         silenceDeprecations: ["import", "global-builtin"],

--- a/liwords-ui/src/App.tsx
+++ b/liwords-ui/src/App.tsx
@@ -197,15 +197,13 @@ const App = React.memo(() => {
     });
   }, [selfPerms, loggedIn, dispatchLoginState]);
 
-  // Get theme from Zustand store
+  // Get theme from Zustand store. The mode--* classes and the darkMode
+  // localStorage key are written by src/stores/ui-store.ts, which owns them --
+  // at module-evaluation time for the initial value, and in setThemeMode
+  // thereafter. An effect here used to duplicate both writes, but it only ever
+  // touched body, not documentElement, which is where the --woogles-* tokens are
+  // declared. Two writers with different targets is a bug waiting to happen.
   const themeMode = useUIStore(selectThemeMode);
-  useEffect(() => {
-    const isDark = themeMode === "dark";
-    console.log("Detected themeMode = ", themeMode);
-    localStorage.setItem("darkMode", isDark ? "true" : "false");
-    document?.body?.classList?.add(`mode--${isDark ? "dark" : "default"}`);
-    document?.body?.classList?.remove(`mode--${isDark ? "default" : "dark"}`);
-  }, [themeMode]);
 
   const antdTheme = useMemo(() => {
     if (themeMode === "dark") {

--- a/liwords-ui/src/color_modes.scss
+++ b/liwords-ui/src/color_modes.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+@use "sass:list";
 @use "sass:map";
 // The body itself is an outlier
 body.mode--dark {
@@ -230,10 +232,93 @@ $modes: (
   ),
 );
 
+// ---------------------------------------------------------------------------
+// Derived tokens.
+//
+// A number of declarations need a colour that is computed from other tokens --
+// a bonus square mixed with the board background, a hover state a few percent
+// lighter. Those used to be written inline as color.mix(m($a), m($b), ...).
+//
+// That works only while m() returns a real Sass colour. The Mantine migration
+// makes m() return a var(), which a Sass colour function cannot consume, so the
+// arithmetic is hoisted here instead: computed once per mode, at build time,
+// named, and reachable through d().
+//
+// CSS color-mix() is deliberately not used. There is no .browserslistrc, so the
+// build inherits rsbuild's default targets, and color.scale($lightness: -10%)
+// is HSL-space scaling (L -> L * 0.9) which color-mix() cannot express at all.
+//
+// Each entry is (operation, token-a, token-b-or-null, amount).
+// ---------------------------------------------------------------------------
+$derived: (
+  // gameroom: bonus-square labels and selected states
+  qws-label: (mix, "color-board-qws", "color-gray-extreme", 30%),
+  qws-selected: (mix, "color-board-qws", "color-timer-light", 60%),
+  tws-label: (mix, "color-board-tws", "color-gray-extreme", 30%),
+  tws-selected: (mix, "color-board-tws", "color-white", 70%),
+  dws-selected: (mix, "color-board-dws", "color-timer-light", 60%),
+  qls-label: (mix, "color-board-qls", "color-gray-extreme", 20%),
+  qls-selected: (mix, "color-board-qls", "color-timer-light", 30%),
+  tls-label: (mix, "color-board-tls", "color-gray-extreme", 20%),
+  tls-selected: (mix, "color-board-tls", "color-white", 70%),
+  dls-selected: (mix, "color-board-dls", "color-timer-light", 30%),
+  timer-light-shade: (scale, "color-timer-light", null, -10%),
+  // game lists: sort-column and hover backgrounds
+  column-sorter-hover: (scale, "color-column-sorter", null, 10%),
+  off-background-hover: (scale, "color-off-background", null, 10%),
+  card-on-timer-low: (
+    mix,
+    "color-card-background",
+    "color-timer-low-light",
+    90%
+  ),
+  off-on-card: (mix, "color-off-background", "color-card-background", 30%),
+  // leagues: promotion/relegation row hover and border
+  win-hover: (adjust, "color-profile-game-win", null, 5%),
+  loss-hover: (adjust, "color-profile-game-loss", null, 5%),
+  win-border: (adjust, "color-profile-game-win", null, -20%),
+  loss-border: (adjust, "color-profile-game-loss", null, -20%),
+  // lobby: announcement hover
+  primary-middle-on-bg: (mix, "color-primary-middle", "color-background", 50%)
+);
+
+@function -raw($mode, $key) {
+  @return map.get(map.get($modes, $mode), $key);
+}
+
+@function -derive($mode, $spec) {
+  $op: list.nth($spec, 1);
+  $a: -raw($mode, list.nth($spec, 2));
+  $b: list.nth($spec, 3);
+  $amount: list.nth($spec, 4);
+
+  @if $op == scale {
+    @return color.scale($a, $lightness: $amount);
+  }
+  @if $op == adjust {
+    @return color.adjust($a, $lightness: $amount);
+  }
+  @return color.mix($a, -raw($mode, $b), $weight: $amount);
+}
+
+// Emits every --woogles-* custom property for one mode. Intended to be called
+// exactly twice, from src/theme/tokens.scss. Do NOT call it from a feature
+// stylesheet: each .scss entry point is its own Sass compilation, so it would
+// emit one copy per entry point.
+@mixin emitTokens($mode) {
+  @each $key, $value in map.get($modes, $mode) {
+    --woogles-#{$key}: #{$value};
+  }
+  @each $name, $spec in $derived {
+    --woogles-d-#{$name}: #{-derive($mode, $spec)};
+  }
+}
+
 @mixin colorModed() {
   @each $mode, $map in $modes {
     .mode--#{$mode} & {
       $mode-map: () !global;
+      $current-mode: $mode !global;
       @each $key, $submap in $map {
         $value: map.get(map.get($modes, $mode), "#{$key}");
         $mode-map: map.merge(
@@ -245,10 +330,17 @@ $modes: (
       }
       @content;
       $mode-map: null !global;
+      $current-mode: null !global;
     }
   }
 }
 
 @function m($key) {
   @return map.get($mode-map, $key);
+}
+
+// Resolves a $derived entry for whichever mode colorModed() is currently
+// emitting. Only valid inside a colorModed() block, exactly like m().
+@function d($name) {
+  @return -derive($current-mode, map.get($derived, $name));
 }

--- a/liwords-ui/src/color_modes.scss
+++ b/liwords-ui/src/color_modes.scss
@@ -1,10 +1,10 @@
+// Definitions only -- this file must emit no CSS of its own. Every feature
+// stylesheet @uses it, and each one is a separate Sass compilation, so anything
+// emitted here ships once per entry point. The dark body background that used
+// to live at the top of this file now lives in src/theme/tokens.scss.
 @use "sass:color";
 @use "sass:list";
 @use "sass:map";
-// The body itself is an outlier
-body.mode--dark {
-  background: #2e2e2e;
-}
 
 // Theming system by Katie McTigue https://medium.com/@katiemctigue/how-to-create-a-dark-mode-in-sass-609f131a3995
 
@@ -314,33 +314,32 @@ $derived: (
   }
 }
 
+// ---------------------------------------------------------------------------
+// The bridge.
+//
+// This used to emit its @content twice -- once under `.mode--default &`, once
+// under `.mode--dark &` -- with the token values baked in as literals. With
+// ~620 call sites that meant every themed rule existed twice in the shipped
+// stylesheet, nothing was overridable at runtime, and JS could not read a
+// colour.
+//
+// Now the values are CSS custom properties, declared per mode in
+// src/theme/tokens.scss, and there is nothing left to duplicate: colorModed()
+// is a passthrough. It is kept rather than deleted so the ~620 existing call
+// sites keep compiling unchanged; a follow-up removes it mechanically.
+//
+// NB: this drops one class of specificity from every themed rule. That is
+// verified safe by scripts/cascade-diff.mjs, which compiles the whole
+// stylesheet both ways and fails if any declaration changes its winner.
+// ---------------------------------------------------------------------------
 @mixin colorModed() {
-  @each $mode, $map in $modes {
-    .mode--#{$mode} & {
-      $mode-map: () !global;
-      $current-mode: $mode !global;
-      @each $key, $submap in $map {
-        $value: map.get(map.get($modes, $mode), "#{$key}");
-        $mode-map: map.merge(
-          $mode-map,
-          (
-            $key: $value,
-          )
-        ) !global;
-      }
-      @content;
-      $mode-map: null !global;
-      $current-mode: null !global;
-    }
-  }
+  @content;
 }
 
 @function m($key) {
-  @return map.get($mode-map, $key);
+  @return var(--woogles-#{$key});
 }
 
-// Resolves a $derived entry for whichever mode colorModed() is currently
-// emitting. Only valid inside a colorModed() block, exactly like m().
 @function d($name) {
-  @return -derive($current-mode, map.get($derived, $name));
+  @return var(--woogles-d-#{$name});
 }

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -1146,7 +1146,7 @@ p.streak-loss {
 
     .bonus-label {
       @include colorModed() {
-        color: color.mix(m($board-qws), m($gray-extreme), $weight: 30%);
+        color: d(qws-label);
       }
 
       @include userboard() {
@@ -1156,11 +1156,7 @@ p.streak-loss {
 
     &.selected {
       @include colorModed() {
-        background-color: color.mix(
-          m($board-qws),
-          m($timer-light),
-          $weight: 60%
-        );
+        background-color: d(qws-selected);
       }
 
       @include userboard() {
@@ -1201,8 +1197,8 @@ p.streak-loss {
 
     &.selected {
       @include colorModed() {
-        background-color: color.mix(m($board-tws), m($white), $weight: 70%);
-        border-color: color.scale(m($timer-light), $lightness: -10%);
+        background-color: d(tws-selected);
+        border-color: d(timer-light-shade);
       }
 
       @include userboard() {
@@ -1212,7 +1208,7 @@ p.streak-loss {
 
       .anticon {
         @include colorModed() {
-          color: color.scale(m($timer-light), $lightness: -10%);
+          color: d(timer-light-shade);
         }
 
         @include userboard() {
@@ -1243,7 +1239,7 @@ p.streak-loss {
 
     .bonus-label {
       @include colorModed() {
-        color: color.mix(m($board-tws), m($gray-extreme), $weight: 30%);
+        color: d(tws-label);
       }
 
       @include userboard() {
@@ -1253,11 +1249,7 @@ p.streak-loss {
 
     &.selected {
       @include colorModed() {
-        background-color: color.mix(
-          m($board-dws),
-          m($timer-light),
-          $weight: 60%
-        );
+        background-color: d(dws-selected);
       }
 
       @include userboard() {
@@ -1292,11 +1284,7 @@ p.streak-loss {
 
     &.selected {
       @include colorModed() {
-        background-color: color.mix(
-          m($board-qls),
-          m($timer-light),
-          $weight: 30%
-        );
+        background-color: d(qls-selected);
       }
 
       @include userboard() {
@@ -1307,7 +1295,7 @@ p.streak-loss {
 
     .bonus-label {
       @include colorModed() {
-        color: color.mix(m($board-qls), m($gray-extreme), $weight: 20%);
+        color: d(qls-label);
       }
 
       @include userboard() {
@@ -1337,8 +1325,8 @@ p.streak-loss {
 
     &.selected {
       @include colorModed() {
-        background-color: color.mix(m($board-tls), m($white), $weight: 70%);
-        border-color: color.scale(m($timer-light), $lightness: -10%);
+        background-color: d(tls-selected);
+        border-color: d(timer-light-shade);
       }
 
       @include userboard() {
@@ -1348,7 +1336,7 @@ p.streak-loss {
 
       .anticon {
         @include colorModed() {
-          color: color.scale(m($timer-light), $lightness: -10%);
+          color: d(timer-light-shade);
         }
 
         @include userboard() {
@@ -1369,11 +1357,7 @@ p.streak-loss {
 
     &.selected {
       @include colorModed() {
-        background-color: color.mix(
-          m($board-dls),
-          m($timer-light),
-          $weight: 30%
-        );
+        background-color: d(dls-selected);
       }
 
       @include userboard() {
@@ -1384,7 +1368,7 @@ p.streak-loss {
 
     .bonus-label {
       @include colorModed() {
-        color: color.mix(m($board-tls), m($gray-extreme), $weight: 20%);
+        color: d(tls-label);
       }
 
       @include userboard() {

--- a/liwords-ui/src/index.tsx
+++ b/liwords-ui/src/index.tsx
@@ -8,6 +8,9 @@ import { BriefProfiles } from "./utils/brief_profiles";
 import "@ant-design/v5-patch-for-react-19";
 
 import "antd/dist/reset.css";
+// Declares the --woogles-* design tokens on :root. Every stylesheet's m() and
+// d() calls resolve against these, so this must be loaded app-wide exactly once.
+import "./theme/tokens.scss";
 import "./index.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TransportProvider } from "@connectrpc/connect-query";

--- a/liwords-ui/src/leagues/leagues.scss
+++ b/liwords-ui/src/leagues/leagues.scss
@@ -541,10 +541,7 @@
 
         .ant-table-tbody > tr.promotion-row:hover > td {
           @include colorModed {
-            background: color.adjust(
-              m($profile-game-win),
-              $lightness: 5%
-            ) !important;
+            background: d(win-hover) !important;
           }
         }
 
@@ -557,10 +554,7 @@
 
         .ant-table-tbody > tr.relegation-row:hover > td {
           @include colorModed {
-            background: color.adjust(
-              m($profile-game-loss),
-              $lightness: 5%
-            ) !important;
+            background: d(loss-hover) !important;
           }
         }
 
@@ -629,8 +623,7 @@
 
           @include colorModed {
             background: m($profile-game-win);
-            border: 1px solid
-              color.adjust(m($profile-game-win), $lightness: -20%);
+            border: 1px solid d(win-border);
           }
         }
 
@@ -644,8 +637,7 @@
 
           @include colorModed {
             background: m($profile-game-loss);
-            border: 1px solid
-              color.adjust(m($profile-game-loss), $lightness: -20%);
+            border: 1px solid d(loss-border);
           }
         }
       }

--- a/liwords-ui/src/lobby/lobby.scss
+++ b/liwords-ui/src/lobby/lobby.scss
@@ -107,11 +107,7 @@
       &:hover h4,
       &:hover p {
         @include colorModed() {
-          background-color: color.mix(
-            m($primary-middle),
-            m($background),
-            $weight: 50%
-          );
+          background-color: d(primary-middle-on-bg);
         }
       }
     }

--- a/liwords-ui/src/shared/gameLists.scss
+++ b/liwords-ui/src/shared/gameLists.scss
@@ -176,16 +176,12 @@
         }
         &:hover {
           @include colorModed() {
-            background-color: color.scale(m($column-sorter), $lightness: 10%);
+            background-color: d(column-sorter-hover);
           }
         }
         td.ant-table-column-sort {
           @include colorModed() {
-            background-color: color.mix(
-              m($card-background),
-              m($timer-low-light),
-              $weight: 90%
-            );
+            background-color: d(card-on-timer-low);
           }
         }
         td {
@@ -231,7 +227,7 @@
         }
         &:hover {
           @include colorModed() {
-            background-color: color.scale(m($off-background), $lightness: 10%);
+            background-color: d(off-background-hover);
           }
         }
         td.seeker {
@@ -262,11 +258,7 @@
         &:hover {
           opacity: 0.85;
           @include colorModed() {
-            background-color: color.mix(
-              m($off-background),
-              m($card-background),
-              $weight: 30%
-            );
+            background-color: d(off-on-card);
           }
         }
       }

--- a/liwords-ui/src/stores/ui-store.ts
+++ b/liwords-ui/src/stores/ui-store.ts
@@ -140,8 +140,20 @@ export const useUIStore = create<UIState>()(
 function updateBodyClass(mode: ThemeMode) {
   if (typeof document === "undefined") return;
 
-  document.body.classList.remove("mode--default", "mode--dark");
-  document.body.classList.add(`mode--${mode === "dark" ? "dark" : "default"}`);
+  const next = `mode--${mode === "dark" ? "dark" : "default"}`;
+
+  // documentElement carries the class because src/theme/tokens.scss declares the
+  // --woogles-* custom properties on :root / html.mode--dark. Custom property
+  // substitution resolves at the declaring element, so they have to live above
+  // body for anything on :root to be able to reference them.
+  //
+  // body keeps the class too: the remaining antd portal overrides in base.scss
+  // are written as `body.mode--dark .ant-notification-notice`, and portals render
+  // outside the app shell. Those go away with the antd notification migration.
+  for (const el of [document.documentElement, document.body]) {
+    el.classList.remove("mode--default", "mode--dark");
+    el.classList.add(next);
+  }
 }
 
 /**

--- a/liwords-ui/src/theme/tokens.scss
+++ b/liwords-ui/src/theme/tokens.scss
@@ -1,0 +1,34 @@
+// Declares the --woogles-* design tokens. Imported once, from src/index.tsx.
+//
+// This is the runtime half of the theming system. color_modes.scss holds the
+// values (the $modes map plus the $derived table); this file turns them into CSS
+// custom properties, and m() / d() in any stylesheet read them back as var().
+//
+// Everything is declared on :root rather than body. Custom property
+// substitution resolves at the element that declares it, and Mantine's
+// cssVariablesResolver output lands on :root -- so a :root-level
+// `--mantine-color-text: var(--woogles-color-gray-extreme)` would find nothing
+// if the woogles tokens lived on body.
+@use "../color_modes" as *;
+
+// Light is the base, so there is never a paint with unresolved tokens.
+:root {
+  @include emitTokens(default);
+}
+
+// `html.mode--dark` (0,1,1) beats `:root` (0,1,0). src/stores/ui-store.ts sets
+// this class on documentElement at module-evaluation time, before React renders,
+// which is what avoids a light-mode flash. It also still sets it on body, which
+// the remaining antd portal overrides in base.scss depend on.
+html.mode--dark {
+  @include emitTokens(dark);
+}
+
+// Slightly darker than --woogles-color-background on purpose: this is the area
+// outside the app shell. Carried over from the top of color_modes.scss, where it
+// was emitted once per entry point. Selector kept byte-identical so its
+// specificity (0,1,1) is unchanged; ui-store.ts sets the class on body as well
+// as on documentElement.
+body.mode--dark {
+  background: #2e2e2e;
+}


### PR DESCRIPTION
Phase 1 of the antd → Mantine migration (`docs/mantine_migration_plan.md`). **Nothing should render differently** — this converts how theme values are delivered, not what they are.

## The problem

`colorModed()` emitted its `@content` twice, once under `.mode--default &` and once under `.mode--dark &`, with token values baked in as literals. At ~620 call sites that meant every themed rule shipped twice, nothing was overridable at runtime, and JS could not read a colour.

## What lands

**1. Derived colours hoisted out of Sass colour functions** (`323904d5`)

23 declarations computed a colour inline, e.g. `color.mix(m($board-qws), m($timer-light), $weight: 60%)`. That only works while `m()` returns a real Sass colour, so it was the one hard blocker to the bridge. They move into a `$derived` table — computed once per mode at build time, named, read back via `d()`. 23 sites → 19 distinct values.

CSS `color-mix()` is deliberately **not** used: there is no `.browserslistrc` so the build inherits rsbuild's default targets, and `color.scale($lightness:)` is HSL-space scaling (`L → L × 0.9`) which `color-mix()` cannot express.

*Provably a pure refactor — the four affected stylesheets compile to byte-identical CSS.*

**2. The bridge** (`ddeb9b1a`)

`m()` and `d()` now return `var(--woogles-*)`; `colorModed()` becomes a passthrough. Tokens are declared once per mode in the new `src/theme/tokens.scss`.

They go on `:root`, not `body`, on purpose: custom-property substitution resolves at the declaring element, and Mantine's `cssVariablesResolver` emits on `:root` — so a later `--mantine-color-text: var(--woogles-color-gray-extreme)` would resolve against `:root`, find nothing, and silently go invalid. `ui-store.ts` now sets `mode--*` on `documentElement` as well as `body`; `body` keeps it because the antd notification overrides in `base.scss` are written as `body.mode--dark .ant-notification-notice` and portals render outside the app shell.

Also drops the redundant theme effect in `App.tsx` — it duplicated ui-store's class and localStorage writes but only touched `body`, not `documentElement`.

| | before | after |
|---|---|---|
| CSS bundle | 356.7 kB | **277.6 kB** |
| gzipped | 46.0 kB | **39.2 kB** |
| `.mode--default` selectors | 845 | 7 |
| `.mode--dark` selectors | 865 | 27 |
| tokens on `:root` | — | 77 (58 base + 19 derived) |
| `var(--woogles-*)` uses | — | 765 |

The 34 remaining `mode--*` selectors are the deliberate ones: the antd portal overrides in `base.scss`, `tokens.scss` itself, and a few hand-written rules.

**3. `cascade-diff` repointed at a git ref** (`ac072232`)

The script existed to prove this specific change safe. Now that the bridge has landed, the real `color_modes.scss` already *is* the passthrough, so it patched a file into the state it was already in and compared it with itself — passing unconditionally. A green check that verifies nothing is worse than no check.

It now compares HEAD against a git ref, which is the question every remaining phase asks: *did any element end up a different colour?* It also reconciles rules that move between files — each `.scss` is its own Sass compilation, so relocating the dark body background into `tokens.scss` initially read as 72 spurious "declaration gone" reports, all one rule.

## Verification

```
$ node scripts/cascade-diff.mjs master
40 stylesheets compared, modes: default, dark
No cascade changes. Every declaration resolves to the same value.
```

Every declaration in all 40 stylesheets resolves to the same value as master, in both modes. Sensitivity checked in both directions — one altered declaration reports 2 changes; changing a single hex digit in one token reports 99 across the codebase in light mode only.

Tests unchanged from master (9 failed / 130 passed — those failures are a pre-existing local node-version artifact, identical on master).

## Review notes

- `node scripts/cascade-diff.mjs master` from `liwords-ui/` should exit 0.
- Worth an eyeball anyway in both modes, since cascade-diff compares values and not layout: lobby, a game, settings, leagues, a tournament. Board and tile themes are the highest-value spot check — `userboard()`/`userTile()` share the cascade with the rules that just lost a class of specificity.
- `colorModed()` survives as a passthrough so ~620 call sites compile unchanged. Phase 1b removes it mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)