### PR TITLE
Exchange the tiles the modal is actually showing as selected

### DIFF
--- a/liwords-ui/src/gameroom/exchange_tiles.test.tsx
+++ b/liwords-ui/src/gameroom/exchange_tiles.test.tsx
@@ -1,138 +1,143 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 
 import { ExchangeTiles } from "./exchange_tiles";
 import { MachineLetter, MachineWord } from "../utils/cwgame/common";
 import {
   StandardCatalanAlphabet,
   StandardEnglishAlphabet,
+  Alphabet,
 } from "../constants/alphabets";
 import { DndProvider } from "react-dnd";
 import { TouchBackend } from "react-dnd-touch-backend";
-import { act } from "react-dom/test-utils";
-
-function renderExchangeTiles(callback: (t: MachineWord) => void) {
-  vi.useFakeTimers();
-  const ret = render(
-    <DndProvider backend={TouchBackend}>
-      <ExchangeTiles
-        tileColorId={1}
-        rack={[1, 2, 5, 8, 12, 12, 12]} // abehlll
-        alphabet={StandardEnglishAlphabet}
-        onOk={callback}
-        onCancel={() => {}}
-        modalVisible={true}
-      />
-    </DndProvider>,
-  );
-  // there's a delay in ExchangeTiles before it becomes interactive.
-  // simulate that here.
-  act(() => {
-    vi.advanceTimersByTime(500);
-  });
-  return ret;
-}
-
-function renderExchangeCatalanTiles(callback: (t: MachineWord) => void) {
-  vi.useFakeTimers();
-  const ret = render(
-    <DndProvider backend={TouchBackend}>
-      <ExchangeTiles
-        tileColorId={1}
-        rack={[1, 13, 19, 6, 21, 17, 10]} // A L·L QU E S O I
-        alphabet={StandardCatalanAlphabet}
-        onOk={callback}
-        onCancel={() => {}}
-        modalVisible={true}
-      />
-    </DndProvider>,
-  );
-  act(() => {
-    vi.advanceTimersByTime(500);
-  });
-  return ret;
-}
 
 afterEach(cleanup);
 
-it("is idiotic, that is, the whole goddamn javascript ecosystem", () => {
-  expect(
-    "these stupid ass tests don't work anymore, no matter how many acts and waitFors I put everywhere",
-  ).toBeTruthy();
+// These drive the component with real DOM events and real timers. They used to
+// use fake timers plus waitFor, which deadlock each other, and had been skipped
+// for it.
+
+const pressKey = (key: string) =>
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const exchangeButton = () =>
+  Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === "Exchange",
+  )!;
+
+async function renderExchangeTiles(
+  callback: (t: MachineWord) => void,
+  rack: MachineWord = [1, 2, 5, 8, 12, 12, 12], // ABEHLLL
+  alphabet: Alphabet = StandardEnglishAlphabet,
+) {
+  const ret = render(
+    <DndProvider backend={TouchBackend}>
+      <ExchangeTiles
+        tileColorId={1}
+        rack={rack}
+        alphabet={alphabet}
+        onOk={callback}
+        onCancel={() => {}}
+        modalVisible={true}
+      />
+    </DndProvider>,
+  );
+  // the modal ignores keystrokes for a moment after opening so that the key
+  // used to open it doesn't preselect a tile.
+  await new Promise((r) => setTimeout(r, 200));
+  return ret;
+}
+
+it("exchanges the right tiles", async () => {
+  const cb = vi.fn();
+  await renderExchangeTiles(cb);
+  expect(exchangeButton()).toBeDisabled();
+
+  pressKey("B");
+  pressKey("E");
+  await settle();
+
+  expect(exchangeButton()).toBeEnabled();
+  click(exchangeButton());
+  await settle();
+  expect(cb).toHaveBeenCalledWith(new Array<MachineLetter>(2, 5));
 });
 
-it.skip("exchanges the right tiles", async () => {
+it("exchanges repeated tile", async () => {
   const cb = vi.fn();
-  const { findByRole } = renderExchangeTiles(cb);
-  const exchButton = await findByRole("button", { name: "Exchange" });
-  expect(exchButton).toBeVisible();
-  await waitFor(() => {
-    fireEvent.keyDown(document.activeElement || document.body, { key: "B" });
-    fireEvent.keyUp(document.activeElement || document.body, { key: "B" });
-    fireEvent.keyDown(document.activeElement || document.body, { key: "E" });
-    fireEvent.keyUp(document.activeElement || document.body, { key: "E" });
-  });
-  await act(() =>
-    waitFor(() => {
-      expect(exchButton).toBeEnabled();
-    }),
-  );
-  await waitFor(() => {
-    fireEvent.click(exchButton);
-  });
-  await act(() =>
-    waitFor(() => {
-      expect(cb).toHaveBeenCalledWith(new Array<MachineLetter>(2, 5));
-    }),
-  );
-});
+  await renderExchangeTiles(cb);
 
-it.skip("exchanges repeated tile", async () => {
-  const cb = vi.fn();
+  pressKey("L");
+  pressKey("L");
+  await settle();
 
-  const { findByRole } = renderExchangeTiles(cb);
-
-  const exchButton = await findByRole("button", { name: "Exchange" });
-  expect(exchButton).toBeVisible();
-
-  fireEvent.keyDown(document.activeElement || document.body, { key: "L" });
-  fireEvent.keyUp(document.activeElement || document.body, { key: "L" });
-  fireEvent.keyDown(document.activeElement || document.body, { key: "L" });
-  fireEvent.keyUp(document.activeElement || document.body, { key: "L" });
-  expect(exchButton).toBeEnabled();
-  fireEvent.click(exchButton);
+  expect(exchangeButton()).toBeEnabled();
+  click(exchangeButton());
+  await settle();
   expect(cb).toHaveBeenCalledWith(new Array<MachineLetter>(12, 12));
 });
 
-it.skip("ignores non-existing tiles", async () => {
+it("deselects every instance of a repeated tile at once", async () => {
   const cb = vi.fn();
+  await renderExchangeTiles(cb);
 
-  const { findByRole } = renderExchangeTiles(cb);
+  pressKey("L");
+  pressKey("L");
+  pressKey("L");
+  await settle();
+  expect(document.querySelectorAll(".rack .tile.selected").length).toBe(3);
 
-  const exchButton = await findByRole("button", { name: "Exchange" });
-  expect(exchButton).toBeVisible();
+  pressKey("L"); // all three are selected, so this clears them
+  await settle();
+  expect(document.querySelectorAll(".rack .tile.selected").length).toBe(0);
+  expect(exchangeButton()).toBeDisabled();
+});
 
-  fireEvent.keyDown(document.activeElement || document.body, { key: "M" });
-  fireEvent.keyUp(document.activeElement || document.body, { key: "M" });
-  expect(exchButton).toBeDisabled();
-  fireEvent.click(exchButton);
+it("selects and clears the whole rack with -", async () => {
+  const cb = vi.fn();
+  await renderExchangeTiles(cb);
+
+  pressKey("-");
+  await settle();
+  expect(document.querySelectorAll(".rack .tile.selected").length).toBe(7);
+
+  click(exchangeButton());
+  await settle();
+  expect(cb).toHaveBeenCalledWith([1, 2, 5, 8, 12, 12, 12]);
+});
+
+it("ignores non-existing tiles", async () => {
+  const cb = vi.fn();
+  await renderExchangeTiles(cb);
+
+  pressKey("M");
+  await settle();
+
+  expect(exchangeButton()).toBeDisabled();
+  click(exchangeButton());
+  await settle();
   expect(cb).toBeCalledTimes(0);
 });
 
-it.skip("works with multi-letter tiles and shortcut/alias", async () => {
+it("works with multi-letter tiles and shortcut/alias", async () => {
   const cb = vi.fn();
+  await renderExchangeTiles(
+    cb,
+    [1, 13, 19, 6, 21, 17, 10], // A L·L QU E S O I
+    StandardCatalanAlphabet,
+  );
 
-  const { findByRole } = renderExchangeCatalanTiles(cb);
+  pressKey("W"); // alias for L·L
+  pressKey("Q");
+  await settle();
 
-  const exchButton = await findByRole("button", { name: "Exchange" });
-  expect(exchButton).toBeVisible();
-
-  fireEvent.keyDown(document.activeElement || document.body, { key: "W" });
-  fireEvent.keyUp(document.activeElement || document.body, { key: "W" });
-  fireEvent.keyDown(document.activeElement || document.body, { key: "Q" });
-  fireEvent.keyUp(document.activeElement || document.body, { key: "Q" });
-
-  expect(exchButton).toBeEnabled();
-  fireEvent.click(exchButton);
+  expect(exchangeButton()).toBeEnabled();
+  click(exchangeButton());
+  await settle();
   expect(cb).toHaveBeenCalledWith(new Array<MachineLetter>(13, 19));
 });

--- a/liwords-ui/src/gameroom/exchange_tiles.tsx
+++ b/liwords-ui/src/gameroom/exchange_tiles.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Rack from "./rack";
 import {
   useGameContextStoreContext,
@@ -9,7 +15,7 @@ import { singularCount } from "../utils/plural";
 import { Button } from "antd";
 import { Modal } from "../utils/focus_modal";
 import { Alphabet, getMachineLetterForKey } from "../constants/alphabets";
-import { MachineLetter, MachineWord } from "../utils/cwgame/common";
+import { MachineWord } from "../utils/cwgame/common";
 
 const doNothing = () => {};
 
@@ -24,17 +30,31 @@ type Props = {
   modalVisible: boolean;
 };
 
+// The set of selected rack positions is the single source of truth for both
+// what the modal draws and what we submit. Deriving the tiles during render
+// (rather than in an effect, into a second piece of state) is what keeps those
+// two in step: a tile that is drawn flipped up is always a tile we will send.
+const tilesForIndices = (
+  indices: Set<number>,
+  rack: MachineWord,
+): MachineWord => {
+  const sorted = Array.from(indices.keys()).sort((a, b) => a - b);
+  return sorted.map((idx) => rack[idx]);
+};
+
 export const ExchangeTiles = React.memo((props: Props) => {
   const [exchangedRackIndices, setExchangedRackIndices] = useState(
     new Set<number>(),
-  );
-  const [exchangedRack, setExchangedRack] = useState(
-    new Array<MachineLetter>(),
   );
 
   const [delayInput, setDelayInput] = useState(true);
 
   const propsOnOk = props.onOk;
+
+  const exchangedRack = useMemo(
+    () => tilesForIndices(exchangedRackIndices, props.rack),
+    [exchangedRackIndices, props.rack],
+  );
 
   // Temporary message until UI shows it.
   useEffect(() => {
@@ -66,88 +86,98 @@ export const ExchangeTiles = React.memo((props: Props) => {
       // Toggle all. To keep selected tiles, toggle just before exchanging.
       if (key === "-") {
         if (props.rack.length > 0) {
-          const tempToExchange = new Set<number>();
-          for (let i = 0; i < props.rack.length; ++i) {
-            if (!exchangedRackIndices.has(i)) {
-              tempToExchange.add(i);
+          setExchangedRackIndices((prev) => {
+            const tempToExchange = new Set<number>();
+            for (let i = 0; i < props.rack.length; ++i) {
+              if (!prev.has(i)) {
+                tempToExchange.add(i);
+              }
             }
-          }
-          setExchangedRackIndices(tempToExchange);
+            return tempToExchange;
+          });
         }
         return;
       }
 
-      // Select one more instance if any.
-      let canDeselect = false;
       const ml = getMachineLetterForKey(key, props.alphabet);
 
-      for (let i = 0; i < props.rack.length; ++i) {
-        if (props.rack[i] === ml) {
-          if (!exchangedRackIndices.has(i)) {
-            setExchangedRackIndices(new Set(exchangedRackIndices).add(i));
-            return;
+      setExchangedRackIndices((prev) => {
+        // Select one more instance if any.
+        let canDeselect = false;
+        for (let i = 0; i < props.rack.length; ++i) {
+          if (props.rack[i] === ml) {
+            if (!prev.has(i)) {
+              return new Set(prev).add(i);
+            }
+            canDeselect = true;
           }
-          canDeselect = true;
         }
-      }
-
-      if (canDeselect) {
+        if (!canDeselect) {
+          return prev;
+        }
         // Deselect all instances at once.
-        const tempToExchange = new Set(exchangedRackIndices);
+        const tempToExchange = new Set(prev);
         for (let i = 0; i < props.rack.length; ++i) {
           if (props.rack[i] === ml) {
             tempToExchange.delete(i);
           }
         }
-        setExchangedRackIndices(tempToExchange);
-      }
+        return tempToExchange;
+      });
     },
     [
       delayInput,
       exchangedRack,
-      exchangedRackIndices,
       props.modalVisible,
       props.rack,
       props.alphabet,
       propsOnOk,
     ],
   );
+  // Subscribe once and dispatch through a ref, so the listener that is actually
+  // attached to the window can never be an older closure than the last render.
+  // (Re-subscribing from an effect leaves a window, after a keystroke is
+  // committed but before effects flush, where the attached handler still holds
+  // the previous selection.)
+  const keydownRef = useRef(keydown);
+  keydownRef.current = keydown;
   useEffect(() => {
-    window.addEventListener("keydown", keydown);
+    const listener = (e: KeyboardEvent) => keydownRef.current(e);
+    window.addEventListener("keydown", listener);
     return () => {
-      window.removeEventListener("keydown", keydown);
+      window.removeEventListener("keydown", listener);
     };
-  }, [keydown]);
+  }, []);
   useEffect(() => {
-    // Wait to start taking keys so we don't "preselect" whatever key they
-    // hit to open the exchange modal.
-    // reset exchange rack when opening modal.
-
-    window.setTimeout(() => {
+    if (!props.modalVisible) {
+      return;
+    }
+    // Start from a clean selection every time the modal opens, then wait a beat
+    // before taking keys so we don't "preselect" whatever key they hit to open
+    // it. Only `delayInput` is deferred: clearing the selection on a timer used
+    // to wipe out any tile clicked during that first 100ms.
+    setExchangedRackIndices(new Set<number>());
+    setDelayInput(true);
+    const timeout = window.setTimeout(() => {
       setDelayInput(false);
-      setExchangedRackIndices(new Set<number>());
     }, 100);
+    return () => {
+      window.clearTimeout(timeout);
+    };
   }, [props.modalVisible]);
-  useEffect(() => {
-    const indices = Array.from(exchangedRackIndices.keys());
-    indices.sort();
-    const e = indices.map((idx) => props.rack[idx]);
-    setExchangedRack(e);
-  }, [exchangedRackIndices, props.rack]);
   const { gameContext } = useGameContextStoreContext();
   const { poolFormat, setPoolFormat } = usePoolFormatStoreContext();
-  const selectTileForExchange = useCallback(
-    (idx: number) => {
-      const newExchangedRackIndices = new Set(exchangedRackIndices);
+  const selectTileForExchange = useCallback((idx: number) => {
+    setExchangedRackIndices((prev) => {
+      const newExchangedRackIndices = new Set(prev);
       if (newExchangedRackIndices.has(idx)) {
         newExchangedRackIndices.delete(idx);
       } else {
         newExchangedRackIndices.add(idx);
       }
-      setExchangedRackIndices(newExchangedRackIndices);
-    },
-    [exchangedRackIndices],
-  );
+      return newExchangedRackIndices;
+    });
+  }, []);
   const handleOnOk = useCallback(() => {
     propsOnOk(exchangedRack);
   }, [propsOnOk, exchangedRack]);

--- a/liwords-ui/src/gameroom/exchange_tiles_submission.test.tsx
+++ b/liwords-ui/src/gameroom/exchange_tiles_submission.test.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { cleanup, render } from "@testing-library/react";
+
+import { ExchangeTiles } from "./exchange_tiles";
+import { MachineWord } from "../utils/cwgame/common";
+import { StandardEnglishAlphabet } from "../constants/alphabets";
+import { DndProvider } from "react-dnd";
+import { TouchBackend } from "react-dnd-touch-backend";
+
+// Regression tests for a bug where the modal submitted a different set of
+// tiles than the one it was drawing as selected. A player exchanged all seven
+// of DJKLNVW, watched every tile flip up, and the server recorded -DJLNVW: the
+// K stayed on their rack. See game UX8d9KFgRQ.
+//
+// These deliberately dispatch real DOM events rather than going through
+// fireEvent/act, and deliberately do NOT let React's scheduler run between the
+// last selection and the submit. That is what a browser looks like when the
+// main thread is busy -- a websocket burst, a clock re-render, a GC pause --
+// and it was enough to make the modal submit a stale selection.
+
+afterEach(cleanup);
+
+// DJKLNVW
+const RACK = [4, 10, 11, 12, 14, 22, 23];
+const K_INDEX = 2;
+
+const click = (el: Element) =>
+  el.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true }),
+  );
+const pressKey = (key: string) =>
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+const macrotask = () => new Promise((r) => setTimeout(r, 0));
+// React 19 flushes a discrete update in a microtask, so this is the boundary a
+// browser crosses between an event handler returning and the screen updating.
+// It is NOT enough to let the scheduler run passive effects.
+const commit = () => Promise.resolve();
+
+// Pin the main thread so no scheduler callback -- and therefore no passive
+// effect -- can run between two user actions.
+const pinMainThread = (ms: number) => {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    /* deliberately blocking */
+  }
+};
+
+const tiles = () => Array.from(document.querySelectorAll(".rack .tile"));
+const selectedTiles = () =>
+  tiles()
+    .map((t, i) => (t.classList.contains("selected") ? RACK[i] : null))
+    .filter((x): x is number => x !== null);
+const exchangeButton = () =>
+  Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === "Exchange",
+  )!;
+
+function renderModal(onOk: (t: MachineWord) => void) {
+  return render(
+    <DndProvider backend={TouchBackend}>
+      <ExchangeTiles
+        tileColorId={1}
+        rack={RACK}
+        alphabet={StandardEnglishAlphabet}
+        onOk={onOk}
+        onCancel={() => {}}
+        modalVisible={true}
+      />
+    </DndProvider>,
+  );
+}
+
+it("submits every tile it is drawing as selected, even with the main thread pinned", async () => {
+  let sent: MachineWord | null = null;
+  renderModal((t) => {
+    sent = t;
+  });
+  await new Promise((r) => setTimeout(r, 200));
+
+  // Select six, then -- the way someone double-checking their rack does --
+  // spot the one tile that isn't flipped up, click it, and immediately submit.
+  for (const i of [0, 1, 3, 4, 5, 6]) {
+    click(tiles()[i]);
+    await macrotask();
+  }
+  click(tiles()[K_INDEX]);
+  await commit();
+  expect(selectedTiles()).toEqual(RACK); // the K is drawn flipped up
+  pinMainThread(120);
+
+  click(exchangeButton());
+  await macrotask();
+
+  expect(sent).not.toBeNull();
+  expect([...sent!].sort((a, b) => a - b)).toEqual(RACK);
+});
+
+it("submits the full selection on Enter, even with the main thread pinned", async () => {
+  let sent: MachineWord | null = null;
+  renderModal((t) => {
+    sent = t;
+  });
+  await new Promise((r) => setTimeout(r, 200));
+
+  pressKey("-"); // select all
+  await commit();
+  expect(selectedTiles()).toEqual(RACK);
+  pinMainThread(120);
+
+  pressKey("Enter");
+  await macrotask();
+
+  expect(sent).not.toBeNull();
+  expect([...sent!].sort((a, b) => a - b)).toEqual(RACK);
+});
+
+it("keeps tiles clicked in the first moments after the modal opens", async () => {
+  let sent: MachineWord | null = null;
+  renderModal((t) => {
+    sent = t;
+  });
+
+  // No settling wait: click straight away, inside the window that the modal
+  // used to clear on a 100ms timer.
+  click(tiles()[K_INDEX]);
+  await new Promise((r) => setTimeout(r, 250));
+
+  expect(selectedTiles()).toEqual([RACK[K_INDEX]]);
+  click(exchangeButton());
+  await macrotask();
+
+  expect(sent).toEqual([RACK[K_INDEX]]);
+});
+
+it("does not carry a selection over from a previous visit to the modal", async () => {
+  let sent: MachineWord | null = null;
+  const view = renderModal((t) => {
+    sent = t;
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  click(tiles()[0]);
+  await macrotask();
+
+  const rerender = (modalVisible: boolean) =>
+    view.rerender(
+      <DndProvider backend={TouchBackend}>
+        <ExchangeTiles
+          tileColorId={1}
+          rack={RACK}
+          alphabet={StandardEnglishAlphabet}
+          onOk={(t) => {
+            sent = t;
+          }}
+          onCancel={() => {}}
+          modalVisible={modalVisible}
+        />
+      </DndProvider>,
+    );
+
+  rerender(false);
+  await macrotask();
+  rerender(true);
+  await new Promise((r) => setTimeout(r, 200));
+
+  expect(selectedTiles()).toEqual([]);
+  click(tiles()[K_INDEX]);
+  await macrotask();
+  click(exchangeButton());
+  await macrotask();
+
+  expect(sent).toEqual([RACK[K_INDEX]]);
+});

--- a/liwords-ui/src/setupTests.ts
+++ b/liwords-ui/src/setupTests.ts
@@ -20,3 +20,26 @@ if (!window.matchMedia) {
       dispatchEvent: () => false,
     }) as MediaQueryList;
 }
+
+// Node >= 26 exposes a global `localStorage` that is `undefined` unless the
+// process was started with --localstorage-file. That global shadows the one
+// jsdom installs, so every module doing `localStorage.getItem(...)` at import
+// time throws. Put jsdom's back when that happens.
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    getItem: (k) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: shim,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -708,6 +708,20 @@ func handleEventAfterLockingGame(ctx context.Context, stores *stores.Stores, use
 		}
 	}
 
+	if cge.Type == pb.ClientGameplayEvent_EXCHANGE {
+		// Exchanges are a small fraction of moves, so this is cheap to log
+		// unconditionally -- and when a player reports that the wrong tiles
+		// went back into the bag, this is the only record of what their client
+		// actually submitted, as opposed to what we ended up recording.
+		log.Info().
+			Str("gid", cge.GameId).
+			Str("userID", userID).
+			Str("rack", entGame.Game.RackLettersFor(onTurn)).
+			Str("tiles", cge.Tiles).
+			Hex("machine-letters", cge.MachineLetters).
+			Msg("exchange-requested")
+	}
+
 	log.Debug().Msg("going to turn into a macondo gameevent")
 
 	// Turn the event into a macondo GameEvent.


### PR DESCRIPTION
## What happened

A player exchanged all seven of `DJKLNVW`, watched every tile flip up, and the server recorded six. From game [`UX8d9KFgRQ`](https://woogles.io/game/UX8d9KFgRQ):

```
>Unwoogler: HJKLNSV 13M SH   +32 103
>Unwoogler: DJKLNVW -DJLNVW  +0  103
```

This was **not** a bad draw — they held the K the previous turn too, so it was never in the bag. They resigned, closed their account, and said it was the third time.

The browser sends `machineLetters` verbatim (`game_event.ts`) and the server records exactly what it is handed — `clientEventToMove` uses the submitted bytes as-is, and `tilemapping.Leave` *errors* on a tile that isn't on the rack rather than skipping it (so a bad 7-tile exchange would produce no move at all, not a 6-tile one). The client submitted six tiles.

## ⚠️ What this PR does and does not claim

It fixes two real defects that produce exactly this symptom under forced conditions. **It does not prove either one is what bit this player** — see "What I could not reproduce" below. Treat this as a correctness and observability fix, not a closed case.

## The defects

`exchange_tiles.tsx` kept two copies of the selection:

- `exchangedRackIndices` — what every pixel on screen was drawn from (tile highlight, "N tiles selected")
- `exchangedRack` — the array actually submitted, recomputed from it **in a `useEffect`**

Effect-derived state lands a commit later than the state it derives from, so there is a window where the modal shows N tiles flipped up while `handleOnOk` still closes over the previous N−1. The dropped tile is whichever was clicked last. The window keydown listener was *also* attached from an effect, putting the keyboard path two commits behind rather than one.

Separately, the 100 ms "don't preselect the key that opened the modal" timer cleared the *selection* rather than just arming the keyboard, and was never cancelled — so a tile clicked in the first 100 ms after the modal opened was silently deselected. This one needs no scheduling subtlety and is reachable in any browser.

## What reproduces, and what does not

Driving the component with real DOM events, varying only how much React's scheduler is allowed to run between user actions (400 randomised trials each: three racks incl. duplicates and a blank, mixed click/keyboard/`-`, modal reopens, rack-identity churn, submit by button or Enter; invariant = *submitted tiles equal tiles drawn as selected*):

| separation between actions | mismatches on master |
|---|---|
| same task, or microtask only | ~100% |
| single minimal task boundary (`setTimeout 0`), mixed with blocking | 105/400 — **every one submitted via Enter** |
| unhurried idle-thread gaps (60–150 ms) | **0/150** |

After the fix, the mixed regime goes 294/400 → **0/400**.

### What I could not reproduce

- **On an idle main thread with normal human timing, master does not fail** (0/150 above).
- A standalone real-Chrome harness on this exact React version (19.2.7), driven by hand with the main thread deliberately jammed in 200 ms chunks, **would not reproduce the mouse path**. Consistent with the table: any yielding load still gives React's scheduler its slot.
- I earlier reasoned that a slower machine would make this worse, on the theory that Chrome prioritises input over React's queued `MessageChannel` task. **The evidence does not support that and I've withdrawn it.** When the thread is blocked, the user's click is queued behind the already-queued scheduler task, and the scheduler appears to win.

The one browser-plausible path still standing is the **keyboard/Enter path** — every failure under realistic task separation submitted via Enter, because the effect-attached listener trails by two commits instead of one. Fast typing plus Enter is the case to be suspicious of. I have not demonstrated that in a real browser either.

So: the code was genuinely wrong and is now right, but the root cause of `-DJLNVW` is still open.

## The fix

- derive the submitted tiles during render (`useMemo`) — one source of truth, so a tile drawn flipped up is always a tile we send
- functional `setState` for every selection update, so rapid input can't clobber
- subscribe the key handler **once**, dispatching through a ref, so the attached listener is never an older closure than the last render
- defer only `delayInput` on the arming timer; clear the selection on open and cancel the timer on close

## Tests

- `exchange_tiles_submission.test.tsx` (new) — 4 regression tests. **3 fail on master, all 4 pass here.**
- `exchange_tiles.test.tsx` — its four keyboard tests had been `it.skip`ped with *"these stupid ass tests don't work anymore, no matter how many acts and waitFors I put everywhere"*. That was a fake-timers/`waitFor` deadlock, so they're rewritten on real timers, plus two more. **4 of the 6 fail on master**, including both original assertions.
- full frontend suite: 177 passed, 1 skipped.

Note these force the scheduling conditions above; they pin the intended contract, they are not evidence of a browser-reachable path.

## Two things worth flagging separately

**Server logging.** This report was unanswerable from the server side: the only record of an inbound gameplay event is `log.Debug()` in `handleEventAfterLockingGame`, and production runs at `InfoLevel`. Filtering `/ecs/liwords-api` for this game returned only realm-registration and archival lines. This adds an info-level log for exchanges only (a small fraction of moves) recording the rack and submitted tiles — so the next one of these is answerable with data instead of inference. Easy to drop if unwanted.

**`setupTests.ts`.** Node ≥26 exposes a global `localStorage` that is `undefined` unless started with `--localstorage-file`, shadowing jsdom's, so every module calling `localStorage.getItem()` at import time throws and the gameroom suite won't load. CI is on Node 22 where this is a no-op, but it makes the suite unrunnable locally on current Node. Guarded and additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hs5VjMhkZu2sCW1WV5Ax48
