### PR TITLE
league: merge the undersized bottom division after enforcing guarantees

### DIFF
--- a/pkg/league/rebalance.go
+++ b/pkg/league/rebalance.go
@@ -135,23 +135,40 @@ func (rm *RebalanceManager) RebalanceDivisions(
 	result.DivisionsCreated = numDivisions
 	result.PlayersAssigned = len(playersWithPriority)
 
-	// Step 6: Merge undersized final division if needed
-	merged, err := rm.MergeUndersizedFinalDivision(ctx, newSeasonID, numDivisions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge undersized final division: %w", err)
-	}
-	result.FinalDivMerged = merged
-	if merged {
-		result.DivisionsCreated--
-	}
-
-	// Step 6b: Enforce promotion/stay guarantees.
-	// Runs after the merge so it operates on the final division layout.
-	// Merge only ever moves players upward (lower-numbered divisions), so it
-	// cannot introduce guarantee violations; enforcement then fixes any that
-	// remain from the initial bucketing.
+	// Step 6: Enforce promotion/stay guarantees.
+	//
+	// This runs BEFORE the undersize merge. Enforcement only ever pulls players
+	// upward (into lower-numbered divisions), so it can drain the bottom
+	// division after bucketing has filled it. Sizing the bottom division first
+	// measures a distribution that enforcement is about to change: the check
+	// passes on the pre-enforcement count and nothing re-examines what is left.
+	//
+	// PROMOTED players are the live path into this. Their ceiling is
+	// prevDiv-1 with no bottom-division exemption (unlike STAYED, see
+	// ceilingForStatus), so promoted players from the previous season's bottom
+	// division can be bucketed into a newly created bottom division and then
+	// pulled straight back out of it.
 	if err := rm.enforceGuarantees(ctx, newSeasonID, playersWithPriority, highestPrevDivNumber); err != nil {
 		return nil, fmt.Errorf("failed to enforce placement guarantees: %w", err)
+	}
+
+	// Step 7: Merge the final division if enforcement (or bucketing) left it
+	// undersized. Merging moves players upward, into a lower-numbered division,
+	// so it can never violate the ceilings enforced above.
+	//
+	// Loop because absorbing one undersized division can leave the division that
+	// becomes the new bottom undersized in turn. numDivisions bounds the loop:
+	// each merge removes exactly one division.
+	for range numDivisions {
+		merged, err := rm.MergeUndersizedFinalDivision(ctx, newSeasonID, result.DivisionsCreated)
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge undersized final division: %w", err)
+		}
+		if !merged {
+			break
+		}
+		result.FinalDivMerged = true
+		result.DivisionsCreated--
 	}
 
 	// Get final division assignments for result and correct placement statuses
@@ -231,13 +248,13 @@ func ceilingForStatus(status ipc.PlacementStatus, prevDiv int32, highestPrevDivN
 }
 
 // enforceGuarantees moves any PROMOTED or STAYED player whose final division
-// violates their earned outcome into their ceiling division.  This is called
-// after MergeUndersizedFinalDivision so that it operates on the final layout;
-// merge only ever moves players upward (into lower-numbered divisions) so it
-// cannot introduce guarantee violations.
+// violates their earned outcome into their ceiling division.
 //
