### PR TITLE
Use spaces instead of tabs in TSH export

### DIFF
--- a/pkg/tournament/export.go
+++ b/pkg/tournament/export.go
@@ -113,7 +113,7 @@ func exportToTSH(ctx context.Context, t *entity.Tournament, us user.Store) (stri
 			if len(split) == 2 {
 				realName = split[1] + ", " + split[0]
 			}
-			fmt.Fprintf(&sb, "%v\t%d", realName, p.Rating)
+			fmt.Fprintf(&sb, "%v %d", realName, p.Rating)
 			scores := make([]int, xhr.CurrentRound+1)
 			// Write all pairings and then scores.
 			for rd := int32(0); rd <= xhr.CurrentRound; rd++ {

--- a/pkg/tournament/testdata/wtf5-tsh.golden
+++ b/pkg/tournament/testdata/wtf5-tsh.golden
@@ -10,18 +10,18 @@ config archive_source_type = 'tsh'
 # config event_name = "Woogles, MI"
 # config event_date = "April 30, 2022"
 #begin_file name=CSW.t
-jellomochas	1111111 4 3 2 4; 473 561 478 460
-xeroexpert	239842 3 4 1 3; 258 251 358 170
-curtis_smith	8008 2 1 4 2; 359 294 393 370
-nchagti	90 1 2 3 1; 309 437 453 327
+jellomochas 1111111 4 3 2 4; 473 561 478 460
+xeroexpert 239842 3 4 1 3; 258 251 358 170
+curtis_smith 8008 2 1 4 2; 359 294 393 370
+nchagti 90 1 2 3 1; 309 437 453 327
 #end_file name=CSW.t
 #begin_file name=NWL.t
-llamaste	111121312 8 5 4 6; 447 275 481 382
-bnjy	99999999 5 7 6 7; 455 440 427 503
-chloe	123124 6 8 7 5; 365 427 452 377
-OnTheHop	89856 7 6 1 8; 283 335 257 274
-josh	1221 2 1 8 3; 403 486 473 450
-bynak	1000 3 4 2 1; 321 386 405 458
-IBex7	333 4 2 3 2; 313 479 436 311
-cesar	0 1 3 5 4; 448 382 439 385
+llamaste 111121312 8 5 4 6; 447 275 481 382
+bnjy 99999999 5 7 6 7; 455 440 427 503
+chloe 123124 6 8 7 5; 365 427 452 377
+OnTheHop 89856 7 6 1 8; 283 335 257 274
+josh 1221 2 1 8 3; 403 486 473 450
+bynak 1000 3 4 2 1; 321 386 405 458
+IBex7 333 4 2 3 2; 313 479 436 311
+cesar 0 1 3 5 4; 448 382 439 385
 #end_file name=NWL.t


### PR DESCRIPTION
The tsh .t archive format is whitespace-delimited; a literal tab between the player name and rating is non-standard. Emit a single space instead.