### PR TITLE
Keep the seed constant across multiround pairings

### DIFF
--- a/pkg/pair/cop/cop.go
+++ b/pkg/pair/cop/cop.go
@@ -1604,7 +1604,16 @@ func simplePair(req *pb.PairRequest, logsb *strings.Builder) *pb.PairResponse {
 		N := max(int(req.InitialNonperfRounds), 1)
 		multiroundPairings = append(multiroundPairings, allPlayerPairings...)
 		for roundIdx := 1; roundIdx < N; roundIdx++ {
-			rp, err := simplePairOnce(req, pairingMethod, poolMembers, playerOrder, currentRound+int32(roundIdx), uint64(req.Seed)+uint64(roundIdx))
+			// The seed must stay the same for every round of the schedule.
+			// GetRoundRobinPairings shuffles the players with the seed alone
+			// and then derives each round by rotating that one ordering, so
+			// the rounds only compose into a round robin if they all share a
+			// seed and differ only in the round. Varying the seed reshuffles
+			// the base ordering and yields a round from an unrelated round
+			// robin each time, which repeats some pairings and omits others.
+			// Initial Fontes pairs each of its groups with the same function
+			// and so has the same requirement.
+			rp, err := simplePairOnce(req, pairingMethod, poolMembers, playerOrder, currentRound+int32(roundIdx), uint64(req.Seed))
 			if err != nil {
 				return &pb.PairResponse{
 					ErrorCode:    pb.PairError_SIMPLE_PAIRING_FAILED,

--- a/pkg/pair/cop/cop_test.go
+++ b/pkg/pair/cop/cop_test.go
@@ -1574,6 +1574,54 @@ func checkSymmetric(t *testing.T, pairings []int32) {
 	}
 }
 
+// countMultiroundMeetings counts how many times each pair of players meets
+// across every round in a multiround pairings slice, keyed as "lo-hi". Byes
+// are not counted.
+func countMultiroundMeetings(multiroundPairings []int32, numPlayers int) map[string]int {
+	meetings := map[string]int{}
+	for round := 0; round < len(multiroundPairings)/numPlayers; round++ {
+		block := multiroundPairings[round*numPlayers : (round+1)*numPlayers]
+		for player, opp := range block {
+			if opp < 0 || int(opp) <= player {
+				continue // bye, or already counted from the other side
+			}
+			meetings[fmt.Sprintf("%d-%d", player, opp)]++
+		}
+	}
+	return meetings
+}
+
+// checkNoRepeatedPairings verifies that no two players meet twice across the
+// rounds of a multiround pairings slice. Use it for schedules that cover less
+// than a full round robin cycle, such as initial fontes.
+func checkNoRepeatedPairings(t *testing.T, multiroundPairings []int32, numPlayers int) {
+	t.Helper()
+	for pair, count := range countMultiroundMeetings(multiroundPairings, numPlayers) {
+		if count > 1 {
+			t.Errorf("players %s meet %d times across %d rounds, expected at most once",
+				pair, count, len(multiroundPairings)/numPlayers)
+		}
+	}
+}
+
+// checkCompleteRoundRobin verifies that the rounds of a multiround pairings
+// slice form the given number of complete round robin cycles: every pair of
+// players meets exactly once per cycle.
+func checkCompleteRoundRobin(t *testing.T, multiroundPairings []int32, numPlayers int, cycles int) {
+	t.Helper()
+	meetings := countMultiroundMeetings(multiroundPairings, numPlayers)
+	expectedPairs := numPlayers * (numPlayers - 1) / 2
+	if len(meetings) != expectedPairs {
+		t.Errorf("%d distinct pairings across %d rounds, expected %d",
+			len(meetings), len(multiroundPairings)/numPlayers, expectedPairs)
+	}
+	for pair, count := range meetings {
+		if count != cycles {
+			t.Errorf("players %s meet %d times, expected %d", pair, count, cycles)
+		}
+	}
+}
+
 // countByes returns the number of players paired with themselves (byes).
 func countByes(pairings []int32) int {
 	n := 0
@@ -1812,8 +1860,9 @@ func TestMultiroundPairings(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		checkSymmetric(t, resp.MultiroundPairings[i*numPlayers:(i+1)*numPlayers])
 	}
-	// Round robin should produce distinct schedules across rounds.
-	is.True(resp.MultiroundPairings[0] != resp.MultiroundPairings[numPlayers])
+	// Round robin should produce distinct schedules across rounds: three
+	// rounds of an eight player cycle must not repeat a pairing.
+	checkNoRepeatedPairings(t, resp.MultiroundPairings, numPlayers)
 
 	// With existing pairings, multiround_pairings is a copy of pairings.
 	pairtestutils.AddRoundPairingsStr(req, "4 5 6 7 0 1 2 3")
@@ -1840,6 +1889,7 @@ func TestMultiroundPairings(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		checkSymmetric(t, resp.MultiroundPairings[i*numPlayers:(i+1)*numPlayers])
 	}
+	checkNoRepeatedPairings(t, resp.MultiroundPairings, numPlayers)
 
 	// AUTO with R=10, P=8: floor(10/7)*7=7 RR rounds, then COP for the remaining 3.
 	autoReq := pairtestutils.CreateDefaultPairRequest()
@@ -1852,6 +1902,7 @@ func TestMultiroundPairings(t *testing.T) {
 	for i := 0; i < rrRoundsTotal; i++ {
 		checkSymmetric(t, resp.MultiroundPairings[i*numPlayers:(i+1)*numPlayers])
 	}
+	checkCompleteRoundRobin(t, resp.MultiroundPairings, numPlayers, rrRoundsTotal/rrRounds)
 
 	// AUTO can only be used at the very start of a tournament, before any
 	// pairings or results exist; once pairings exist, it must be rejected.
@@ -1870,6 +1921,7 @@ func TestMultiroundPairings(t *testing.T) {
 	for i := 0; i < rrRoundsTotal; i++ {
 		checkSymmetric(t, resp.MultiroundPairings[i*numPlayers:(i+1)*numPlayers])
 	}
+	checkCompleteRoundRobin(t, resp.MultiroundPairings, numPlayers, rrRoundsTotal/rrRounds)
 
 	// AUTO with R=17, P=8: floor(17/7)*7=14 RR rounds, then COP for rounds 14-16.
 	autoReq = pairtestutils.CreateDefaultPairRequest()
@@ -1882,6 +1934,7 @@ func TestMultiroundPairings(t *testing.T) {
 	for i := 0; i < rrRoundsTotal; i++ {
 		checkSymmetric(t, resp.MultiroundPairings[i*numPlayers:(i+1)*numPlayers])
 	}
+	checkCompleteRoundRobin(t, resp.MultiroundPairings, numPlayers, rrRoundsTotal/rrRounds)
 	pairtestutils.AddNDummyRounds(autoReq, rrRoundsTotal)
 	resp = COPPair(autoReq)
 	is.Equal(resp.ErrorCode, pb.PairError_INVALID_AUTO_PAIRING_METHOD_USAGE)
@@ -1896,6 +1949,7 @@ func TestMultiroundPairings(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		checkSymmetric(t, resp.MultiroundPairings[i*numPlayers:(i+1)*numPlayers])
 	}
+	checkNoRepeatedPairings(t, resp.MultiroundPairings, numPlayers)
 
 	// AUTO with 10 players and R=8 (< rrRounds=9): rounds 0-2 use Initial
 	// Fontes, and round 3 onward now uses COP directly (Swiss was removed).


### PR DESCRIPTION
## Problem

`multiround_pairings` does not form a valid schedule. The rounds after the first repeat some pairings and omit others entirely:

- **4 players, 6 rounds** (2 round robin cycles): only 2 of the 3 possible pairings ever appear; players 0-3 and 1-2 never meet.
- **6 players, 5 rounds** (1 cycle): 11 of 15 pairs appear, 4 of them twice.
- **20 players, initial fontes**: round 3 comes back byte-identical to round 1.

Only the first round is correct, because it comes from the `simplePairOnce` call at cop.go:1533 that passes `uint64(req.Seed)` unmodified.

## Cause

`simplePair` generates the remaining rounds with `uint64(req.Seed)+uint64(roundIdx)`, giving every round a different seed.

`GetRoundRobinPairings` shuffles the players with `rand.NewPCG(seed, 0)` — the seed alone — and then derives each round by rotating that one ordering by `round % l`. The rounds only compose into a round robin if they share a seed and differ only in the round. Bumping the seed reshuffles the base ordering, so each round is a valid round from an *unrelated* round robin. Initial Fontes pairs each of its N-tile groups with the same function and has the same requirement; 20 players splits into groups of 4, where only 3 distinct pairings exist, which is why a fontes round repeated exactly.

## Fix

Pass the request seed unchanged for every round. `currentRound+int32(roundIdx)` was already correct and is the parameter meant to vary.

## Why the tests did not catch it

The two relevant tests cover different things, and the gap between them is exactly where the bug lives:

- `TestRoundRobin` does verify full cycle coverage, exhaustively, for 2..25 players over 60 rounds — but `seed` is the outer loop and `round` the inner one, so it only ever exercises the correct usage. It validates the generator, not the caller.
- `TestMultiroundPairings` exercises the buggy caller, but only asserted slice length and per-round symmetry, both of which a schedule of repeated rounds satisfies. Its one distinctness check, `resp.MultiroundPairings[0] != resp.MultiroundPairings[numPlayers]`, compared two single `int32` elements rather than two rounds.

This PR adds `checkNoRepeatedPairings` and `checkCompleteRoundRobin` and applies them to `MultiroundPairings`: no repeats for partial schedules such as initial fontes, and every pair exactly once per cycle for the AUTO round robin schedules.

Reverting the one-line fix with the new assertions in place fails as expected:

```
cop_test.go:1865: players 2-4 meet 2 times across 3 rounds, expected at most once
cop_test.go:1905: 21 distinct pairings across 7 rounds, expected 28
cop_test.go:1924: players 2-3 meet 3 times, expected 2
```

`go test ./pkg/pair/... -count=1` passes with the fix.

## Impact

Nothing consumed the affected rounds until now — clients read only `pairings`, which was always correct. This surfaced while wiring TSH's COP command to apply `multiround_pairings` for `PAIR_AUTO`, where it would have paired an initial fontes or round robin schedule containing real repeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)