-// Division sizing may drift slightly as a result; that is intentional and left
-// to be addressed separately.
+// This runs before MergeUndersizedFinalDivision. Enforcement only ever moves
+// players upward (into lower-numbered divisions), so it shrinks lower divisions
+// and can leave the bottom one undersized; the merge that follows is what
+// resizes it. Running the size check first instead would measure a distribution
+// that enforcement is about to change.
 func (rm *RebalanceManager) enforceGuarantees(
 	ctx context.Context,
 	seasonID uuid.UUID,

--- a/pkg/league/rebalance_integration_test.go
+++ b/pkg/league/rebalance_integration_test.go
@@ -567,7 +567,7 @@ func TestEnforceGuarantees_PromotedPlayerGuaranteed(t *testing.T) {
 // Scenario: 30 players across 2 divisions of 15.
 //   - Div-1: 2 relegated (virtual div 2, score ~150k) + 13 stayed (virtual div 1, ~240k).
 //   - Div-2: 3 relegated (virtual div 3 — beyond last div, overflow to div 2)
-//             + 12 stayed (virtual div 2, ~140k).
+//   - 12 stayed (virtual div 2, ~140k).
 //
 // The 2 relegated from div1 and 3 relegated from div2 both have high relegated bonus (50k).
 // We construct a case where some STAYED-from-div1 players (ceiling=div1) are crowded out.
@@ -830,4 +830,143 @@ func TestEnforceGuarantees_BottomDivisionStayedCanSeedNewDivision(t *testing.T) 
 	// pulled back into Division 1 by their unconditional ceiling guarantee.
 	is.Equal(div1Count, 15)
 	is.Equal(div2Count, 13)
+}
+
+// TestRebalance_EnforcementDrainedBottomDivisionGetsMerged covers the ordering
+// between MergeUndersizedFinalDivision and enforceGuarantees.
+//
+// The merge used to run first, sizing the bottom division against a
+// distribution that enforcement was about to change: bucketing filled it past
+// MinimumFinalDivSize, the size check passed, and enforcement then pulled the
+// ceiling-holding players back up out of it, leaving a rump division nothing
+// rechecked.
+//
+// PROMOTED is the status that still reaches this. Its ceiling is prevDiv-1
+// with no bottom-division exemption -- c817963c added one only for STAYED --
+// so promoted players from the previous bottom division can be bucketed into a
+// newly created bottom division and immediately pulled back out.
+//
+// Scenario: season 1 has 4 divisions of 15. Division 4 (the bottom) sends 4
+// players up as PROMOTED and keeps 11 as STAYED. All 60 return for season 2,
+// which needs round(60/15)=4 divisions. Priority bucketing puts the 4 PROMOTED
+// (virtual div 3, bonus 30k) below the 15 STAYED players of virtual div 3
+// (bonus 40k), so they land at the top of Division 4 alongside the 11 STAYED
+// players from the old bottom division -- 15 players, comfortably above the
+// threshold. Enforcement then moves those 4 up to their ceiling of Division 3,
+// dropping Division 4 to 11. The merge must run after that to see it.
+func TestRebalance_EnforcementDrainedBottomDivisionGetsMerged(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	allStores, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	store := allStores.LeagueStore
+	leagueID, season1ID := createLeagueAndSeason(t, ctx, allStores)
+
+	// Season 1: four divisions of 15 (users 1-15, 16-30, 31-45, 46-60).
+	s1Divs := make([]uuid.UUID, 5) // 1-indexed by division number
+	for divNum := 1; divNum <= 4; divNum++ {
+		id := uuid.New()
+		_, err := store.CreateDivision(ctx, models.CreateDivisionParams{
+			Uuid: id, SeasonID: season1ID, DivisionNumber: int32(divNum),
+			DivisionName: pgtype.Text{String: fmt.Sprintf("Division %d", divNum), Valid: true},
+		})
+		is.NoErr(err)
+		s1Divs[divNum] = id
+	}
+
+	for i := 1; i <= 60; i++ {
+		divNum := (i-1)/15 + 1
+		divID := s1Divs[divNum]
+		rankInDiv := (i-1)%15 + 1
+
+		_, err := store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season1ID,
+			Status:     pgtype.Text{String: "REGISTERED", Valid: true},
+			DivisionID: pgtype.UUID{Bytes: divID, Valid: true},
+		})
+		is.NoErr(err)
+		err = store.UpsertStanding(ctx, models.UpsertStandingParams{
+			UserID: int32(i), DivisionID: divID,
+		})
+		is.NoErr(err)
+
+		// Division 4's top 4 finishers are promoted; everyone else stays.
+		// Distinct ranks keep bucketing order deterministic.
+		outcome := ipc.StandingResult_RESULT_STAYED
+		if divNum == 4 && rankInDiv <= 4 {
+			outcome = ipc.StandingResult_RESULT_PROMOTED
+		}
+		err = store.UpdateStandingResult(ctx, models.UpdateStandingResultParams{
+			DivisionID: divID, UserID: int32(i),
+			Result: pgtype.Int4{Int32: int32(outcome), Valid: true},
+		})
+		is.NoErr(err)
+		err = store.UpdatePreviousDivisionRank(ctx, models.UpdatePreviousDivisionRankParams{
+			UserID: int32(i), SeasonID: season1ID,
+			PreviousDivisionRank: pgtype.Int4{Int32: int32(rankInDiv), Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	// Season 2: all 60 return.
+	season2ID := uuid.New()
+	_, err := store.CreateSeason(ctx, models.CreateSeasonParams{
+		Uuid: season2ID, LeagueID: leagueID, SeasonNumber: 2,
+		StartDate: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		EndDate:   pgtype.Timestamptz{Time: time.Now().AddDate(0, 0, 14), Valid: true},
+		Status:    int32(ipc.SeasonStatus_SEASON_SCHEDULED),
+	})
+	is.NoErr(err)
+
+	for i := 1; i <= 60; i++ {
+		_, err = store.RegisterPlayer(ctx, models.RegisterPlayerParams{
+			UserID: int32(i), SeasonID: season2ID,
+			Status: pgtype.Text{String: "REGISTERED", Valid: true},
+		})
+		is.NoErr(err)
+	}
+
+	regs, err := store.GetSeasonRegistrations(ctx, season2ID)
+	is.NoErr(err)
+	is.Equal(len(regs), 60)
+
+	categorized := make([]CategorizedPlayer, 60)
+	for i, r := range regs {
+		categorized[i] = CategorizedPlayer{Registration: r, Category: PlayerCategoryReturning}
+	}
+
+	rm := NewRebalanceManager(allStores)
+	result, err := rm.RebalanceDivisions(ctx, leagueID, season1ID, season2ID, 2, categorized, 15)
+	is.NoErr(err)
+
+	// Enforcement drained the bucketed Division 4 from 15 down to 11, so the
+	// merge that follows must absorb it: 4 divisions created, 3 survive.
+	is.True(result.FinalDivMerged)
+	is.Equal(result.DivisionsCreated, 3)
+
+	s2Divs, err := store.GetDivisionsBySeason(ctx, season2ID)
+	is.NoErr(err)
+	is.Equal(len(s2Divs), 3)
+
+	counts := map[int32]int{}
+	for _, d := range s2Divs {
+		players, err := store.GetDivisionRegistrations(ctx, d.Uuid)
+		is.NoErr(err)
+		counts[d.DivisionNumber] = len(players)
+	}
+
+	// Every surviving division must clear the minimum. With the merge running
+	// first this ended as 15/15/19/11, leaving an 11-player bottom division.
+	for divNum, n := range counts {
+		is.True(n >= MinimumFinalDivSize)
+		if n < MinimumFinalDivSize {
+			t.Errorf("division %d has %d players, below minimum %d", divNum, n, MinimumFinalDivSize)
+		}
+	}
+	is.Equal(counts[1], 15)
+	is.Equal(counts[2], 15)
+	is.Equal(counts[3], 30) // 15 STAYED + 4 enforced-up PROMOTED + 11 merged in
+	is.Equal(len(counts), 3)
 }

--- a/pkg/league/rebalance_test.go
+++ b/pkg/league/rebalance_test.go
@@ -428,3 +428,81 @@ func TestNewRookieSplitting(t *testing.T) {
 		})
 	}
 }
