### PR TITLE
Component gallery, and the first Mantine component theme

### DIFF
--- a/liwords-ui/src/App.tsx
+++ b/liwords-ui/src/App.tsx
@@ -52,6 +52,7 @@ import { ChatMessageSchema } from "./gen/api/proto/ipc/chat_pb";
 import { MessageType } from "./gen/api/proto/ipc/ipc_pb";
 import Footer from "./navigation/footer";
 import { Embed } from "./embed/embed";
+import { ComponentGallery } from "./dev/component_gallery";
 
 import { App as AntDApp } from "antd";
 import { ConfigProvider } from "antd";
@@ -491,6 +492,15 @@ const App = React.memo(() => {
                 <Route path="docs/:manualId/:sectionId" element={<DocPage />} />
                 <Route path="about" element={<Team />} />
                 <Route path="team" element={<Team />} />
+                {/* Side-by-side antd/Mantine reference for the migration.
+                    import.meta.env.DEV is statically false in production, so
+                    the whole component tree-shakes out. It deliberately imports
+                    no stylesheet -- a stylesheet import is a side effect that
+                    survives tree-shaking even when the component does not.
+                    Removed in Phase 9 with antd. */}
+                {import.meta.env.DEV && (
+                  <Route path="dev/components" element={<ComponentGallery />} />
+                )}
                 <Route path="terms" element={<TermsOfService />} />
                 <Route path="register" element={<Register />} />
                 <Route path="verify-email" element={<VerifyEmail />} />

--- a/liwords-ui/src/dev/component_gallery.tsx
+++ b/liwords-ui/src/dev/component_gallery.tsx
@@ -1,0 +1,406 @@
+import React, { useState } from "react";
+import {
+  Alert as AntAlert,
+  Button as AntButton,
+  Card as AntCard,
+  Dropdown as AntDropdown,
+  Input as AntInput,
+  InputNumber as AntInputNumber,
+  Modal as AntModal,
+  Select as AntSelect,
+  Table as AntTable,
+  Tabs as AntTabs,
+  Tag as AntTag,
+  Tooltip as AntTooltip,
+} from "antd";
+import {
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Group,
+  Menu,
+  Modal,
+  NumberInput,
+  PasswordInput,
+  Select,
+  Stack,
+  Table,
+  Tabs,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+
+/**
+ * Side-by-side reference for the antd -> Mantine migration.
+ *
+ * Phase 2 translates ~322 lines of antd reskin mixins from base.scss into
+ * Mantine component theme overrides. Without something rendering both, that
+ * work is written blind and its mistakes only surface later, tangled up with
+ * whichever area is being migrated at the time.
+ *
+ * This page renders each component both ways so the theme can be tuned against
+ * the thing it is supposed to match. It inherits the app's colour mode, so
+ * toggling dark mode in Settings exercises the real path rather than a mock.
+ *
+ * Dev-only -- App.tsx does not register the route in production builds. Delete
+ * this directory in Phase 9 along with antd.
+ */
+
+type SpecimenProps = {
+  name: string;
+  note?: string;
+  antd: React.ReactNode;
+  mantine: React.ReactNode;
+};
+
+// Layout uses Mantine style props rather than a stylesheet, so this module has
+// no side-effect import and tree-shakes cleanly out of production builds.
+// Nothing here styles the specimens themselves: the point is to see each
+// library's real output, so cosmetics applied here would be lying to us.
+const Pane = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <Box
+    style={{
+      border: "1px dashed var(--woogles-color-gray-subtle)",
+      borderRadius: 4,
+      padding: 12,
+      minWidth: 0,
+    }}
+  >
+    <Text
+      size="10px"
+      tt="uppercase"
+      c="dimmed"
+      mb={8}
+      style={{ letterSpacing: "0.12em" }}
+    >
+      {label}
+    </Text>
+    <Group gap={8} align="center" wrap="wrap">
+      {children}
+    </Group>
+  </Box>
+);
+
+const Specimen = ({ name, note, antd, mantine }: SpecimenProps) => (
+  <Box
+    style={{
+      display: "grid",
+      gridTemplateColumns: "160px 1fr 1fr",
+      gap: 16,
+      alignItems: "start",
+      padding: "20px 0",
+      borderTop: "1px solid var(--woogles-color-gray-subtle)",
+    }}
+  >
+    <Box pt={4}>
+      <Text fw={700}>{name}</Text>
+      {note && (
+        <Text size="xs" c="dimmed" mt={2}>
+          {note}
+        </Text>
+      )}
+    </Box>
+    <Pane label="antd">{antd}</Pane>
+    <Pane label="mantine">{mantine}</Pane>
+  </Box>
+);
+
+const rows = [
+  { key: "1", player: "cesar", rating: 1842, result: "Win" },
+  { key: "2", player: "jesse", rating: 1790, result: "Loss" },
+];
+
+export const ComponentGallery = React.memo(() => {
+  const [antModalOpen, setAntModalOpen] = useState(false);
+  const [mantineModalOpen, setMantineModalOpen] = useState(false);
+
+  return (
+    <Stack
+      gap={0}
+      p={24}
+      maw={1400}
+      mx="auto"
+      c="var(--woogles-color-gray-extreme)"
+    >
+      <Title order={2}>Component gallery</Title>
+      <Text c="dimmed" size="sm">
+        antd on the left, Mantine on the right. Toggle dark mode in Settings to
+        compare both schemes. Dev builds only.
+      </Text>
+
+      <Specimen
+        name="Button"
+        note="base.scss @mixin button, 104 lines"
+        antd={
+          <>
+            <AntButton>Default</AntButton>
+            <AntButton type="primary">Primary</AntButton>
+            <AntButton disabled>Disabled</AntButton>
+            <AntButton danger>Danger</AntButton>
+          </>
+        }
+        mantine={
+          <>
+            <Button variant="default">Default</Button>
+            <Button>Primary</Button>
+            <Button disabled>Disabled</Button>
+            <Button color="red">Danger</Button>
+          </>
+        }
+      />
+
+      <Specimen
+        name="Card"
+        note="189 .ant-card selectors in SCSS"
+        antd={
+          <AntCard title="Card title" extra={<a href="#gallery">More</a>}>
+            Card body content.
+          </AntCard>
+        }
+        mantine={
+          <Card withBorder>
+            <Group justify="space-between" mb="xs">
+              <Text fw={700}>Card title</Text>
+              <Text size="sm">More</Text>
+            </Group>
+            Card body content.
+          </Card>
+        }
+      />
+
+      <Specimen
+        name="Text inputs"
+        antd={
+          <>
+            <AntInput placeholder="Text" />
+            <AntInputNumber placeholder="Number" />
+            <AntInput.Password placeholder="Password" />
+            <AntInput.TextArea placeholder="Textarea" rows={2} />
+          </>
+        }
+        mantine={
+          <>
+            <TextInput placeholder="Text" />
+            <NumberInput placeholder="Number" />
+            <PasswordInput placeholder="Password" />
+            <Textarea placeholder="Textarea" rows={2} />
+          </>
+        }
+      />
+
+      <Specimen
+        name="Select"
+        note="184 Select.Option children to convert"
+        antd={
+          <AntSelect
+            defaultValue="csw24"
+            options={[
+              { value: "csw24", label: "CSW24" },
+              { value: "nwl23", label: "NWL23" },
+            ]}
+          />
+        }
+        mantine={
+          <Select
+            defaultValue="csw24"
+            data={[
+              { value: "csw24", label: "CSW24" },
+              { value: "nwl23", label: "NWL23" },
+            ]}
+          />
+        }
+      />
+
+      <Specimen
+        name="Tabs"
+        note="base.scss @mixin tabs, 44 lines"
+        antd={
+          <AntTabs
+            defaultActiveKey="a"
+            items={[
+              { key: "a", label: "Chat", children: "Chat pane" },
+              { key: "b", label: "Players", children: "Players pane" },
+            ]}
+          />
+        }
+        mantine={
+          <Tabs defaultValue="a">
+            <Tabs.List>
+              <Tabs.Tab value="a">Chat</Tabs.Tab>
+              <Tabs.Tab value="b">Players</Tabs.Tab>
+            </Tabs.List>
+            <Tabs.Panel value="a" pt="xs">
+              Chat pane
+            </Tabs.Panel>
+            <Tabs.Panel value="b" pt="xs">
+              Players pane
+            </Tabs.Panel>
+          </Tabs>
+        }
+      />
+
+      <Specimen
+        name="Tag / Badge"
+        note="custom 16-colour palette in App.scss"
+        antd={
+          <>
+            <AntTag className="ant-tag-win">Win</AntTag>
+            <AntTag className="ant-tag-loss">Loss</AntTag>
+            <AntTag className="ant-tag-bye">Bye</AntTag>
+            <AntTag className="ant-tag-repeat">Repeat</AntTag>
+          </>
+        }
+        mantine={
+          <>
+            <Badge color="green">Win</Badge>
+            <Badge color="red">Loss</Badge>
+            <Badge color="gray">Bye</Badge>
+            <Badge color="blue">Repeat</Badge>
+          </>
+        }
+      />
+
+      <Specimen
+        name="Alert"
+        antd={
+          <>
+            <AntAlert message="Info message" type="info" />
+            <AntAlert message="Error message" type="error" />
+          </>
+        }
+        mantine={
+          <>
+            <Alert>Info message</Alert>
+            <Alert color="red">Error message</Alert>
+          </>
+        }
+      />
+
+      <Specimen
+        name="Tooltip"
+        note="33 files"
+        antd={
+          <AntTooltip title="Tooltip body" open>
+            <AntButton>Hover</AntButton>
+          </AntTooltip>
+        }
+        mantine={
+          <Tooltip label="Tooltip body" opened>
+            <Button variant="default">Hover</Button>
+          </Tooltip>
+        }
+      />
+
+      <Specimen
+        name="Dropdown / Menu"
+        antd={
+          <AntDropdown
+            menu={{
+              items: [
+                { key: "1", label: "Resign" },
+                { key: "2", label: "Offer draw" },
+              ],
+            }}
+          >
+            <AntButton>Actions</AntButton>
+          </AntDropdown>
+        }
+        mantine={
+          <Menu>
+            <Menu.Target>
+              <Button variant="default">Actions</Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              <Menu.Item>Resign</Menu.Item>
+              <Menu.Item>Offer draw</Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        }
+      />
+
+      <Specimen
+        name="Table"
+        note="38 instances; Mantine's is presentational only"
+        antd={
+          <AntTable
+            size="small"
+            pagination={false}
+            dataSource={rows}
+            columns={[
+              { title: "Player", dataIndex: "player", key: "player" },
+              { title: "Rating", dataIndex: "rating", key: "rating" },
+              { title: "Result", dataIndex: "result", key: "result" },
+            ]}
+          />
+        }
+        mantine={
+          <Table>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Player</Table.Th>
+                <Table.Th>Rating</Table.Th>
+                <Table.Th>Result</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.map((r) => (
+                <Table.Tr key={r.key}>
+                  <Table.Td>{r.player}</Table.Td>
+                  <Table.Td>{r.rating}</Table.Td>
+                  <Table.Td>{r.result}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        }
+      />
+
+      <Specimen
+        name="Modal"
+        note="base.scss @mixin modal, 56 lines; also mobile full-screen"
+        antd={
+          <>
+            <AntButton onClick={() => setAntModalOpen(true)}>
+              Open antd modal
+            </AntButton>
+            <AntModal
+              title="Modal title"
+              open={antModalOpen}
+              onCancel={() => setAntModalOpen(false)}
+              onOk={() => setAntModalOpen(false)}
+            >
+              Modal body content.
+            </AntModal>
+          </>
+        }
+        mantine={
+          <>
+            <Button variant="default" onClick={() => setMantineModalOpen(true)}>
+              Open Mantine modal
+            </Button>
+            <Modal
+              title="Modal title"
+              opened={mantineModalOpen}
+              onClose={() => setMantineModalOpen(false)}
+            >
+              Modal body content.
+            </Modal>
+          </>
+        }
+      />
+    </Stack>
+  );
+});
+
+export default ComponentGallery;

--- a/liwords-ui/src/theme/components.ts
+++ b/liwords-ui/src/theme/components.ts
@@ -1,0 +1,58 @@
+import { Button } from "@mantine/core";
+import classes from "./mantine_components.module.css";
+
+/**
+ * Mantine component overrides, translated from the antd reskin mixins in
+ * base.scss so migrated components inherit the Woogles look instead of each
+ * area re-fixing it locally.
+ *
+ * Compare any change against /dev/components in a dev build, in both colour
+ * modes. These values are reproductions of existing behaviour, not fresh design
+ * decisions -- where antd does something unusual it is copied deliberately.
+ *
+ * Values come through `vars` wherever Mantine exposes a CSS variable for them,
+ * since those are documented API. Only what has no variable goes in the CSS
+ * module.
+ *
+ * NOT reproduced: @mixin button puts `margin: 0 6px` on every default button
+ * and `6px 3px` on every primary one. Baking margins into a component is a
+ * footgun -- it fights every layout that wants to control its own spacing, and
+ * Mantine's idiom is an explicit <Group gap>. Each area that migrates buttons
+ * needs to add spacing at the call site; expect to notice it there.
+ */
+export const components = {
+  Button: Button.extend({
+    classNames: { root: classes.button },
+    vars: (_theme, props) => {
+      const filled = props.variant === undefined || props.variant === "filled";
+      return {
+        root: {
+          "--button-fz": "12px",
+          "--button-height": "36px",
+          "--button-padding-x": "18px",
+
+          // Primary is a solid fill with a small radius; everything else is an
+          // outline in primary-dark on the page background, square-cornered.
+          "--button-radius": filled ? "3px" : "0",
+
+          // Hover and rest are identical on purpose -- see the CSS module.
+          ...(filled
+            ? {
+                "--button-bg": "var(--woogles-color-button)",
+                "--button-hover": "var(--woogles-color-button)",
+                "--button-color": "var(--woogles-color-button-text)",
+                "--button-hover-color": "var(--woogles-color-button-text)",
+                "--button-bd": "0",
+              }
+            : {
+                "--button-bg": "var(--woogles-color-background)",
+                "--button-hover": "var(--woogles-color-background)",
+                "--button-color": "var(--woogles-color-primary-dark)",
+                "--button-hover-color": "var(--woogles-color-primary-dark)",
+                "--button-bd": "1px solid var(--woogles-color-primary-dark)",
+              }),
+        },
+      };
+    },
+  }),
+};

--- a/liwords-ui/src/theme/mantine_components.module.css
+++ b/liwords-ui/src/theme/mantine_components.module.css
@@ -1,0 +1,43 @@
+/*
+ * Per-component styling for the Mantine theme, referenced from
+ * src/theme/components.ts via each component's `classNames`.
+ *
+ * Only properties Mantine does not expose as a CSS variable belong here --
+ * anything with a `--component-*` variable should go through `vars` instead,
+ * since those are part of Mantine's documented API and survive upgrades.
+ */
+
+/*
+ * Woogles buttons are flat and static: no transition, and hover/focus/active
+ * look identical to rest. That is deliberate in base.scss's @mixin button and
+ * predates the migration, so it is reproduced rather than modernised.
+ */
+.button {
+  font-weight: 800;
+  transition: none;
+  touch-action: manipulation;
+}
+
+.button:hover,
+.button:focus,
+.button:active {
+  transition: none;
+}
+
+/*
+ * Keyboard shortcut hint, revealed on hover of an enabled button. Rendered by
+ * game controls as <span class="key-command">. Carried over verbatim from
+ * @mixin button.
+ */
+.button :global(span.key-command) {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0 4px;
+  font-size: 10px;
+  opacity: 0;
+}
+
+.button:not(:disabled):hover :global(span.key-command) {
+  opacity: 1;
+}

--- a/liwords-ui/src/theme/woogles-theme.ts
+++ b/liwords-ui/src/theme/woogles-theme.ts
@@ -1,3 +1,4 @@
+import { components } from "./components";
 import {
   createTheme,
   type CSSVariablesResolver,
@@ -38,6 +39,8 @@ export const wooglesTheme = createTheme({
   headings: { fontFamily: "Mulish, sans-serif" },
 
   colors: { woogles: wooglesBlue },
+
+  components,
   primaryColor: "woogles",
 
   // antd's Button token sets borderRadius: 0. Match it so Mantine buttons do


### PR DESCRIPTION
Phase 2, started. Two commits: a dev-only reference page, and Button translated against it.

## Why the gallery exists

Phase 2 translates ~322 lines of antd reskin mixins into Mantine component overrides. **Nothing renders a Mantine component until Phase 4a**, so as planned that work gets written blind and its mistakes surface later, tangled up with whichever area is being migrated.

That is the same shape as the mistake behind your dark-mode popup border: plenty of work, and a verification story that could not see the thing that actually mattered.

`/dev/components` renders each component both ways — antd left, Mantine right — so the theme is tuned against what it is supposed to match. It inherits the app's colour mode, so toggling dark mode in Settings exercises the real path.

**It costs production nothing.** `import.meta.env.DEV` is statically false in a production build, so the whole thing tree-shakes out — verified by grepping the built bundle for the page's strings and by the bundle being the size it was before. Two things had to be right for that:

- **No stylesheet import.** A stylesheet import is a side effect that survives tree-shaking even when the component does not; an earlier version leaked 1 kB of gallery CSS into production. Layout uses Mantine style props instead.
- **Static import, not `React.lazy`.** Lazy emits its chunk regardless of whether the route is registered, which made it worse (+269 kB).

## Button

Only Button so far — on purpose. Confirming the pattern on the most-used component (92 files) beats replicating an unverified one twelve times.

Faithful reproduction, not redesign. Woogles buttons are flat and static: no transition, and hover/focus/active identical to rest. Odd by modern convention, entirely intentional in the existing SCSS, so it is copied. Mantine exposes `--button-hover`, so it goes through the documented API rather than fighting the component.

Values go through `vars` wherever Mantine has a CSS variable (versioned API); only `font-weight`, `transition` and the `key-command` hint live in the CSS module.

**One deliberate deviation:** `@mixin button` puts `margin: 0 6px` on every default button and `6px 3px` on every primary one. I did not reproduce that — baking margins into a component fights every layout that wants to control its own spacing, and Mantine's idiom is an explicit `<Group gap>`. Each area migrating buttons will need spacing at the call site. Flagged in the file so it is a decision rather than a surprise. Say the word if you'd rather I reproduce it and keep the diffs smaller.

## How to look at it

No backend needed:

```
cd liwords-ui && npm start
# http://localhost:3000/dev/components
```

Compare the Button row in both colour modes. If it looks right, I'll translate the remaining eleven the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHtGtRozwwtzGYFDLrp6uJ