### PR TITLE
Fix unverified-users-cleanup aborting on blockings FK

### DIFF
--- a/cmd/maintenance/main.go
+++ b/cmd/maintenance/main.go
@@ -509,7 +509,29 @@ func UnverifiedUsersCleanup() error {
 	}
 	defer tx.Rollback(ctx)
 
-	// Delete followings first (foreign key constraint)
+	// Delete blockings first (foreign key constraint).
+	// Both blockings FKs are ON DELETE RESTRICT, so a single leftover row here
+	// aborts the whole transaction and the cleanup silently deletes nothing.
+	// Remove both where unverified users are blocked AND where they're the blocker.
+	queryBlockings := `
+		DELETE FROM blockings
+		WHERE user_id IN (
+			SELECT id FROM users
+			WHERE verified = false AND created_at < NOW() - INTERVAL '48 hours'
+		)
+		OR blocker_id IN (
+			SELECT id FROM users
+			WHERE verified = false AND created_at < NOW() - INTERVAL '48 hours'
+		)
+	`
+	resultBlockings, err := tx.Exec(ctx, queryBlockings)
+	if err != nil {
+		return err
+	}
+	blockingsDeleted := resultBlockings.RowsAffected()
+	log.Info().Int64("blockingsDeleted", blockingsDeleted).Msg("deleted unverified user blockings")
+
+	// Delete followings next (foreign key constraint)
 	// Remove both where unverified users are being followed AND where they're following others
 	queryFollowings := `
 		DELETE FROM followings
@@ -562,6 +584,7 @@ func UnverifiedUsersCleanup() error {
 	}
 
 	log.Info().
+		Int64("blockingsDeleted", blockingsDeleted).
 		Int64("followingsDeleted", followingsDeleted).
 		Int64("profilesDeleted", profilesDeleted).
 		Int64("usersDeleted", usersDeleted).

--- a/pkg/stores/user/db.go
+++ b/pkg/stores/user/db.go
@@ -248,48 +248,9 @@ func (s *DBStore) UpdateVerificationToken(ctx context.Context, uuid string, toke
 	})
 }
 
-// DeleteUnverifiedUsers deletes users who haven't verified their email after the specified duration
-func (s *DBStore) DeleteUnverifiedUsers(ctx context.Context, olderThan time.Duration) (int, error) {
-	tx, err := s.dbPool.BeginTx(ctx, common.DefaultTxOptions)
-	if err != nil {
-		return 0, err
-	}
-	defer tx.Rollback(ctx)
-
-	cutoffTime := time.Now().Add(-olderThan)
-
-	// Delete profiles first (foreign key constraint)
-	_, err = tx.Exec(ctx, `
-		DELETE FROM profiles
-		WHERE user_id IN (
-			SELECT id FROM users
-			WHERE verified = false AND created_at < $1
-		)
-	`, cutoffTime)
-	if err != nil {
-		return 0, fmt.Errorf("failed to delete unverified user profiles: %w", err)
-	}
-
-	// Delete users
-	result, err := tx.Exec(ctx, `
-		DELETE FROM users
-		WHERE verified = false AND created_at < $1
-	`, cutoffTime)
-	if err != nil {
-		return 0, fmt.Errorf("failed to delete unverified users: %w", err)
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return 0, err
-	}
-
-	rowsAffected := int(result.RowsAffected())
-	if rowsAffected > 0 {
-		log.Info().Int("count", rowsAffected).Dur("older_than", olderThan).Msg("deleted-unverified-users")
-	}
-
-	return rowsAffected, nil
-}
+// NOTE: DeleteUnverifiedUsers used to live here, but it was never called and
+// its delete ordering was incomplete (it missed both followings and blockings).
+// The real cleanup is UnverifiedUsersCleanup in cmd/maintenance/main.go.
 
 // New creates a new user in the DB.
 func (s *DBStore) New(ctx context.Context, u *entity.User) error {

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -25,7 +25,6 @@ type Store interface {
 	SetPassword(ctx context.Context, uuid string, hashpass string) error
 	SetEmailVerified(ctx context.Context, uuid string, verified bool) error
 	UpdateVerificationToken(ctx context.Context, uuid string, token string, expiresAt time.Time) error
-	DeleteUnverifiedUsers(ctx context.Context, olderThan time.Duration) (int, error)
 	SetAvatarUrl(ctx context.Context, uuid string, avatarUrl string) error
 	GetBriefProfiles(ctx context.Context, uuids []string) (map[string]*upb.BriefProfile, error)
 	SetPersonalInfo(ctx context.Context, uuid string, email string, firstName string, lastName string, birthDate string, countryCode string, about string) error


### PR DESCRIPTION
## What's wrong

The nightly `unverified-users-cleanup` maintenance command has not deleted a single user since **2026-02-01**. It is still scheduled and still runs — the EventBridge rule `liwords-daily-midnight-maintenance` is `ENABLED` on `cron(0 5 * * ? *)` and its ECS target command still lists the task. It just fails on every run and rolls back:

```
2026-07-29T05:03:59Z | error | violates foreign key constraint "blockings_user_id_users_id_foreign"
2026-07-30T05:03:47Z | error | ... same
2026-07-31T05:02:41Z | error | ... same
2026-08-01T05:02:50Z | error | ... same
2026-08-02T05:02:24Z | error | ... same
```

(That's the whole visible window — `/ecs/liwords-maintenance` has 5-day retention.)

## Root cause

`UnverifiedUsersCleanup` deletes child rows from `followings` and `profiles` before deleting from `users`, but not from `blockings`. Both `blockings` FKs are `ON DELETE RESTRICT`:

```
blockings_user_id_users_id_foreign     ON DELETE RESTRICT
blockings_blocker_id_users_id_foreign  ON DELETE RESTRICT
```

Everything runs in one transaction, so one leftover row aborts the lot. The `followingsDeleted: 376` / `profilesDeleted: 7537` lines in the logs are work that gets thrown away on rollback — which is why those counts barely move day to day.

## When it broke

The oldest stuck unverified user dates to 2026-01-29 06:33 UTC. In that same day's batch is `Jianfeng` (id 866886, created 2026-01-29 09:27 UTC), who never verified and who someone had blocked. Both crossed the 48-hour threshold in time for the 2026-02-01 05:00 run — the first failing one. Every run since has failed the same way.

## Impact

| | count |
|---|---|
| Unverified users >48h | **7,736** |
| Orphan `profiles` | 7,736 |
| `followings` | 386 |
| `blockings` (the blocker) | **8** |

Growing ~215/week. Eight rows have been holding up six months of cleanup.

## The fix

Delete from `blockings` first, both directions, mirroring the existing `followings` query, and log the count alongside the others.

I audited all 17 tables with a `RESTRICT`/`NO ACTION` FK to `users` against the stuck cohort in prod. `blockings` is the only one with any rows — `games`, `game_players`, `puzzles`, `puzzle_attempts`, `puzzle_votes`, `broadcasts`, `broadcast_annotators`, `broadcast_directors`, `broadcast_games`, `user_actions`, `integrations`, `collections`, `game_comments` and `tournaments` are all zero, as you'd expect since unverified users can't log in. So this one delete is sufficient to unblock the backlog.

## Also in here

Removed `DBStore.DeleteUnverifiedUsers` and its `user.Store` interface entry. It was never called anywhere, and it had the same defect in worse form — it missed both `followings` and `blockings` — so it was a trap for whoever wired it up next. `DBStore` is the only implementer and there are no mocks, so nothing else was affected.

## Verification

`go build ./...` and `go vet` are clean. I could not dry-run the SQL against prod: `bin/proddb` connects as a read-only role, which is working as intended.

Once this deploys, expect the first successful run to report roughly `blockingsDeleted: 8, followingsDeleted: ~386, profilesDeleted: ~7736, usersDeleted: ~7736`. Worth watching that run's log to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)