+
+// TestDeutschSeason20_BottomDivisionRetention reproduces the Deutsch season 20
+// incident, which shipped a 3-player Division 5 on 2026-09-10.
+//
+// The maintenance task was running an image built before c817963c ("Don't pin
+// STAYED players to the previous season's bottom division"), so the deployed
+// ceilingForStatus had no bottom-division exemption for STAYED players. This
+// test pins the deployed-vs-fixed difference using the real production inputs,
+// so we know the deploy alone accounts for the outcome.
+//
+// Season 19 had 4 divisions, so highestPrevDivNumber was 4. Season 20 drew 73
+// registrations, needing round(73/15)=5 divisions, and priority bucketing put
+// these 13 players in the new bottom Division 5. Their (status, prevDiv) values
+// are taken verbatim from the division-preparation log at 2026-09-10T06:02:04Z.
+//
+// Division 5's final size is fully determined by these 13 players: enforcement
+// only ever moves a player to a LOWER-numbered division, so nobody can be moved
+// into the highest-numbered one. Retention is therefore exactly the count of
+// these players whose ceiling does not sit above Division 5.
+func TestDeutschSeason20_BottomDivisionRetention(t *testing.T) {
+	const (
+		bucketedDivision     = int32(5)
+		highestPrevDivNumber = int32(4) // season 19 had 4 divisions
+	)
+
+	// The 13 players bucketed into Division 5, from the production log.
+	div5 := []struct {
+		username string
+		status   ipc.PlacementStatus
+		prevDiv  int32
+	}{
+		{"aero", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"MrsLollypop", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"Anna12", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"peperoth", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"ANFAENGER", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"farmerobama", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"Claudine", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"janonym", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"Clodette", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"Friedusch", ipc.PlacementStatus_PLACEMENT_STAYED, 4},
+		{"MarkusK", ipc.PlacementStatus_PLACEMENT_NEW, 4},
+		{"dundunPokert", ipc.PlacementStatus_PLACEMENT_NEW, 4},
+		{"AH1959", ipc.PlacementStatus_PLACEMENT_SHORT_HIATUS_RETURNING, 4},
+	}
+	require.Len(t, div5, 13, "production bucketed 13 players into Division 5")
+
+	// retained mirrors the enforceGuarantees decision: a player is pulled out of
+	// their bucketed division when they hold a ceiling above it.
+	retained := []string{}
+	for _, p := range div5 {
+		ceiling, hasGuarantee := ceilingForStatus(p.status, p.prevDiv, highestPrevDivNumber)
+		if hasGuarantee && bucketedDivision > ceiling {
+			continue // enforcement moves this player up and out
+		}
+		retained = append(retained, p.username)
+	}
+
+	// With c817963c the 10 STAYED players were already in the previous season's
+	// bottom division (prevDiv 4 == highestPrevDivNumber 4), so they carry no
+	// ceiling and stay put to seed the new division. NEW and hiatus returners
+	// never carry one. All 13 are retained -- a viable division.
+	//
+	// On the image actually deployed, those 10 got a ceiling of Division 4 and
+	// were pulled out, leaving only the 3 players production shipped with:
+	// MarkusK, dundunPokert and AH1959.
+	assert.Len(t, retained, 13,
+		"all 13 bucketed players should stay in Division 5; got %v", retained)
+
+	for _, p := range div5 {
+		t.Run(p.username, func(t *testing.T) {
+			_, hasGuarantee := ceilingForStatus(p.status, p.prevDiv, highestPrevDivNumber)
+			assert.False(t, hasGuarantee,
+				"%s (%s from div %d) must not carry a ceiling that empties the new bottom division",
+				p.username, p.status, p.prevDiv)
+		})
+	}
+}


### PR DESCRIPTION
## What

Reorders division rebalancing so `MergeUndersizedFinalDivision` runs **after** `enforceGuarantees`, and adds regression coverage for two separate things that produced undersized bottom divisions.

## The ordering bug (fixed here)

The merge ran first, so it sized the bottom division against a distribution that enforcement was about to change. Bucketing fills that division past `MinimumFinalDivSize`, the size check passes, and enforcement then pulls ceiling-holding players back up out of it — leaving a rump division nothing rechecks. The old code acknowledged the drift and deferred it:

> `// Division sizing may drift slightly as a result; that is intentional and left to be addressed separately.`

**PROMOTED is the status that still reaches this on current master.** Its ceiling is `prevDiv-1` with no bottom-division exemption — c817963c added one only for STAYED — so promoted players from the previous season's bottom division can be bucketed into a newly created bottom division and pulled straight back out.

`TestRebalance_EnforcementDrainedBottomDivisionGetsMerged` drives that path: season 1 has 4 divisions of 15, division 4 sends 4 players up as PROMOTED, and all 60 return. Bucketing puts those 4 at the top of the new Division 4 (15 players, above the threshold); enforcement moves them to their ceiling of Division 3, dropping it to 11. Verified to **fail on master** (`not true: result.FinalDivMerged`) and pass with the reorder.

Enforcement now runs first, then the merge, looping because absorbing one undersized division can leave the next one short. Merging only ever moves players into lower-numbered divisions, so it cannot violate the ceilings just enforced.

## The Deutsch season 20 incident (not this bug — pinned by test)

Deutsch shipped a **3-player Division 5** on 2026-09-10. This reorder is *not* what explains it. The `liwords-maintenance` ECS task definition is pinned to an image built **2026-06-09**, predating c817963c (2026-07-23), so the deployed `ceilingForStatus` had no bottom-division exemption. Season 19 had 4 divisions; season 20's 73 registrations needed 5; bucketing put 10 STAYED-from-div-4 players plus 2 NEW and 1 hiatus returner into the new Division 5; the deployed code gave those 10 a ceiling of Division 4 and pulled every one of them out.

`TestDeutschSeason20_BottomDivisionRetention` replays the 13 real players from that season's preparation log. The scenario needs no pipeline simulation: enforcement only moves players to lower-numbered divisions, so nobody can be moved *into* the highest-numbered one, and Division 5's outcome is fully determined by its own 13 members.

| code | Division 5 retains |
|---|---|
| deployed (pre-c817963c) | 3 — `MarkusK`, `dundunPokert`, `AH1959` |
| current master | all 13 |

The 3 are byte-for-byte what production shipped, confirmed against the prod DB. **Deploying a current maintenance image is what fixes Deutsch**; this PR does not, and does not try to.

## Not included

- **No maintenance task-def bump.** That's a prod deploy and is being handled separately. Worth noting the CI gap behind it: `deploy/build-and-tag.sh` builds and pushes `liwords-maintenance:master-ghNNNN` every master merge, but `build-and-deploy.yml` only registers a new task-def revision for `liwords-db-migration`, so maintenance is bumped by hand (Apr 15, May 5, Jun 9) and had drifted 3 months and 22 league commits behind.
- **No remediation for the live Deutsch season 20.** Backfilling that division to 15 games/player is not achievable: 23 players × 15 games = 345 slots, which is odd and so impossible. The nearest uniform target preserving existing games is 18 each, and anything above 14 breaks `MaxLeagueGamesPerPlayer` — it floors `gamesRemaining` in standings, and `mirrorForBest` in `rank_bounds.go` documents that it *requires* constant total games per player, so best-rank bounds would silently corrupt.

## Testing

Full `pkg/league` suite passes. Both new tests verified to fail without their respective fixes.